### PR TITLE
Add StatusMonitorService and multiple haptic improvements

### DIFF
--- a/src/EDButtkicker/Configuration/AppSettings.cs
+++ b/src/EDButtkicker/Configuration/AppSettings.cs
@@ -1,28 +1,37 @@
-using EDButtkicker.Services;
-
 namespace EDButtkicker.Configuration;
 
 public class AppSettings
 {
-    public EliteDangerousSettings EliteDangerous { get; set; } = new();
-    public AudioSettings Audio { get; set; } = new();
-    public ContextualIntelligenceConfiguration? ContextualIntelligence { get; set; } = new();
+	public EliteDangerousSettings EliteDangerous { get; set; } = new();
+	public AudioSettings Audio { get; set; } = new();
+	public ContextualIntelligenceConfiguration? ContextualIntelligence { get; set; } = new();
 }
 
 public class EliteDangerousSettings
 {
-    public string JournalPath { get; set; } = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        "Saved Games", "Frontier Developments", "Elite Dangerous");
-    public bool MonitorLatestOnly { get; set; } = true;
+	public string JournalPath { get; set; } = Path.Combine(
+		Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+		"Saved Games", "Frontier Developments", "Elite Dangerous");
+	public bool MonitorLatestOnly { get; set; } = true;
 }
 
 public class AudioSettings
 {
-    public int SampleRate { get; set; } = 44100;
-    public int BufferSize { get; set; } = 1024;
-    public int DefaultFrequency { get; set; } = 40;
-    public int MaxIntensity { get; set; } = 80;
-    public string AudioDeviceName { get; set; } = string.Empty;
-    public int AudioDeviceId { get; set; } = -1; // -1 means use default
+	public int SampleRate { get; set; } = 44100;
+	public int BufferSize { get; set; } = 1024;
+	public int DefaultFrequency { get; set; } = 40;
+	public int MaxIntensity { get; set; } = 80;
+	public string AudioDeviceName { get; set; } = string.Empty;
+	public int AudioDeviceId { get; set; } = -1;
+}
+
+public class ContextualIntelligenceConfiguration
+{
+	public bool Enabled { get; set; } = false;
+	public double LearningRate { get; set; } = 0.1;
+	public double PredictionThreshold { get; set; } = 0.7;
+	public bool EnableAdaptiveIntensity { get; set; } = true;
+	public bool EnablePredictivePatterns { get; set; } = true;
+	public bool EnableContextualVoice { get; set; } = true;
+	public bool LogContextAnalysis { get; set; } = false;
 }

--- a/src/EDButtkicker/Configuration/EventMappings.cs
+++ b/src/EDButtkicker/Configuration/EventMappings.cs
@@ -4,598 +4,869 @@ namespace EDButtkicker.Configuration;
 
 public class EventMappingsConfig
 {
-    public Dictionary<string, EventMapping> EventMappings { get; set; } = new();
-    
-    public static EventMappingsConfig GetDefault()
-    {
-        return new EventMappingsConfig
-        {
-            EventMappings = new Dictionary<string, EventMapping>
-            {
-                ["StartJump"] = new EventMapping
-                {
-                    EventType = "StartJump",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Hyperspace Jump",
-                        Pattern = PatternType.MultiLayer,
-                        Frequency = 35,
-                        Duration = 3000,
-                        Intensity = 90,
-                        FadeIn = 500,
-                        FadeOut = 1000,
-                        IntensityCurve = IntensityCurve.Exponential,
-                        EnableVoiceAnnouncement = true,
-                        VoiceMessage = "Hyperspace jump initiated",
-                        Layers = new List<PatternLayer>
-                        {
-                            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 35, Amplitude = 0.7f, Curve = IntensityCurve.Exponential },
-                            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 70, Amplitude = 0.3f, Curve = IntensityCurve.Linear, PhaseOffset = 90 }
-                        }
-                    },
-                    Enabled = true
-                },
-                ["Docked"] = new EventMapping
-                {
-                    EventType = "Docked",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Landing Gear Lock & Fuel Connection",
-                        Pattern = PatternType.Sequence,
-                        Frequency = 42,
-                        Duration = 4000,
-                        Intensity = 55,
-                        FadeIn = 5,
-                        FadeOut = 300,
-                        Layers = new List<PatternLayer>
-                        {
-                            // 1. Quick hard rumble - landing gear lock (keep strong!)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Square,
-                                Frequency = 35,
-                                Amplitude = 0.7f,
-                                StartTime = 0,
-                                Duration = 200,
-                                FadeIn = 10,
-                                FadeOut = 50,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // 2. Small break (no layer - natural silence from 250ms to 600ms)
-                            
-                            // 3. Hose connection - now more noticeable
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 42,
-                                Amplitude = 0.55f, // Boosted from 0.35f
-                                StartTime = 600,
-                                Duration = 250,
-                                FadeIn = 20,
-                                FadeOut = 30,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // 4. Gas flowing - much more prominent and satisfying
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 38,
-                                Amplitude = 0.5f, // Boosted from 0.25f (doubled!)
-                                StartTime = 1000,
-                                Duration = 2500,
-                                FadeIn = 150,
-                                FadeOut = 800,
-                                Curve = IntensityCurve.Exponential
-                            }
-                        }
-                    },
-                    Enabled = true
-                },
-                ["Undocked"] = new EventMapping
-                {
-                    EventType = "Undocked",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Service Disconnection & Gear Release",
-                        Pattern = PatternType.Sequence,
-                        Frequency = 40,
-                        Duration = 2200,
-                        Intensity = 50,
-                        FadeIn = 50,
-                        FadeOut = 600,
-                        Layers = new List<PatternLayer>
-                        {
-                            // Systems shutdown warning (brief alert)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 52,
-                                Amplitude = 0.3f,
-                                StartTime = 0,
-                                Duration = 150,
-                                FadeIn = 5,
-                                FadeOut = 30,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // Fuel hoses disconnecting (declining rumble)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 42,
-                                Amplitude = 0.45f,
-                                StartTime = 200,
-                                Duration = 1400,
-                                FadeIn = 50,
-                                FadeOut = 500,
-                                Curve = IntensityCurve.Logarithmic
-                            },
-                            // Maintenance stopping (fading oscillation)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Triangle,
-                                Frequency = 30,
-                                Amplitude = 0.3f,
-                                StartTime = 400,
-                                Duration = 1000,
-                                FadeIn = 100,
-                                FadeOut = 400,
-                                Curve = IntensityCurve.Exponential
-                            },
-                            // Landing gear releasing (final mechanical click)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Square,
-                                Frequency = 35,
-                                Amplitude = 0.5f,
-                                StartTime = 1800,
-                                Duration = 160,
-                                FadeIn = 10,
-                                FadeOut = 40,
-                                Curve = IntensityCurve.Linear
-                            }
-                        }
-                    },
-                    Enabled = true
-                },
-                ["HullDamage"] = new EventMapping
-                {
-                    EventType = "HullDamage",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Hull Damage",
-                        Pattern = PatternType.SharpPulse,
-                        Frequency = 50,
-                        Duration = 200,
-                        Intensity = 80,
-                        IntensityFromDamage = true,
-                        MaxIntensity = 100,
-                        MinIntensity = 30,
-                        IntensityCurve = IntensityCurve.Bounce,
-                        EnableVoiceAnnouncement = true,
-                        VoiceMessage = "Hull integrity at {health} percent",
-                        Conditions = new Dictionary<string, object>
-                        {
-                            ["health_below"] = 0.5 // Only announce if health below 50%
-                        }
-                    },
-                    Enabled = true
-                },
-                ["ShipTargeted"] = new EventMapping
-                {
-                    EventType = "ShipTargeted",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Target Lock",
-                        Pattern = PatternType.SharpPulse,
-                        Frequency = 60,
-                        Duration = 150,
-                        Intensity = 40
-                    },
-                    Enabled = true
-                },
-                ["FighterDestroyed"] = new EventMapping
-                {
-                    EventType = "FighterDestroyed",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Explosion",
-                        Pattern = PatternType.Impact,
-                        Frequency = 30,
-                        Duration = 1000,
-                        Intensity = 95,
-                        FadeIn = 0,
-                        FadeOut = 600
-                    },
-                    Enabled = true
-                },
-                
-                // Planetary Landing Events
-                ["Touchdown"] = new EventMapping
-                {
-                    EventType = "Touchdown",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Landing Pad Touchdown Sequence",
-                        Pattern = PatternType.Sequence,
-                        Frequency = 35,
-                        Duration = 2800,
-                        Intensity = 50,
-                        FadeIn = 5,
-                        FadeOut = 400,
-                        Layers = new List<PatternLayer>
-                        {
-                            // 1. Initial touchdown impact (brief sharp contact)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Square,
-                                Frequency = 32,
-                                Amplitude = 0.6f,
-                                StartTime = 0,
-                                Duration = 120,
-                                FadeIn = 5,
-                                FadeOut = 30,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // 2. Landing pad adjustment (ship settling)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Triangle,
-                                Frequency = 28,
-                                Amplitude = 0.4f,
-                                StartTime = 200,
-                                Duration = 400,
-                                FadeIn = 50,
-                                FadeOut = 100,
-                                Curve = IntensityCurve.Logarithmic
-                            },
-                            // 3. Magnetic clamps engaging (mechanical locking)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Square,
-                                Frequency = 38,
-                                Amplitude = 0.45f,
-                                StartTime = 800,
-                                Duration = 180,
-                                FadeIn = 10,
-                                FadeOut = 20,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // 4. Pad systems connecting (gentle service connection)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 35,
-                                Amplitude = 0.3f,
-                                StartTime = 1200,
-                                Duration = 1200,
-                                FadeIn = 100,
-                                FadeOut = 500,
-                                Curve = IntensityCurve.Exponential
-                            }
-                        }
-                    },
-                    Enabled = true
-                },
-                ["Liftoff"] = new EventMapping
-                {
-                    EventType = "Liftoff",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Landing Pad Liftoff Sequence",
-                        Pattern = PatternType.Sequence,
-                        Frequency = 34,
-                        Duration = 2400,
-                        Intensity = 52,
-                        FadeIn = 20,
-                        FadeOut = 600,
-                        Layers = new List<PatternLayer>
-                        {
-                            // 1. Service systems disconnecting (brief shutdown)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 36,
-                                Amplitude = 0.35f,
-                                StartTime = 0,
-                                Duration = 200,
-                                FadeIn = 20,
-                                FadeOut = 40,
-                                Curve = IntensityCurve.Logarithmic
-                            },
-                            // 2. Magnetic clamps releasing (mechanical release)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Square,
-                                Frequency = 40,
-                                Amplitude = 0.4f,
-                                StartTime = 300,
-                                Duration = 140,
-                                FadeIn = 10,
-                                FadeOut = 25,
-                                Curve = IntensityCurve.Linear
-                            },
-                            // 3. Thrusters spooling up (engine preparation)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Triangle,
-                                Frequency = 30,
-                                Amplitude = 0.45f,
-                                StartTime = 600,
-                                Duration = 800,
-                                FadeIn = 100,
-                                FadeOut = 150,
-                                Curve = IntensityCurve.Exponential
-                            },
-                            // 4. Liftoff thrust (gradual engine power increase)
-                            new PatternLayer
-                            {
-                                Waveform = WaveformType.Sine,
-                                Frequency = 32,
-                                Amplitude = 0.55f,
-                                StartTime = 1200,
-                                Duration = 1000,
-                                FadeIn = 200,
-                                FadeOut = 400,
-                                Curve = IntensityCurve.Exponential
-                            }
-                        }
-                    },
-                    Enabled = true
-                },
-                
-                // Heat Warning
-                ["HeatWarning"] = new EventMapping
-                {
-                    EventType = "HeatWarning",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Overheating Warning",
-                        Pattern = PatternType.Oscillating,
-                        Frequency = 55,
-                        Duration = 1500,
-                        Intensity = 60,
-                        FadeIn = 200,
-                        FadeOut = 200
-                    },
-                    Enabled = true
-                },
-                ["HeatDamage"] = new EventMapping
-                {
-                    EventType = "HeatDamage",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Heat Damage",
-                        Pattern = PatternType.Oscillating,
-                        Frequency = 65,
-                        Duration = 800,
-                        Intensity = 85,
-                        FadeIn = 50,
-                        FadeOut = 200
-                    },
-                    Enabled = true
-                },
-                
-                // Fuel Scooping
-                ["FuelScoop"] = new EventMapping
-                {
-                    EventType = "FuelScoop",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Fuel Scooping",
-                        Pattern = PatternType.SustainedRumble,
-                        Frequency = 35,
-                        Duration = 2500,
-                        Intensity = 50,
-                        FadeIn = 400,
-                        FadeOut = 600
-                    },
-                    Enabled = true
-                },
-                
-                // Combat Events
-                ["UnderAttack"] = new EventMapping
-                {
-                    EventType = "UnderAttack",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Under Attack",
-                        Pattern = PatternType.SharpPulse,
-                        Frequency = 70,
-                        Duration = 300,
-                        Intensity = 95,
-                        FadeIn = 0,
-                        FadeOut = 100
-                    },
-                    Enabled = true
-                },
-                
-                // Fighter Bay Events
-                ["LaunchFighter"] = new EventMapping
-                {
-                    EventType = "LaunchFighter",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Fighter Launch",
-                        Pattern = PatternType.BuildupRumble,
-                        Frequency = 40,
-                        Duration = 1500,
-                        Intensity = 60,
-                        FadeIn = 200,
-                        FadeOut = 400
-                    },
-                    Enabled = true
-                },
-                ["DockFighter"] = new EventMapping
-                {
-                    EventType = "DockFighter",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Fighter Docking",
-                        Pattern = PatternType.Impact,
-                        Frequency = 45,
-                        Duration = 600,
-                        Intensity = 55,
-                        FadeIn = 100,
-                        FadeOut = 200
-                    },
-                    Enabled = true
-                },
-                
-                // Neutron Star Boost
-                ["JetConeBoost"] = new EventMapping
-                {
-                    EventType = "JetConeBoost",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Neutron Boost",
-                        Pattern = PatternType.Oscillating,
-                        Frequency = 25,
-                        Duration = 3000,
-                        Intensity = 80,
-                        FadeIn = 500,
-                        FadeOut = 800
-                    },
-                    Enabled = true
-                },
-                
-                // Interdiction Events
-                ["Interdicted"] = new EventMapping
-                {
-                    EventType = "Interdicted",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Being Interdicted",
-                        Pattern = PatternType.Oscillating,
-                        Frequency = 45,
-                        Duration = 4000,
-                        Intensity = 85,
-                        FadeIn = 300,
-                        FadeOut = 500
-                    },
-                    Enabled = true
-                },
-                ["Interdiction"] = new EventMapping
-                {
-                    EventType = "Interdiction",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Interdicting Target",
-                        Pattern = PatternType.BuildupRumble,
-                        Frequency = 40,
-                        Duration = 3500,
-                        Intensity = 75,
-                        FadeIn = 400,
-                        FadeOut = 600
-                    },
-                    Enabled = true
-                },
-                
-                // Additional Combat/Damage Events
-                ["ShieldsDown"] = new EventMapping
-                {
-                    EventType = "ShieldsDown",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Shields Down",
-                        Pattern = PatternType.Impact,
-                        Frequency = 35,
-                        Duration = 1000,
-                        Intensity = 90,
-                        FadeIn = 50,
-                        FadeOut = 400
-                    },
-                    Enabled = true
-                },
-                ["ShieldsUp"] = new EventMapping
-                {
-                    EventType = "ShieldsUp",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Shields Online",
-                        Pattern = PatternType.BuildupRumble,
-                        Frequency = 50,
-                        Duration = 800,
-                        Intensity = 60,
-                        FadeIn = 200,
-                        FadeOut = 300,
-                        EnableVoiceAnnouncement = true,
-                        VoiceMessage = "Shields are online"
-                    },
-                    Enabled = true
-                },
-                
-                ["SupercruiseEntry"] = new EventMapping
-                {
-                    EventType = "SupercruiseEntry",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Supercruise Entry",
-                        Pattern = PatternType.BuildupRumble,
-                        Frequency = 30,
-                        Duration = 1500,
-                        Intensity = 50,
-                        FadeIn = 300,
-                        FadeOut = 500
-                    },
-                    Enabled = true
-                },
-                
-                ["SupercruiseExit"] = new EventMapping
-                {
-                    EventType = "SupercruiseExit",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Supercruise Exit",
-                        Pattern = PatternType.Impact,
-                        Frequency = 40,
-                        Duration = 800,
-                        Intensity = 60,
-                        FadeIn = 100,
-                        FadeOut = 300
-                    },
-                    Enabled = true
-                },
+	public Dictionary<string, EventMapping> EventMappings { get; set; } = new();
 
-                // Additional event name variations based on actual Elite Dangerous journal events
-                ["ShieldState"] = new EventMapping 
-                {
-                    EventType = "ShieldState",
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Shield State Change",
-                        Pattern = PatternType.SharpPulse,
-                        Frequency = 45,
-                        Duration = 500,
-                        Intensity = 70,
-                        FadeIn = 100,
-                        FadeOut = 200
-                    },
-                    Enabled = true
-                },
-                
-                // Advanced Pattern Examples
-                ["CriticalDamageSequence"] = new EventMapping
-                {
-                    EventType = "HullDamage", // This would be triggered conditionally
-                    Pattern = new HapticPattern
-                    {
-                        Name = "Critical Damage Sequence",
-                        Pattern = PatternType.Sequence,
-                        Frequency = 60,
-                        Duration = 500,
-                        Intensity = 100,
-                        ChainedPatterns = new List<string> { "Warning Pulse", "Emergency Alert" },
-                        Conditions = new Dictionary<string, object>
-                        {
-                            ["health_below"] = 0.25 // Only for critical health
-                        },
-                        EnableVoiceAnnouncement = true,
-                        VoiceMessage = "Critical hull damage! Seek immediate repairs!",
-                        IntensityCurve = IntensityCurve.Exponential
-                    },
-                    Enabled = false // Disabled by default - advanced users can enable
-                }
-            }
-        };
-    }
+	public static EventMappingsConfig GetDefault()
+	{
+		return new EventMappingsConfig
+		{
+			EventMappings = new Dictionary<string, EventMapping>
+			{
+				["StartJump"] = new EventMapping
+				{
+					EventType = "StartJump",
+					Pattern = new HapticPattern
+					{
+						Name = "Hyperspace Jump",
+						Pattern = PatternType.MultiLayer,
+						Frequency = 35,
+						Duration = 5000,
+						Intensity = 90,
+						FadeIn = 500,
+						FadeOut = 1000,
+						MaxIntensity = 100,
+						IntensityCurve = IntensityCurve.Exponential,
+						EnableVoiceAnnouncement = true,
+						VoiceMessage = "Hyperspace jump initiated",
+						Layers = new List<PatternLayer>
+						{
+							new PatternLayer { Waveform = WaveformType.Sine, Frequency = 35, Amplitude = 0.7f, Curve = IntensityCurve.Exponential },
+							new PatternLayer { Waveform = WaveformType.Sine, Frequency = 70, Amplitude = 0.3f, Curve = IntensityCurve.Linear, PhaseOffset = 90 }
+						}
+					},
+					Enabled = true
+				},
+
+				["FSDJump"] = new EventMapping
+				{
+					EventType = "FSDJump",
+					Pattern = new HapticPattern
+					{
+						Name = "Hyperspace Arrival",
+						Pattern = PatternType.Sequence,
+						Frequency = 38,
+						Duration = 2000,
+						Intensity = 70,
+						FadeIn = 0,
+						FadeOut = 500,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 35, Amplitude = 0.8f,  StartTime = 0,   Duration = 150, FadeIn = 0,   FadeOut = 40,  Curve = IntensityCurve.Linear },
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 30, Amplitude = 0.5f,  StartTime = 200, Duration = 800, FadeIn = 50,  FadeOut = 300, Curve = IntensityCurve.Logarithmic },
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 42, Amplitude = 0.35f, StartTime = 800, Duration = 900, FadeIn = 100, FadeOut = 500, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["Docked"] = new EventMapping
+				{
+					EventType = "Docked",
+					Pattern = new HapticPattern
+					{
+						Name = "Station Docking Sequence",
+						Pattern = PatternType.Sequence,
+						Frequency = 38,
+						Duration = 5500,
+						Intensity = 100,
+						FadeIn = 0,
+						FadeOut = 600,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// 1. Initial pad contact - ship weight hitting the landing pad
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 28, Amplitude = 0.95f, StartTime = 0,    Duration = 250,  FadeIn = 0,   FadeOut = 60,  Curve = IntensityCurve.Linear },
+							// 2. Ship settling under its own weight - low heavy rumble
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 22, Amplitude = 0.7f,  StartTime = 200,  Duration = 600,  FadeIn = 80,  FadeOut = 200, Curve = IntensityCurve.Logarithmic },
+							// 3. Secondary bounce/settle - ship rocking to rest
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 25, Amplitude = 0.45f, StartTime = 700,  Duration = 400,  FadeIn = 100, FadeOut = 250, Curve = IntensityCurve.Logarithmic },
+							// 4. Magnetic clamps engaging - sharp mechanical lock
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 42, Amplitude = 0.85f, StartTime = 1300, Duration = 180,  FadeIn = 0,   FadeOut = 40,  Curve = IntensityCurve.Linear },
+							// 5. Clamp pressure building - hydraulic hold
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 35, Amplitude = 0.5f,  StartTime = 1500, Duration = 500,  FadeIn = 50,  FadeOut = 200, Curve = IntensityCurve.Exponential },
+							// 6. Second clamp set locking (larger ships have multiple)
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 40, Amplitude = 0.7f,  StartTime = 2100, Duration = 150,  FadeIn = 0,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							// 7. Fuel hose connecting - brief mechanical thud
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 48, Amplitude = 0.55f, StartTime = 2800, Duration = 200,  FadeIn = 10,  FadeOut = 50,  Curve = IntensityCurve.Linear },
+							// 8. Fuel flowing - sustained low rumble, fading as tank fills
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 32, Amplitude = 0.5f,  StartTime = 3100, Duration = 2000, FadeIn = 200, FadeOut = 900, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["Undocked"] = new EventMapping
+				{
+					EventType = "Undocked",
+					Pattern = new HapticPattern
+					{
+						Name = "Station Undocking Sequence",
+						Pattern = PatternType.Sequence,
+						Frequency = 38,
+						Duration = 2000,
+						Intensity = 75,
+						FadeIn = 0,
+						FadeOut = 400,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// 1. Fuel line disconnect - quick sharp pull
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 46, Amplitude = 0.6f,  StartTime = 0,   Duration = 120,  FadeIn = 0,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							// 2. Clamps releasing - lighter than engage, just a snap
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 40, Amplitude = 0.65f, StartTime = 300, Duration = 140,  FadeIn = 0,   FadeOut = 25,  Curve = IntensityCurve.Linear },
+							// 3. Ship lifting off pad - brief thruster vibration
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 30, Amplitude = 0.45f, StartTime = 550, Duration = 800,  FadeIn = 80,  FadeOut = 400, Curve = IntensityCurve.Exponential },
+							// 4. Clear of pad - fades as ship moves into mail slot
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 26, Amplitude = 0.3f,  StartTime = 1200, Duration = 600, FadeIn = 100, FadeOut = 400, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["HullDamage"] = new EventMapping
+				{
+					EventType = "HullDamage",
+					Pattern = new HapticPattern
+					{
+						Name = "Hull Damage",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 50,
+						Duration = 200,
+						Intensity = 80,
+						IntensityFromDamage = true,
+						MaxIntensity = 100,
+						MinIntensity = 30,
+						IntensityCurve = IntensityCurve.Bounce,
+						EnableVoiceAnnouncement = true,
+						VoiceMessage = "Hull integrity at {health} percent",
+						Conditions = new Dictionary<string, object>
+						{
+							["health_below"] = 0.5
+						}
+					},
+					Enabled = true
+				},
+
+				["ShipTargeted"] = new EventMapping
+				{
+					EventType = "ShipTargeted",
+					Pattern = new HapticPattern
+					{
+						Name = "Target Lock",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 60,
+						Duration = 150,
+						Intensity = 40,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				["FighterDestroyed"] = new EventMapping
+				{
+					EventType = "FighterDestroyed",
+					Pattern = new HapticPattern
+					{
+						Name = "Explosion",
+						Pattern = PatternType.Impact,
+						Frequency = 30,
+						Duration = 1000,
+						Intensity = 95,
+						FadeIn = 0,
+						FadeOut = 600,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["Touchdown"] = new EventMapping
+				{
+					EventType = "Touchdown",
+					Pattern = new HapticPattern
+					{
+						Name = "Planetary Touchdown Sequence",
+						Pattern = PatternType.Sequence,
+						Frequency = 30,
+						Duration = 5000,
+						Intensity = 100,
+						FadeIn = 0,
+						FadeOut = 600,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// 1. Gear making first ground contact - hard impact
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 25, Amplitude = 1.0f,  StartTime = 0,    Duration = 300,  FadeIn = 0,   FadeOut = 80,  Curve = IntensityCurve.Linear },
+							// 2. Ship mass transferring to ground - heavy deep rumble
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 20, Amplitude = 0.8f,  StartTime = 200,  Duration = 800,  FadeIn = 60,  FadeOut = 300, Curve = IntensityCurve.Logarithmic },
+							// 3. Ground surface vibration - planet surface texture
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 35, Amplitude = 0.5f,  StartTime = 400,  Duration = 600,  FadeIn = 100, FadeOut = 300, Curve = IntensityCurve.Logarithmic },
+							// 4. Secondary bounce - ship rocking on uneven ground
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 22, Amplitude = 0.55f, StartTime = 900,  Duration = 500,  FadeIn = 80,  FadeOut = 250, Curve = IntensityCurve.Logarithmic },
+							// 5. Magnetic clamps engaging - sharp lock into ground anchors
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 40, Amplitude = 0.85f, StartTime = 1600, Duration = 200,  FadeIn = 0,   FadeOut = 40,  Curve = IntensityCurve.Linear },
+							// 6. Second clamp set locking
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 38, Amplitude = 0.75f, StartTime = 1900, Duration = 160,  FadeIn = 0,   FadeOut = 35,  Curve = IntensityCurve.Linear },
+							// 7. Clamp hydraulic pressure building
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 30, Amplitude = 0.45f, StartTime = 2100, Duration = 700,  FadeIn = 80,  FadeOut = 300, Curve = IntensityCurve.Exponential },
+							// 8. Systems connecting - pad services linking up
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 42, Amplitude = 0.35f, StartTime = 3000, Duration = 1600, FadeIn = 200, FadeOut = 800, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["Liftoff"] = new EventMapping
+				{
+					EventType = "Liftoff",
+					Pattern = new HapticPattern
+					{
+						Name = "Planetary Liftoff Sequence",
+						Pattern = PatternType.Sequence,
+						Frequency = 30,
+						Duration = 3000,
+						Intensity = 85,
+						FadeIn = 0,
+						FadeOut = 600,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// 1. Clamps releasing - lighter snap than engage
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 38, Amplitude = 0.65f, StartTime = 0,    Duration = 140,  FadeIn = 0,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							// 2. Second clamp set releasing
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 36, Amplitude = 0.55f, StartTime = 200,  Duration = 120,  FadeIn = 0,   FadeOut = 25,  Curve = IntensityCurve.Linear },
+							// 3. Thrusters spooling up - building vibration
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 28, Amplitude = 0.6f,  StartTime = 450,  Duration = 900,  FadeIn = 150, FadeOut = 100, Curve = IntensityCurve.Exponential },
+							// 4. Gear leaving ground - brief separation thud
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 24, Amplitude = 0.7f,  StartTime = 1100, Duration = 200,  FadeIn = 0,   FadeOut = 60,  Curve = IntensityCurve.Linear },
+							// 5. Climbing thrust - strong engine rumble
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 32, Amplitude = 0.55f, StartTime = 1300, Duration = 1200, FadeIn = 100, FadeOut = 500, Curve = IntensityCurve.Exponential },
+							// 6. Fading as ship clears the surface
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 26, Amplitude = 0.3f,  StartTime = 2000, Duration = 800,  FadeIn = 200, FadeOut = 600, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["HeatWarning"] = new EventMapping
+				{
+					EventType = "HeatWarning",
+					Pattern = new HapticPattern
+					{
+						Name = "Overheating Warning",
+						Pattern = PatternType.Oscillating,
+						Frequency = 55,
+						Duration = 1500,
+						Intensity = 60,
+						FadeIn = 200,
+						FadeOut = 200,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["HeatDamage"] = new EventMapping
+				{
+					EventType = "HeatDamage",
+					Pattern = new HapticPattern
+					{
+						Name = "Heat Damage",
+						Pattern = PatternType.Oscillating,
+						Frequency = 65,
+						Duration = 800,
+						Intensity = 85,
+						FadeIn = 50,
+						FadeOut = 200,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["FuelScoop"] = new EventMapping
+				{
+					EventType = "FuelScoop",
+					Pattern = new HapticPattern
+					{
+						Name = "Fuel Scooping",
+						Pattern = PatternType.SustainedRumble,
+						Frequency = 35,
+						Duration = 2500,
+						Intensity = 50,
+						FadeIn = 400,
+						FadeOut = 600,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				["UnderAttack"] = new EventMapping
+				{
+					EventType = "UnderAttack",
+					Pattern = new HapticPattern
+					{
+						Name = "Under Attack",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 70,
+						Duration = 300,
+						Intensity = 95,
+						FadeIn = 0,
+						FadeOut = 100,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				["LaunchFighter"] = new EventMapping
+				{
+					EventType = "LaunchFighter",
+					Pattern = new HapticPattern
+					{
+						Name = "Fighter Launch",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 40,
+						Duration = 1500,
+						Intensity = 60,
+						FadeIn = 200,
+						FadeOut = 400,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["DockFighter"] = new EventMapping
+				{
+					EventType = "DockFighter",
+					Pattern = new HapticPattern
+					{
+						Name = "Fighter Docking",
+						Pattern = PatternType.Impact,
+						Frequency = 45,
+						Duration = 600,
+						Intensity = 55,
+						FadeIn = 100,
+						FadeOut = 200,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["JetConeBoost"] = new EventMapping
+				{
+					EventType = "JetConeBoost",
+					Pattern = new HapticPattern
+					{
+						Name = "Neutron Boost",
+						Pattern = PatternType.Oscillating,
+						Frequency = 25,
+						Duration = 3000,
+						Intensity = 80,
+						FadeIn = 500,
+						FadeOut = 800,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["Interdicted"] = new EventMapping
+				{
+					EventType = "Interdicted",
+					Pattern = new HapticPattern
+					{
+						Name = "Being Interdicted",
+						Pattern = PatternType.Oscillating,
+						Frequency = 45,
+						Duration = 4000,
+						Intensity = 75,
+						FadeIn = 300,
+						FadeOut = 500,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["Interdiction"] = new EventMapping
+				{
+					EventType = "Interdiction",
+					Pattern = new HapticPattern
+					{
+						Name = "Interdicting Target",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 40,
+						Duration = 3500,
+						Intensity = 75,
+						FadeIn = 400,
+						FadeOut = 600,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["ShieldsDown"] = new EventMapping
+				{
+					EventType = "ShieldsDown",
+					Pattern = new HapticPattern
+					{
+						Name = "Shields Down",
+						Pattern = PatternType.Impact,
+						Frequency = 35,
+						Duration = 1000,
+						Intensity = 90,
+						FadeIn = 50,
+						FadeOut = 400,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["ShieldsUp"] = new EventMapping
+				{
+					EventType = "ShieldsUp",
+					Pattern = new HapticPattern
+					{
+						Name = "Shields Online",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 50,
+						Duration = 800,
+						Intensity = 60,
+						FadeIn = 200,
+						FadeOut = 300,
+						MaxIntensity = 100,
+						EnableVoiceAnnouncement = true,
+						VoiceMessage = "Shields are online"
+					},
+					Enabled = true
+				},
+
+				["SupercruiseEntry"] = new EventMapping
+				{
+					EventType = "SupercruiseEntry",
+					Pattern = new HapticPattern
+					{
+						Name = "Supercruise Entry",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 30,
+						Duration = 1500,
+						Intensity = 50,
+						FadeIn = 300,
+						FadeOut = 500,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["SupercruiseExit"] = new EventMapping
+				{
+					EventType = "SupercruiseExit",
+					Pattern = new HapticPattern
+					{
+						Name = "Supercruise Exit",
+						Pattern = PatternType.Impact,
+						Frequency = 40,
+						Duration = 800,
+						Intensity = 60,
+						FadeIn = 100,
+						FadeOut = 300,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["ShieldState"] = new EventMapping
+				{
+					EventType = "ShieldState",
+					Pattern = new HapticPattern
+					{
+						Name = "Shield State Change",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 45,
+						Duration = 500,
+						Intensity = 60,
+						FadeIn = 100,
+						FadeOut = 200,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- Landing Gear (enhanced) ---
+				["LandingGearDown"] = new EventMapping
+				{
+					EventType = "LandingGearDown",
+					Pattern = new HapticPattern
+					{
+						Name = "Landing Gear Deploy",
+						Pattern = PatternType.Sequence,
+						Frequency = 38,
+						Duration = 3000,
+						Intensity = 90,
+						FadeIn = 0,
+						FadeOut = 300,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// Initial deploy clunk - hard mechanical release
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 42, Amplitude = 0.9f,  StartTime = 0,    Duration = 180,  FadeIn = 0,   FadeOut = 40,  Curve = IntensityCurve.Linear },
+							// First stage extension - heavy hydraulic rumble
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 30, Amplitude = 0.65f, StartTime = 200,  Duration = 600,  FadeIn = 60,  FadeOut = 100, Curve = IntensityCurve.Logarithmic },
+							// Mid-travel vibration - gear moving through airframe
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 48, Amplitude = 0.45f, StartTime = 700,  Duration = 700,  FadeIn = 100, FadeOut = 200, Curve = IntensityCurve.Linear },
+							// Second clunk - gear reaching full extension
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 36, Amplitude = 0.8f,  StartTime = 1500, Duration = 200,  FadeIn = 0,   FadeOut = 50,  Curve = IntensityCurve.Linear },
+							// Locking pins engaging - final mechanical confirmation
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 44, Amplitude = 0.7f,  StartTime = 1800, Duration = 120,  FadeIn = 0,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							// Hydraulic pressure settling - system stabilising
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 28, Amplitude = 0.35f, StartTime = 2000, Duration = 800,  FadeIn = 100, FadeOut = 400, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				["LandingGearUp"] = new EventMapping
+				{
+					EventType = "LandingGearUp",
+					Pattern = new HapticPattern
+					{
+						Name = "Landing Gear Retract",
+						Pattern = PatternType.Sequence,
+						Frequency = 38,
+						Duration = 2500,
+						Intensity = 90,
+						FadeIn = 0,
+						FadeOut = 300,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							// Locking pins releasing
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 44, Amplitude = 0.75f, StartTime = 0,    Duration = 120,  FadeIn = 0,   FadeOut = 25,  Curve = IntensityCurve.Linear },
+							// Unlock clunk
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 38, Amplitude = 0.7f,  StartTime = 150,  Duration = 150,  FadeIn = 0,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							// Hydraulic retraction - strong pull
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 32, Amplitude = 0.6f,  StartTime = 350,  Duration = 700,  FadeIn = 40,  FadeOut = 150, Curve = IntensityCurve.Logarithmic },
+							// Mid-travel through airframe
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 46, Amplitude = 0.4f,  StartTime = 900,  Duration = 600,  FadeIn = 80,  FadeOut = 200, Curve = IntensityCurve.Linear },
+							// Final stow thud - gear locked away
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 40, Amplitude = 0.65f, StartTime = 1600, Duration = 160,  FadeIn = 0,   FadeOut = 40,  Curve = IntensityCurve.Linear },
+							// Bay doors closing - gentle fade
+							new PatternLayer { Waveform = WaveformType.Sine,     Frequency = 26, Amplitude = 0.3f,  StartTime = 1850, Duration = 500,  FadeIn = 80,  FadeOut = 350, Curve = IntensityCurve.Exponential }
+						}
+					},
+					Enabled = true
+				},
+
+				// --- Hardpoints ---
+				["HardpointsDeployed"] = new EventMapping
+				{
+					EventType = "HardpointsDeployed",
+					Pattern = new HapticPattern
+					{
+						Name = "Hardpoints Deploy",
+						Pattern = PatternType.Sequence,
+						Frequency = 45,
+						Duration = 800,
+						Intensity = 95,
+						FadeIn = 0,
+						FadeOut = 150,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							new PatternLayer { Waveform = WaveformType.Square, Frequency = 48, Amplitude = 0.75f, StartTime = 0,   Duration = 100, FadeIn = 0,  FadeOut = 20,  Curve = IntensityCurve.Linear },
+							new PatternLayer { Waveform = WaveformType.Sine,   Frequency = 55, Amplitude = 0.4f,  StartTime = 150, Duration = 500, FadeIn = 50, FadeOut = 200, Curve = IntensityCurve.Exponential },
+							new PatternLayer { Waveform = WaveformType.Square, Frequency = 50, Amplitude = 0.55f, StartTime = 600, Duration = 100, FadeIn = 0,  FadeOut = 30,  Curve = IntensityCurve.Linear }
+						}
+					},
+					Enabled = true
+				},
+
+				["HardpointsRetracted"] = new EventMapping
+				{
+					EventType = "HardpointsRetracted",
+					Pattern = new HapticPattern
+					{
+						Name = "Hardpoints Retract",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 42,
+						Duration = 500,
+						Intensity = 40,
+						FadeIn = 0,
+						FadeOut = 150,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- Cargo Scoop ---
+				["CargoScoopDeployed"] = new EventMapping
+				{
+					EventType = "CargoScoopDeployed",
+					Pattern = new HapticPattern
+					{
+						Name = "Cargo Scoop Deploy",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 35,
+						Duration = 700,
+						Intensity = 40,
+						FadeIn = 100,
+						FadeOut = 250,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["CargoScoopRetracted"] = new EventMapping
+				{
+					EventType = "CargoScoopRetracted",
+					Pattern = new HapticPattern
+					{
+						Name = "Cargo Scoop Retract",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 38,
+						Duration = 240,
+						Intensity = 30,
+						FadeIn = 0,
+						FadeOut = 100,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- Silent Running ---
+				["SilentRunningOn"] = new EventMapping
+				{
+					EventType = "SilentRunningOn",
+					Pattern = new HapticPattern
+					{
+						Name = "Silent Running Engaged",
+						Pattern = PatternType.Fade,
+						Frequency = 28,
+						Duration = 1000,
+						Intensity = 45,
+						FadeIn = 400,
+						FadeOut = 500,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["SilentRunningOff"] = new EventMapping
+				{
+					EventType = "SilentRunningOff",
+					Pattern = new HapticPattern
+					{
+						Name = "Silent Running Disengaged",
+						Pattern = PatternType.BuildupRumble,
+						Frequency = 38,
+						Duration = 600,
+						Intensity = 40,
+						FadeIn = 50,
+						FadeOut = 200,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- FSD States ---
+				["FsdCooldown"] = new EventMapping
+				{
+					EventType = "FsdCooldown",
+					Pattern = new HapticPattern
+					{
+						Name = "FSD Cooldown",
+						Pattern = PatternType.Oscillating,
+						Frequency = 30,
+						Duration = 1500,
+						Intensity = 35,
+						FadeIn = 200,
+						FadeOut = 600,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- Warnings ---
+				["LowFuel"] = new EventMapping
+				{
+					EventType = "LowFuel",
+					Pattern = new HapticPattern
+					{
+						Name = "Low Fuel Warning",
+						Pattern = PatternType.Oscillating,
+						Frequency = 45,
+						Duration = 2000,
+						Intensity = 70,
+						FadeIn = 100,
+						FadeOut = 400,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["Overheating"] = new EventMapping
+				{
+					EventType = "Overheating",
+					Pattern = new HapticPattern
+					{
+						Name = "Ship Overheating",
+						Pattern = PatternType.Oscillating,
+						Frequency = 60,
+						Duration = 1500,
+						Intensity = 80,
+						FadeIn = 50,
+						FadeOut = 300,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				// --- Night Vision ---
+				["NightVisionOn"] = new EventMapping
+				{
+					EventType = "NightVisionOn",
+					Pattern = new HapticPattern
+					{
+						Name = "Night Vision On",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 52,
+						Duration = 100,
+						Intensity = 25,
+						FadeIn = 0,
+						FadeOut = 50,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				["NightVisionOff"] = new EventMapping
+				{
+					EventType = "NightVisionOff",
+					Pattern = new HapticPattern
+					{
+						Name = "Night Vision Off",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 48,
+						Duration = 100,
+						Intensity = 20,
+						FadeIn = 0,
+						FadeOut = 50,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				// --- Colonisation ---
+				["DockingGranted"] = new EventMapping
+				{
+					EventType = "DockingGranted",
+					Pattern = new HapticPattern
+					{
+						Name = "Docking Clearance",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 55,
+						Duration = 120,
+						Intensity = 35,
+						FadeIn = 5,
+						FadeOut = 40,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["SupercruiseDestinationDrop"] = new EventMapping
+				{
+					EventType = "SupercruiseDestinationDrop",
+					Pattern = new HapticPattern
+					{
+						Name = "Destination Drop",
+						Pattern = PatternType.Impact,
+						Frequency = 38,
+						Duration = 600,
+						Intensity = 50,
+						FadeIn = 20,
+						FadeOut = 300,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["ColonisationContribution"] = new EventMapping
+				{
+					EventType = "ColonisationContribution",
+					Pattern = new HapticPattern
+					{
+						Name = "Cargo Delivered",
+						Pattern = PatternType.Sequence,
+						Frequency = 40,
+						Duration = 1800,
+						Intensity = 65,
+						FadeIn = 10,
+						FadeOut = 400,
+						MaxIntensity = 100,
+						Layers = new List<PatternLayer>
+						{
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 38, Amplitude = 0.5f,  StartTime = 0,    Duration = 150, FadeIn = 5,   FadeOut = 30,  Curve = IntensityCurve.Linear },
+							new PatternLayer { Waveform = WaveformType.Triangle, Frequency = 32, Amplitude = 0.55f, StartTime = 300,  Duration = 900, FadeIn = 100, FadeOut = 200, Curve = IntensityCurve.Logarithmic },
+							new PatternLayer { Waveform = WaveformType.Square,   Frequency = 42, Amplitude = 0.6f,  StartTime = 1400, Duration = 200, FadeIn = 10,  FadeOut = 80,  Curve = IntensityCurve.Linear }
+						}
+					},
+					Enabled = false
+				},
+
+				["RefuelAll"] = new EventMapping
+				{
+					EventType = "RefuelAll",
+					Pattern = new HapticPattern
+					{
+						Name = "Refuelling",
+						Pattern = PatternType.SustainedRumble,
+						Frequency = 32,
+						Duration = 1200,
+						Intensity = 30,
+						FadeIn = 300,
+						FadeOut = 500,
+						MaxIntensity = 100
+					},
+					Enabled = true
+				},
+
+				["MarketBuy"] = new EventMapping
+				{
+					EventType = "MarketBuy",
+					Pattern = new HapticPattern
+					{
+						Name = "Cargo Loaded",
+						Pattern = PatternType.SharpPulse,
+						Frequency = 45,
+						Duration = 100,
+						Intensity = 25,
+						FadeIn = 5,
+						FadeOut = 30,
+						MaxIntensity = 100
+					},
+					Enabled = false
+				},
+
+				["CriticalDamageSequence"] = new EventMapping
+				{
+					EventType = "HullDamage",
+					Pattern = new HapticPattern
+					{
+						Name = "Critical Damage Sequence",
+						Pattern = PatternType.Sequence,
+						Frequency = 60,
+						Duration = 500,
+						Intensity = 100,
+						MaxIntensity = 100,
+						ChainedPatterns = new List<string> { "Warning Pulse", "Emergency Alert" },
+						Conditions = new Dictionary<string, object>
+						{
+							["health_below"] = 0.25
+						},
+						EnableVoiceAnnouncement = true,
+						VoiceMessage = "Critical hull damage! Seek immediate repairs!",
+						IntensityCurve = IntensityCurve.Exponential
+					},
+					Enabled = true
+				}
+			}
+		};
+	}
 }

--- a/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
+++ b/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
@@ -9,201 +9,205 @@ namespace EDButtkicker.Controllers;
 
 public class ContextualIntelligenceApiController
 {
-    private readonly ILogger<ContextualIntelligenceApiController> _logger;
-    private readonly AppSettings _settings;
-    private readonly ContextualIntelligenceService _contextualIntelligence;
+	private readonly ILogger<ContextualIntelligenceApiController> _logger;
+	private readonly AppSettings _settings;
+	private readonly ContextualIntelligenceService _contextualIntelligence;
 
-    public ContextualIntelligenceApiController(
-        ILogger<ContextualIntelligenceApiController> logger, 
-        AppSettings settings,
-        ContextualIntelligenceService contextualIntelligence)
-    {
-        _logger = logger;
-        _settings = settings;
-        _contextualIntelligence = contextualIntelligence;
-    }
+	public ContextualIntelligenceApiController(
+		ILogger<ContextualIntelligenceApiController> logger,
+		AppSettings settings,
+		ContextualIntelligenceService contextualIntelligence)
+	{
+		_logger = logger;
+		_settings = settings;
+		_contextualIntelligence = contextualIntelligence;
+	}
 
-    public async Task GetContextualIntelligenceStatus(HttpContext context)
-    {
-        try
-        {
-            var gameContext = _contextualIntelligence.GetCurrentContext();
-            var config = _settings.ContextualIntelligence ?? new ContextualIntelligenceConfiguration();
-            
-            var response = new
-            {
-                configuration = new
-                {
-                    enabled = config.Enabled,
-                    learning_rate = config.LearningRate,
-                    prediction_threshold = config.PredictionThreshold,
-                    adaptive_intensity = config.EnableAdaptiveIntensity,
-                    predictive_patterns = config.EnablePredictivePatterns,
-                    contextual_voice = config.EnableContextualVoice,
-                    log_analysis = config.LogContextAnalysis
-                },
-                current_context = new
-                {
-                    game_state = gameContext.CurrentState.ToString(),
-                    state_duration = gameContext.StateActivityDuration.TotalMinutes,
-                    current_system = gameContext.CurrentSystem,
-                    current_station = gameContext.CurrentStation,
-                    hull_integrity = gameContext.HullIntegrity,
-                    shield_strength = gameContext.ShieldStrength,
-                    threat_level = gameContext.ThreatLevel.ToString(),
-                    combat_intensity = gameContext.CombatIntensity,
-                    exploration_mode = gameContext.ExplorationActivity.ToString(),
-                    is_carrying_cargo = gameContext.IsCarryingCargo,
-                    cargo_value = gameContext.CargoValue,
-                    player_aggressiveness = gameContext.PlayerAggressiveness,
-                    player_cautiousness = gameContext.PlayerCautiousness,
-                    intensity_multiplier = gameContext.GetContextualIntensityMultiplier(),
-                    is_dangerous_situation = gameContext.IsInDangerousSituation(),
-                    is_routine_activity = gameContext.IsInRoutineActivity()
-                },
-                predictions = new
-                {
-                    predicted_next_state = gameContext.PredictedNextState?.ToString(),
-                    prediction_confidence = gameContext.PredictionConfidence,
-                    likely_upcoming_events = gameContext.LikelyUpcomingEvents
-                },
-                statistics = new
-                {
-                    systems_visited = gameContext.SystemsVisited,
-                    bodies_scanned = gameContext.BodiesScanned,
-                    recent_event_types = gameContext.RecentEventFrequency.Keys.Take(10).ToArray(),
-                    state_time_spent = gameContext.StateTimeSpent.Select(kvp => new 
-                    { 
-                        state = kvp.Key.ToString(), 
-                        time_minutes = kvp.Value.TotalMinutes 
-                    }).ToArray()
-                }
-            };
+	public async Task GetContextualIntelligenceStatus(HttpContext context)
+	{
+		try
+		{
+			var gameContext = _contextualIntelligence.GetCurrentContext();
+			var config = _settings.ContextualIntelligence ?? new ContextualIntelligenceConfiguration();
 
-            context.Response.ContentType = "application/json";
-            using var writer = new StreamWriter(context.Response.Body);
-            await writer.WriteAsync(JsonSerializer.Serialize(response, new JsonSerializerOptions 
-            { 
-                WriteIndented = true 
-            }));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting contextual intelligence status");
-            context.Response.StatusCode = 500;
-            using var errorWriter = new StreamWriter(context.Response.Body);
-            await errorWriter.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-        }
-    }
+			var response = new
+			{
+				configuration = new
+				{
+					enabled = config.Enabled,
+					learning_rate = config.LearningRate,
+					prediction_threshold = config.PredictionThreshold,
+					adaptive_intensity = config.EnableAdaptiveIntensity,
+					predictive_patterns = config.EnablePredictivePatterns,
+					contextual_voice = config.EnableContextualVoice,
+					log_analysis = config.LogContextAnalysis
+				},
+				current_context = new
+				{
+					game_state = gameContext.CurrentState.ToString(),
+					state_duration = gameContext.StateActivityDuration.TotalMinutes,
+					current_system = gameContext.CurrentSystem,
+					current_station = gameContext.CurrentStation,
+					hull_integrity = gameContext.HullIntegrity,
+					shield_strength = gameContext.ShieldStrength,
+					threat_level = gameContext.ThreatLevel.ToString(),
+					combat_intensity = gameContext.CombatIntensity,
+					exploration_mode = gameContext.ExplorationActivity.ToString(),
+					is_carrying_cargo = gameContext.IsCarryingCargo,
+					cargo_value = gameContext.CargoValue,
+					player_aggressiveness = gameContext.PlayerAggressiveness,
+					player_cautiousness = gameContext.PlayerCautiousness,
+					intensity_multiplier = gameContext.GetContextualIntensityMultiplier(),
+					is_dangerous_situation = gameContext.IsInDangerousSituation(),
+					is_routine_activity = gameContext.IsInRoutineActivity()
+				},
+				predictions = new
+				{
+					predicted_next_state = gameContext.PredictedNextState?.ToString(),
+					prediction_confidence = gameContext.PredictionConfidence,
+					likely_upcoming_events = gameContext.LikelyUpcomingEvents
+				},
+				statistics = new
+				{
+					systems_visited = gameContext.SystemsVisited,
+					bodies_scanned = gameContext.BodiesScanned,
+					recent_event_types = gameContext.RecentEventFrequency.Keys.Take(10).ToArray(),
+					state_time_spent = gameContext.StateTimeSpent.Select(kvp => new
+					{
+						state = kvp.Key.ToString(),
+						time_minutes = kvp.Value.TotalMinutes
+					}).ToArray()
+				}
+			};
 
-    public async Task UpdateContextualIntelligenceConfig(HttpContext context)
-    {
-        try
-        {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
-            {
-                context.Response.StatusCode = 400;
-                using var errorWriter = new StreamWriter(context.Response.Body);
-                await errorWriter.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
-                return;
-            }
+			context.Response.ContentType = "application/json";
+			await context.Response.WriteAsync(JsonSerializer.Serialize(response, new JsonSerializerOptions
+			{
+				WriteIndented = true
+			}));
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error getting contextual intelligence status");
+			if (!context.Response.HasStarted)
+			{
+				context.Response.StatusCode = 500;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+			}
+		}
+	}
 
-            var configUpdate = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (configUpdate == null)
-            {
-                context.Response.StatusCode = 400;
-                using var errorWriter = new StreamWriter(context.Response.Body);
-                await errorWriter.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid JSON format" }));
-                return;
-            }
+	public async Task UpdateContextualIntelligenceConfig(HttpContext context)
+	{
+		try
+		{
+			using var reader = new StreamReader(context.Request.Body);
+			var json = await reader.ReadToEndAsync();
 
-            // Ensure we have a configuration object
-            if (_settings.ContextualIntelligence == null)
-                _settings.ContextualIntelligence = new ContextualIntelligenceConfiguration();
+			if (string.IsNullOrEmpty(json))
+			{
+				context.Response.StatusCode = 400;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
+				return;
+			}
 
-            var config = _settings.ContextualIntelligence;
+			var configUpdate = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+			if (configUpdate == null)
+			{
+				context.Response.StatusCode = 400;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid JSON format" }));
+				return;
+			}
 
-            // Update configuration values
-            if (configUpdate.ContainsKey("enabled") && bool.TryParse(configUpdate["enabled"].ToString(), out bool enabled))
-                config.Enabled = enabled;
+			if (_settings.ContextualIntelligence == null)
+				_settings.ContextualIntelligence = new ContextualIntelligenceConfiguration();
 
-            if (configUpdate.ContainsKey("learning_rate") && double.TryParse(configUpdate["learning_rate"].ToString(), out double learningRate))
-                config.LearningRate = Math.Max(0.01, Math.Min(1.0, learningRate));
+			var config = _settings.ContextualIntelligence;
 
-            if (configUpdate.ContainsKey("prediction_threshold") && double.TryParse(configUpdate["prediction_threshold"].ToString(), out double predictionThreshold))
-                config.PredictionThreshold = Math.Max(0.1, Math.Min(1.0, predictionThreshold));
+			if (configUpdate.ContainsKey("enabled") && bool.TryParse(configUpdate["enabled"].ToString(), out bool enabled))
+				config.Enabled = enabled;
 
-            if (configUpdate.ContainsKey("adaptive_intensity") && bool.TryParse(configUpdate["adaptive_intensity"].ToString(), out bool adaptiveIntensity))
-                config.EnableAdaptiveIntensity = adaptiveIntensity;
+			if (configUpdate.ContainsKey("learning_rate") && double.TryParse(configUpdate["learning_rate"].ToString(), out double learningRate))
+				config.LearningRate = Math.Max(0.01, Math.Min(1.0, learningRate));
 
-            if (configUpdate.ContainsKey("predictive_patterns") && bool.TryParse(configUpdate["predictive_patterns"].ToString(), out bool predictivePatterns))
-                config.EnablePredictivePatterns = predictivePatterns;
+			if (configUpdate.ContainsKey("prediction_threshold") && double.TryParse(configUpdate["prediction_threshold"].ToString(), out double predictionThreshold))
+				config.PredictionThreshold = Math.Max(0.1, Math.Min(1.0, predictionThreshold));
 
-            if (configUpdate.ContainsKey("contextual_voice") && bool.TryParse(configUpdate["contextual_voice"].ToString(), out bool contextualVoice))
-                config.EnableContextualVoice = contextualVoice;
+			if (configUpdate.ContainsKey("adaptive_intensity") && bool.TryParse(configUpdate["adaptive_intensity"].ToString(), out bool adaptiveIntensity))
+				config.EnableAdaptiveIntensity = adaptiveIntensity;
 
-            if (configUpdate.ContainsKey("log_analysis") && bool.TryParse(configUpdate["log_analysis"].ToString(), out bool logAnalysis))
-                config.LogContextAnalysis = logAnalysis;
+			if (configUpdate.ContainsKey("predictive_patterns") && bool.TryParse(configUpdate["predictive_patterns"].ToString(), out bool predictivePatterns))
+				config.EnablePredictivePatterns = predictivePatterns;
 
-            _logger.LogInformation("Contextual Intelligence configuration updated via web interface - Enabled: {Enabled}", config.Enabled);
+			if (configUpdate.ContainsKey("contextual_voice") && bool.TryParse(configUpdate["contextual_voice"].ToString(), out bool contextualVoice))
+				config.EnableContextualVoice = contextualVoice;
 
-            context.Response.ContentType = "application/json";
-            using var responseWriter = new StreamWriter(context.Response.Body);
-            await responseWriter.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                success = true, 
-                message = "Contextual Intelligence configuration updated successfully",
-                enabled = config.Enabled
-            }));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating contextual intelligence configuration");
-            context.Response.StatusCode = 500;
-            using var errorWriter = new StreamWriter(context.Response.Body);
-            await errorWriter.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-        }
-    }
+			if (configUpdate.ContainsKey("log_analysis") && bool.TryParse(configUpdate["log_analysis"].ToString(), out bool logAnalysis))
+				config.LogContextAnalysis = logAnalysis;
 
-    public async Task GetGameContextPredictions(HttpContext context)
-    {
-        try
-        {
-            var predictions = _contextualIntelligence.GetPredictedUpcomingEvents();
-            var gameContext = _contextualIntelligence.GetCurrentContext();
-            
-            var response = new
-            {
-                predictions = predictions,
-                current_state = gameContext.CurrentState.ToString(),
-                predicted_next_state = gameContext.PredictedNextState?.ToString(),
-                confidence = gameContext.PredictionConfidence,
-                context_factors = new
-                {
-                    threat_level = gameContext.ThreatLevel.ToString(),
-                    hull_integrity = gameContext.HullIntegrity,
-                    time_in_state = gameContext.StateActivityDuration.TotalMinutes,
-                    carrying_cargo = gameContext.IsCarryingCargo,
-                    exploration_activity = gameContext.ExplorationActivity.ToString()
-                }
-            };
+			_logger.LogInformation("Contextual Intelligence configuration updated via web interface - Enabled: {Enabled}", config.Enabled);
 
-            context.Response.ContentType = "application/json";
-            using var writer = new StreamWriter(context.Response.Body);
-            await writer.WriteAsync(JsonSerializer.Serialize(response, new JsonSerializerOptions 
-            { 
-                WriteIndented = true 
-            }));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting game context predictions");
-            context.Response.StatusCode = 500;
-            using var errorWriter = new StreamWriter(context.Response.Body);
-            await errorWriter.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-        }
-    }
+			context.Response.ContentType = "application/json";
+			await context.Response.WriteAsync(JsonSerializer.Serialize(new
+			{
+				success = true,
+				message = "Contextual Intelligence configuration updated successfully",
+				enabled = config.Enabled
+			}));
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error updating contextual intelligence configuration");
+			if (!context.Response.HasStarted)
+			{
+				context.Response.StatusCode = 500;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+			}
+		}
+	}
+
+	public async Task GetGameContextPredictions(HttpContext context)
+	{
+		try
+		{
+			var predictions = _contextualIntelligence.GetPredictedUpcomingEvents();
+			var gameContext = _contextualIntelligence.GetCurrentContext();
+
+			var response = new
+			{
+				predictions = predictions,
+				current_state = gameContext.CurrentState.ToString(),
+				predicted_next_state = gameContext.PredictedNextState?.ToString(),
+				confidence = gameContext.PredictionConfidence,
+				context_factors = new
+				{
+					threat_level = gameContext.ThreatLevel.ToString(),
+					hull_integrity = gameContext.HullIntegrity,
+					time_in_state = gameContext.StateActivityDuration.TotalMinutes,
+					carrying_cargo = gameContext.IsCarryingCargo,
+					exploration_activity = gameContext.ExplorationActivity.ToString()
+				}
+			};
+
+			context.Response.ContentType = "application/json";
+			await context.Response.WriteAsync(JsonSerializer.Serialize(response, new JsonSerializerOptions
+			{
+				WriteIndented = true
+			}));
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error getting game context predictions");
+			if (!context.Response.HasStarted)
+			{
+				context.Response.StatusCode = 500;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+			}
+		}
+	}
 }

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -172,6 +172,7 @@ class Program
                 // Add hosted services
                 services.AddHostedService<JournalMonitorService>();
                 services.AddHostedService<WebConfigurationService>();
+				services.AddHostedService<StatusMonitorService>();
             })
             .ConfigureLogging(logging =>
             {

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -39,33 +39,32 @@ public class AudioEngineService : IDisposable
             {
                 _logger.LogInformation("Initializing Audio Engine");
                 LogSystemAudioInfo();
-                
                 // Create wave output device
-                if (_settings.Audio.AudioDeviceId >= 0)
-                {
-                    _logger.LogDebug("Attempting to use specific audio device - ID: {DeviceId}, Name: '{DeviceName}'", 
-                        _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName);
-                    
-                    // Validate device still exists
-                    if (ValidateAudioDevice(_settings.Audio.AudioDeviceId))
-                    {
-                        _waveOut = new WaveOutEvent { DeviceNumber = _settings.Audio.AudioDeviceId };
-                        _logger.LogInformation("✓ Successfully configured audio device {DeviceId}: {DeviceName}", 
-                            _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName);
-                    }
-                    else
-                    {
-                        _logger.LogWarning("⚠ Configured audio device {DeviceId} '{DeviceName}' not available, falling back to default", 
-                            _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName);
-                        _waveOut = new WaveOutEvent();
-                    }
-                }
-                else
-                {
-                    _waveOut = new WaveOutEvent();
-                    var defaultDevice = GetDefaultAudioDevice();
-                    _logger.LogInformation("Using default audio device: {DefaultDevice}", defaultDevice ?? "Unknown");
-                }
+				if (!string.IsNullOrEmpty(_settings.Audio.AudioDeviceName))
+				{
+					_logger.LogDebug("Attempting to find audio device by name: '{DeviceName}'", _settings.Audio.AudioDeviceName);
+					
+					var deviceEnumerator = new MMDeviceEnumerator();
+					var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+					var matchedDevice = devices.FirstOrDefault(d => d.FriendlyName == _settings.Audio.AudioDeviceName);
+					
+					if (matchedDevice != null)
+					{
+						_waveOut = new WasapiOut(matchedDevice, AudioClientShareMode.Shared, true, 200);
+						_logger.LogInformation("✓ Using audio device: {DeviceName}", matchedDevice.FriendlyName);
+					}
+					else
+					{
+						_logger.LogWarning("⚠ Device '{DeviceName}' not found, falling back to default", _settings.Audio.AudioDeviceName);
+						_waveOut = new WaveOutEvent();
+					}
+				}
+				else
+				{
+					_waveOut = new WaveOutEvent();
+					var defaultDevice = GetDefaultAudioDevice();
+					_logger.LogInformation("Using default audio device: {DefaultDevice}", defaultDevice ?? "Unknown");
+				}
 
                 // Log wave output configuration
                 LogWaveOutConfiguration();

--- a/src/EDButtkicker/Services/ContextualIntelligenceService.cs
+++ b/src/EDButtkicker/Services/ContextualIntelligenceService.cs
@@ -5,387 +5,440 @@ using System.Text.Json;
 
 namespace EDButtkicker.Services;
 
-public class ContextualIntelligenceService
+public class ContextualIntelligenceService : IDisposable
 {
-    private readonly ILogger<ContextualIntelligenceService> _logger;
-    private readonly AppSettings _settings;
-    private readonly GameContext _gameContext;
-    private readonly Dictionary<string, DateTime> _eventHistory = new();
-    private readonly Dictionary<string, int> _eventPatterns = new();
-    private DateTime _lastAnalysisUpdate = DateTime.UtcNow;
+	private readonly ILogger<ContextualIntelligenceService> _logger;
+	private readonly AppSettings _settings;
+	private readonly UserSettingsService _userSettingsService;
+	private readonly GameContext _gameContext;
+	private readonly Dictionary<string, DateTime> _eventHistory = new();
+	private readonly Dictionary<string, int> _eventPatterns = new();
+	private DateTime _lastAnalysisUpdate = DateTime.UtcNow;
+	private DateTime _lastSave = DateTime.UtcNow;
+	private static readonly TimeSpan SaveInterval = TimeSpan.FromMinutes(2);
 
-    // Configuration
-    public bool IsEnabled => _settings.ContextualIntelligence?.Enabled ?? false;
-    public double LearningRate => _settings.ContextualIntelligence?.LearningRate ?? 0.1;
-    public double PredictionThreshold => _settings.ContextualIntelligence?.PredictionThreshold ?? 0.7;
-    public bool EnableAdaptiveIntensity => _settings.ContextualIntelligence?.EnableAdaptiveIntensity ?? true;
-    public bool EnablePredictivePatterns => _settings.ContextualIntelligence?.EnablePredictivePatterns ?? true;
-    public bool EnableContextualVoice => _settings.ContextualIntelligence?.EnableContextualVoice ?? true;
+	// Configuration
+	public bool IsEnabled => _settings.ContextualIntelligence?.Enabled ?? false;
+	public double LearningRate => _settings.ContextualIntelligence?.LearningRate ?? 0.1;
+	public double PredictionThreshold => _settings.ContextualIntelligence?.PredictionThreshold ?? 0.7;
+	public bool EnableAdaptiveIntensity => _settings.ContextualIntelligence?.EnableAdaptiveIntensity ?? true;
+	public bool EnablePredictivePatterns => _settings.ContextualIntelligence?.EnablePredictivePatterns ?? true;
+	public bool EnableContextualVoice => _settings.ContextualIntelligence?.EnableContextualVoice ?? true;
 
-    public ContextualIntelligenceService(
-        ILogger<ContextualIntelligenceService> logger,
-        AppSettings settings)
-    {
-        _logger = logger;
-        _settings = settings;
-        _gameContext = new GameContext();
-        
-        _logger.LogInformation("Contextual Intelligence Service initialized - Enabled: {Enabled}", IsEnabled);
-    }
+	public ContextualIntelligenceService(
+		ILogger<ContextualIntelligenceService> logger,
+		AppSettings settings,
+		UserSettingsService userSettingsService)
+	{
+		_logger = logger;
+		_settings = settings;
+		_userSettingsService = userSettingsService;
+		_gameContext = new GameContext();
 
-    public GameContext GetCurrentContext() => _gameContext;
+		// Load saved context synchronously on startup
+		LoadContextAsync().GetAwaiter().GetResult();
 
-    public void ProcessEvent(JournalEvent journalEvent)
-    {
-        if (!IsEnabled) return;
+		_logger.LogInformation("Contextual Intelligence Service initialized - Enabled: {Enabled}", IsEnabled);
+	}
 
-        try
-        {
-            _logger.LogDebug("Processing event for contextual analysis: {EventType}", journalEvent.Event);
-            
-            // Update event history and patterns
-            UpdateEventHistory(journalEvent);
-            
-            // Analyze and update game context
-            AnalyzeGameState(journalEvent);
-            UpdateCombatContext(journalEvent);
-            UpdateExplorationContext(journalEvent);
-            UpdateTradingContext(journalEvent);
-            
-            // Perform behavioral analysis
-            AnalyzeBehavioralPatterns(journalEvent);
-            
-            // Update predictions
-            UpdatePredictions();
-            
-            _logger.LogDebug("Context updated - State: {State}, Threat: {Threat}, Intensity: {Intensity}x", 
-                _gameContext.CurrentState, _gameContext.ThreatLevel, _gameContext.GetContextualIntensityMultiplier());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing event for contextual intelligence: {EventType}", journalEvent.Event);
-        }
-    }
+	private async Task LoadContextAsync()
+	{
+		try
+		{
+			var snapshot = await _userSettingsService.LoadGameContextAsync();
+			if (snapshot == null) return;
 
-    public HapticPattern GetContextuallyAdjustedPattern(HapticPattern originalPattern, JournalEvent? journalEvent = null)
-    {
-        if (!IsEnabled || !EnableAdaptiveIntensity)
-            return originalPattern;
+			// Restore learned behavioural data
+			_gameContext.PlayerAggressiveness = snapshot.PlayerAggressiveness;
+			_gameContext.PlayerCautiousness = snapshot.PlayerCautiousness;
+			_gameContext.SystemsVisited = snapshot.SystemsVisited;
+			_gameContext.BodiesScanned = snapshot.BodiesScanned;
+			_gameContext.HullIntegrity = snapshot.LastHullIntegrity;
 
-        try
-        {
-            var adjustedPattern = ClonePattern(originalPattern);
-            var contextMultiplier = _gameContext.GetContextualIntensityMultiplier();
-            
-            // Apply contextual intensity adjustment
-            adjustedPattern.Intensity = (int)Math.Min(
-                adjustedPattern.Intensity * contextMultiplier,
-                _settings.Audio.MaxIntensity);
-            
-            // Adjust duration for urgent situations
-            if (_gameContext.IsInDangerousSituation())
-            {
-                adjustedPattern.Duration = (int)(adjustedPattern.Duration * 1.2);
-                adjustedPattern.FadeOut = Math.Max(adjustedPattern.FadeOut / 2, 50);
-            }
-            
-            // Extend patterns for routine activities to add variety
-            if (_gameContext.IsInRoutineActivity())
-            {
-                adjustedPattern.Duration = (int)(adjustedPattern.Duration * 0.8);
-                adjustedPattern.FadeIn *= 2;
-                adjustedPattern.FadeOut *= 2;
-            }
-            
-            // Adjust frequency for combat context
-            if (_gameContext.CurrentState == GameState.InCombat)
-            {
-                adjustedPattern.Frequency += (int)(_gameContext.CombatIntensity * 10);
-                adjustedPattern.Frequency = Math.Min(adjustedPattern.Frequency, 80);
-            }
-            
-            _logger.LogDebug("Pattern adjusted contextually - Original: {OrigIntensity}%, New: {NewIntensity}%, Multiplier: {Multiplier}x",
-                originalPattern.Intensity, adjustedPattern.Intensity, contextMultiplier);
-                
-            return adjustedPattern;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error adjusting pattern contextually, using original");
-            return originalPattern;
-        }
-    }
+			if (!string.IsNullOrEmpty(snapshot.LastKnownSystem))
+				_gameContext.CurrentSystem = snapshot.LastKnownSystem;
 
-    public string? GetContextualVoiceMessage(string eventType, JournalEvent? journalEvent = null)
-    {
-        if (!IsEnabled || !EnableContextualVoice)
-            return null;
+			// Restore event frequency history
+			foreach (var kvp in snapshot.RecentEventFrequency)
+				_gameContext.RecentEventFrequency[kvp.Key] = kvp.Value;
 
-        try
-        {
-            return eventType switch
-            {
-                "HullDamage" when _gameContext.ThreatLevel >= CombatThreatLevel.High => 
-                    GetCriticalDamageMessage(journalEvent),
-                "FSDJump" when _gameContext.ExplorationActivity == ExplorationMode.FirstDiscovery => 
-                    "Entering uncharted system. Scanning for valuable discoveries.",
-                "Docked" when _gameContext.IsCarryingCargo && _gameContext.CargoValue > 1000000 => 
-                    "High-value cargo delivered safely. Excellent profit margin achieved.",
-                "UnderAttack" when _gameContext.ThreatLevel == CombatThreatLevel.Critical => 
-                    "Critical threat detected! Evasive maneuvers recommended immediately!",
-                "ShieldsUp" when _gameContext.HullIntegrity < 0.3 => 
-                    "Shields restored. Hull integrity critical - seek immediate repairs.",
-                "Interdicted" when _gameContext.IsCarryingCargo => 
-                    "Interdiction detected! Cargo at risk - prepare for evasion or combat.",
-                _ => null
-            };
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error generating contextual voice message");
-            return null;
-        }
-    }
+			// Restore state time spent
+			foreach (var kvp in snapshot.StateTimeSpent)
+			{
+				if (Enum.TryParse<GameState>(kvp.Key, out var state))
+					_gameContext.StateTimeSpent[state] = kvp.Value;
+			}
 
-    public List<string> GetPredictedUpcomingEvents()
-    {
-        if (!IsEnabled || !EnablePredictivePatterns)
-            return new List<string>();
+			_logger.LogInformation(
+				"Restored game context - Systems: {Systems}, Aggressiveness: {Agg:F2}, Cautiousness: {Cau:F2}",
+				snapshot.SystemsVisited,
+				snapshot.PlayerAggressiveness,
+				snapshot.PlayerCautiousness);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to restore game context, starting fresh");
+		}
+	}
 
-        return _gameContext.LikelyUpcomingEvents.ToList();
-    }
+	private async Task SaveContextAsync()
+	{
+		try
+		{
+			var snapshot = new GameContextSnapshot
+			{
+				PlayerAggressiveness = _gameContext.PlayerAggressiveness,
+				PlayerCautiousness = _gameContext.PlayerCautiousness,
+				SystemsVisited = _gameContext.SystemsVisited,
+				BodiesScanned = _gameContext.BodiesScanned,
+				LastHullIntegrity = _gameContext.HullIntegrity,
+				LastKnownSystem = _gameContext.CurrentSystem,
+				RecentEventFrequency = new Dictionary<string, int>(_gameContext.RecentEventFrequency),
+				StateTimeSpent = _gameContext.StateTimeSpent
+					.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value),
+				SavedAt = DateTime.UtcNow
+			};
 
-    private void UpdateEventHistory(JournalEvent journalEvent)
-    {
-        _eventHistory[journalEvent.Event] = journalEvent.Timestamp;
-        _gameContext.IncrementEventFrequency(journalEvent.Event);
-        
-        // Clean old event frequency data (keep last 100 events per type)
-        if (_gameContext.RecentEventFrequency.Values.Sum() > 1000)
-        {
-            var oldestEvents = _gameContext.RecentEventFrequency
-                .Where(kvp => kvp.Value < 2)
-                .Select(kvp => kvp.Key)
-                .ToList();
-            
-            foreach (var eventType in oldestEvents)
-                _gameContext.RecentEventFrequency.Remove(eventType);
-        }
-    }
+			await _userSettingsService.SaveGameContextAsync(snapshot);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to save game context");
+		}
+	}
 
-    private void AnalyzeGameState(JournalEvent journalEvent)
-    {
-        var newState = journalEvent.Event switch
-        {
-            "StartUp" or "LoadGame" => GameState.MainMenu,
-            "SupercruiseEntry" => GameState.InSupercruise,
-            "SupercruiseExit" => GameState.InSystem,
-            "Docked" => GameState.Docked,
-            "Undocked" => GameState.InSystem,
-            "Touchdown" => GameState.Landed,
-            "Liftoff" => GameState.InSystem,
-            "LaunchSRV" => GameState.SRVMode,
-            "DockSRV" => GameState.Landed,
-            "LaunchFighter" or "VehicleSwitch" when journalEvent.AdditionalData?.ContainsKey("To") == true &&
-                journalEvent.AdditionalData["To"]?.ToString()?.Contains("Fighter") == true => GameState.FighterMode,
-            "UnderAttack" or "HullDamage" => GameState.InCombat,
-            "Interdicted" or "Interdiction" => GameState.Interdiction,
-            _ => _gameContext.CurrentState
-        };
+	public GameContext GetCurrentContext() => _gameContext;
 
-        if (newState != _gameContext.CurrentState)
-        {
-            _logger.LogDebug("Game state changing from {OldState} to {NewState}", _gameContext.CurrentState, newState);
-            _gameContext.UpdateState(newState);
-        }
+	public void ProcessEvent(JournalEvent journalEvent)
+	{
+		if (!IsEnabled) return;
 
-        // Update location context
-        if (!string.IsNullOrEmpty(journalEvent.StarSystem))
-            _gameContext.CurrentSystem = journalEvent.StarSystem;
-        
-        if (!string.IsNullOrEmpty(journalEvent.StationName))
-            _gameContext.CurrentStation = journalEvent.StationName;
+		try
+		{
+			_logger.LogDebug("Processing event for contextual analysis: {EventType}", journalEvent.Event);
 
-        // Update ship status
-        if (journalEvent.Health.HasValue)
-            _gameContext.HullIntegrity = journalEvent.Health.Value;
-    }
+			UpdateEventHistory(journalEvent);
+			AnalyzeGameState(journalEvent);
+			UpdateCombatContext(journalEvent);
+			UpdateExplorationContext(journalEvent);
+			UpdateTradingContext(journalEvent);
+			AnalyzeBehavioralPatterns(journalEvent);
+			UpdatePredictions();
 
-    private void UpdateCombatContext(JournalEvent journalEvent)
-    {
-        switch (journalEvent.Event)
-        {
-            case "UnderAttack":
-                _gameContext.IsUnderAttack = true;
-                _gameContext.LastCombatActivity = DateTime.UtcNow;
-                _gameContext.CombatIntensity = Math.Min(_gameContext.CombatIntensity + 0.2, 1.0);
-                break;
-                
-            case "HullDamage":
-                var threatLevel = (_gameContext.HullIntegrity, _gameContext.ShieldStrength) switch
-                {
-                    (< 0.25, _) => CombatThreatLevel.Critical,
-                    (< 0.5, < 0.3) => CombatThreatLevel.High,
-                    (_, < 0.5) => CombatThreatLevel.Medium,
-                    _ => CombatThreatLevel.Low
-                };
-                _gameContext.ThreatLevel = threatLevel;
-                _gameContext.LastCombatActivity = DateTime.UtcNow;
-                break;
-                
-            case "ShieldsUp":
-                _gameContext.ShieldStrength = 1.0;
-                if (_gameContext.ThreatLevel > CombatThreatLevel.Low)
-                    _gameContext.ThreatLevel = CombatThreatLevel.Low;
-                break;
-                
-            case "ShieldDown":
-                _gameContext.ShieldStrength = 0.0;
-                _gameContext.ThreatLevel = (CombatThreatLevel)Math.Max((byte)_gameContext.ThreatLevel, (byte)CombatThreatLevel.Medium);
-                break;
-                
-            case "FighterDestroyed" or "ShipTargeted":
-                _gameContext.EnemyCount = Math.Max(_gameContext.EnemyCount - 1, 0);
-                break;
-        }
+			_logger.LogDebug("Context updated - State: {State}, Threat: {Threat}, Intensity: {Intensity}x",
+				_gameContext.CurrentState, _gameContext.ThreatLevel, _gameContext.GetContextualIntensityMultiplier());
 
-        // Combat cooldown
-        if (_gameContext.LastCombatActivity.HasValue &&
-            DateTime.UtcNow - _gameContext.LastCombatActivity.Value > TimeSpan.FromMinutes(2))
-        {
-            _gameContext.IsUnderAttack = false;
-            _gameContext.ThreatLevel = CombatThreatLevel.None;
-            _gameContext.CombatIntensity *= 0.9; // Gradual decay
-        }
-    }
+			// Periodically save learned data every 2 minutes of play activity
+			if (DateTime.UtcNow - _lastSave > SaveInterval)
+			{
+				_lastSave = DateTime.UtcNow;
+				_ = Task.Run(SaveContextAsync);
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error processing event for contextual intelligence: {EventType}", journalEvent.Event);
+		}
+	}
 
-    private void UpdateExplorationContext(JournalEvent journalEvent)
-    {
-        switch (journalEvent.Event)
-        {
-            case "FSSDiscoveryScan":
-                _gameContext.ExplorationActivity = ExplorationMode.SystemScanning;
-                break;
-                
-            case "Scan" when journalEvent.AdditionalData?.ContainsKey("BodyName") == true:
-                _gameContext.ExplorationActivity = ExplorationMode.PlanetScanning;
-                _gameContext.BodiesScanned++;
-                break;
-                
-            case "CodexEntry":
-                _gameContext.ExplorationActivity = ExplorationMode.SignalInvestigation;
-                break;
-                
-            case "FSDJump":
-                _gameContext.SystemsVisited++;
-                if (journalEvent.AdditionalData?.ContainsKey("Population") == true)
-                {
-                    var population = journalEvent.AdditionalData["Population"]?.ToString();
-                    _gameContext.IsInPopulatedSystem = !string.IsNullOrEmpty(population) && population != "0";
-                }
-                break;
-        }
-    }
+	public void Dispose()
+	{
+		// Save on shutdown so nothing is lost
+		_logger.LogInformation("Saving game context on shutdown...");
+		SaveContextAsync().GetAwaiter().GetResult();
+	}
 
-    private void UpdateTradingContext(JournalEvent journalEvent)
-    {
-        switch (journalEvent.Event)
-        {
-            case "MarketBuy":
-                _gameContext.IsCarryingCargo = true;
-                if (journalEvent.AdditionalData?.ContainsKey("TotalCost") == true &&
-                    int.TryParse(journalEvent.AdditionalData["TotalCost"]?.ToString(), out int cost))
-                {
-                    _gameContext.CargoValue += cost;
-                }
-                break;
-                
-            case "MarketSell":
-                if (journalEvent.AdditionalData?.ContainsKey("TotalSale") == true &&
-                    int.TryParse(journalEvent.AdditionalData["TotalSale"]?.ToString(), out int sale))
-                {
-                    _gameContext.CargoValue = Math.Max(_gameContext.CargoValue - sale, 0);
-                }
-                break;
-        }
-    }
+	public HapticPattern GetContextuallyAdjustedPattern(HapticPattern originalPattern, JournalEvent? journalEvent = null)
+	{
+		if (!IsEnabled || !EnableAdaptiveIntensity)
+			return originalPattern;
 
-    private void AnalyzeBehavioralPatterns(JournalEvent journalEvent)
-    {
-        // Analyze player aggressiveness based on combat engagement
-        if (journalEvent.Event == "UnderAttack")
-        {
-            _gameContext.PlayerAggressiveness += LearningRate;
-        }
-        else if (journalEvent.Event == "FSDJump" && _gameContext.IsUnderAttack)
-        {
-            // Player fled from combat
-            _gameContext.PlayerCautiousness += LearningRate;
-            _gameContext.PlayerAggressiveness -= LearningRate * 0.5;
-        }
+		try
+		{
+			var adjustedPattern = ClonePattern(originalPattern);
+			var contextMultiplier = _gameContext.GetContextualIntensityMultiplier();
 
-        // Normalize behavioral scores
-        _gameContext.PlayerAggressiveness = Math.Max(0, Math.Min(1, _gameContext.PlayerAggressiveness));
-        _gameContext.PlayerCautiousness = Math.Max(0, Math.Min(1, _gameContext.PlayerCautiousness));
-    }
+			adjustedPattern.Intensity = (int)Math.Min(
+				adjustedPattern.Intensity * contextMultiplier,
+				_settings.Audio.MaxIntensity);
 
-    private void UpdatePredictions()
-    {
-        if (!EnablePredictivePatterns || DateTime.UtcNow - _lastAnalysisUpdate < TimeSpan.FromSeconds(30))
-            return;
+			if (_gameContext.IsInDangerousSituation())
+			{
+				adjustedPattern.Duration = (int)(adjustedPattern.Duration * 1.2);
+				adjustedPattern.FadeOut = Math.Max(adjustedPattern.FadeOut / 2, 50);
+			}
 
-        _lastAnalysisUpdate = DateTime.UtcNow;
-        
-        // Predict next state based on current context
-        _gameContext.PredictedNextState = _gameContext.CurrentState switch
-        {
-            GameState.Docked when _gameContext.StateActivityDuration > TimeSpan.FromMinutes(5) => GameState.InSystem,
-            GameState.InSupercruise when _gameContext.HasUnscannedBodies => GameState.InSystem,
-            GameState.InSystem when _gameContext.IsCarryingCargo => GameState.Docked,
-            GameState.InCombat when _gameContext.HullIntegrity < 0.3 => GameState.InSupercruise,
-            _ => null
-        };
+			if (_gameContext.IsInRoutineActivity())
+			{
+				adjustedPattern.Duration = (int)(adjustedPattern.Duration * 0.8);
+				adjustedPattern.FadeIn *= 2;
+				adjustedPattern.FadeOut *= 2;
+			}
 
-        // Predict likely upcoming events
-        _gameContext.LikelyUpcomingEvents.Clear();
-        
-        if (_gameContext.CurrentState == GameState.Docked)
-            _gameContext.LikelyUpcomingEvents.Add("Undocked");
-            
-        if (_gameContext.IsInDangerousSituation())
-            _gameContext.LikelyUpcomingEvents.AddRange(new[] { "HullDamage", "ShieldDown", "UnderAttack" });
-            
-        if (_gameContext.CurrentState == GameState.InSupercruise && _gameContext.HasUnscannedBodies)
-            _gameContext.LikelyUpcomingEvents.Add("SupercruiseExit");
-    }
+			if (_gameContext.CurrentState == GameState.InCombat)
+			{
+				adjustedPattern.Frequency += (int)(_gameContext.CombatIntensity * 10);
+				adjustedPattern.Frequency = Math.Min(adjustedPattern.Frequency, 80);
+			}
 
-    private string GetCriticalDamageMessage(JournalEvent? journalEvent)
-    {
-        var hullPercent = (int)(_gameContext.HullIntegrity * 100);
-        
-        if (hullPercent < 15)
-            return "CRITICAL HULL BREACH! Emergency repairs required immediately!";
-        else if (hullPercent < 30)
-            return $"Severe hull damage detected! Hull integrity at {hullPercent}%. Seek repairs!";
-        else
-            return $"Hull damage sustained. Integrity at {hullPercent}%.";
-    }
+			_logger.LogDebug("Pattern adjusted contextually - Original: {OrigIntensity}%, New: {NewIntensity}%, Multiplier: {Multiplier}x",
+				originalPattern.Intensity, adjustedPattern.Intensity, contextMultiplier);
 
-    private HapticPattern ClonePattern(HapticPattern original)
-    {
-        // Create a deep copy of the pattern for modification
-        var json = JsonSerializer.Serialize(original);
-        return JsonSerializer.Deserialize<HapticPattern>(json) ?? original;
-    }
-}
+			return adjustedPattern;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error adjusting pattern contextually, using original");
+			return originalPattern;
+		}
+	}
 
-public class ContextualIntelligenceConfiguration
-{
-    public bool Enabled { get; set; } = false;
-    public double LearningRate { get; set; } = 0.1;
-    public double PredictionThreshold { get; set; } = 0.7;
-    public bool EnableAdaptiveIntensity { get; set; } = true;
-    public bool EnablePredictivePatterns { get; set; } = true;
-    public bool EnableContextualVoice { get; set; } = true;
-    public bool LogContextAnalysis { get; set; } = false;
+	public string? GetContextualVoiceMessage(string eventType, JournalEvent? journalEvent = null)
+	{
+		if (!IsEnabled || !EnableContextualVoice)
+			return null;
+
+		try
+		{
+			return eventType switch
+			{
+				"HullDamage" when _gameContext.ThreatLevel >= CombatThreatLevel.High =>
+					GetCriticalDamageMessage(journalEvent),
+				"FSDJump" when _gameContext.ExplorationActivity == ExplorationMode.FirstDiscovery =>
+					"Entering uncharted system. Scanning for valuable discoveries.",
+				"Docked" when _gameContext.IsCarryingCargo && _gameContext.CargoValue > 1000000 =>
+					"High-value cargo delivered safely. Excellent profit margin achieved.",
+				"UnderAttack" when _gameContext.ThreatLevel == CombatThreatLevel.Critical =>
+					"Critical threat detected! Evasive maneuvers recommended immediately!",
+				"ShieldsUp" when _gameContext.HullIntegrity < 0.3 =>
+					"Shields restored. Hull integrity critical - seek immediate repairs.",
+				"Interdicted" when _gameContext.IsCarryingCargo =>
+					"Interdiction detected! Cargo at risk - prepare for evasion or combat.",
+				_ => null
+			};
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error generating contextual voice message");
+			return null;
+		}
+	}
+
+	public List<string> GetPredictedUpcomingEvents()
+	{
+		if (!IsEnabled || !EnablePredictivePatterns)
+			return new List<string>();
+
+		return _gameContext.LikelyUpcomingEvents.ToList();
+	}
+
+	private void UpdateEventHistory(JournalEvent journalEvent)
+	{
+		_eventHistory[journalEvent.Event] = journalEvent.Timestamp;
+		_gameContext.IncrementEventFrequency(journalEvent.Event);
+
+		if (_gameContext.RecentEventFrequency.Values.Sum() > 1000)
+		{
+			var oldestEvents = _gameContext.RecentEventFrequency
+				.Where(kvp => kvp.Value < 2)
+				.Select(kvp => kvp.Key)
+				.ToList();
+
+			foreach (var eventType in oldestEvents)
+				_gameContext.RecentEventFrequency.Remove(eventType);
+		}
+	}
+
+	private void AnalyzeGameState(JournalEvent journalEvent)
+	{
+		var newState = journalEvent.Event switch
+		{
+			"StartUp" or "LoadGame" => GameState.MainMenu,
+			"SupercruiseEntry" => GameState.InSupercruise,
+			"SupercruiseExit" => GameState.InSystem,
+			"Docked" => GameState.Docked,
+			"Undocked" => GameState.InSystem,
+			"Touchdown" => GameState.Landed,
+			"Liftoff" => GameState.InSystem,
+			"LaunchSRV" => GameState.SRVMode,
+			"DockSRV" => GameState.Landed,
+			"LaunchFighter" or "VehicleSwitch" when journalEvent.AdditionalData?.ContainsKey("To") == true &&
+				journalEvent.AdditionalData["To"]?.ToString()?.Contains("Fighter") == true => GameState.FighterMode,
+			_ => (GameState?)null
+		};
+
+		if (newState.HasValue && newState.Value != _gameContext.CurrentState)
+		{
+			_gameContext.UpdateState(newState.Value);
+		}
+
+		if (!string.IsNullOrEmpty(journalEvent.StarSystem))
+			_gameContext.CurrentSystem = journalEvent.StarSystem;
+
+		if (!string.IsNullOrEmpty(journalEvent.StationName))
+			_gameContext.CurrentStation = journalEvent.StationName;
+
+		if (journalEvent.Health.HasValue)
+			_gameContext.HullIntegrity = journalEvent.Health.Value;
+	}
+
+	private void UpdateCombatContext(JournalEvent journalEvent)
+	{
+		switch (journalEvent.Event)
+		{
+			case "UnderAttack":
+				_gameContext.IsUnderAttack = true;
+				_gameContext.LastCombatActivity = DateTime.UtcNow;
+				_gameContext.CombatIntensity = Math.Min(_gameContext.CombatIntensity + 0.2, 1.0);
+				break;
+
+			case "HullDamage":
+				var threatLevel = (_gameContext.HullIntegrity, _gameContext.ShieldStrength) switch
+				{
+					(< 0.25, _) => CombatThreatLevel.Critical,
+					(< 0.5, < 0.3) => CombatThreatLevel.High,
+					(_, < 0.5) => CombatThreatLevel.Medium,
+					_ => CombatThreatLevel.Low
+				};
+				_gameContext.ThreatLevel = threatLevel;
+				_gameContext.LastCombatActivity = DateTime.UtcNow;
+				break;
+
+			case "ShieldsUp":
+				_gameContext.ShieldStrength = 1.0;
+				if (_gameContext.ThreatLevel > CombatThreatLevel.Low)
+					_gameContext.ThreatLevel = CombatThreatLevel.Low;
+				break;
+
+			case "ShieldDown":
+				_gameContext.ShieldStrength = 0.0;
+				_gameContext.ThreatLevel = (CombatThreatLevel)Math.Max((byte)_gameContext.ThreatLevel, (byte)CombatThreatLevel.Medium);
+				break;
+
+			case "FighterDestroyed" or "ShipTargeted":
+				_gameContext.EnemyCount = Math.Max(_gameContext.EnemyCount - 1, 0);
+				break;
+		}
+
+		if (_gameContext.LastCombatActivity.HasValue &&
+			DateTime.UtcNow - _gameContext.LastCombatActivity.Value > TimeSpan.FromMinutes(2))
+		{
+			_gameContext.IsUnderAttack = false;
+			_gameContext.ThreatLevel = CombatThreatLevel.None;
+			_gameContext.CombatIntensity *= 0.9;
+		}
+	}
+
+	private void UpdateExplorationContext(JournalEvent journalEvent)
+	{
+		switch (journalEvent.Event)
+		{
+			case "FSSDiscoveryScan":
+				_gameContext.ExplorationActivity = ExplorationMode.SystemScanning;
+				break;
+
+			case "Scan" when journalEvent.AdditionalData?.ContainsKey("BodyName") == true:
+				_gameContext.ExplorationActivity = ExplorationMode.PlanetScanning;
+				_gameContext.BodiesScanned++;
+				break;
+
+			case "CodexEntry":
+				_gameContext.ExplorationActivity = ExplorationMode.SignalInvestigation;
+				break;
+
+			case "FSDJump":
+				_gameContext.SystemsVisited++;
+				if (journalEvent.AdditionalData?.ContainsKey("Population") == true)
+				{
+					var population = journalEvent.AdditionalData["Population"]?.ToString();
+					_gameContext.IsInPopulatedSystem = !string.IsNullOrEmpty(population) && population != "0";
+				}
+				break;
+		}
+	}
+
+	private void UpdateTradingContext(JournalEvent journalEvent)
+	{
+		switch (journalEvent.Event)
+		{
+			case "MarketBuy":
+				_gameContext.IsCarryingCargo = true;
+				if (journalEvent.AdditionalData?.ContainsKey("TotalCost") == true &&
+					int.TryParse(journalEvent.AdditionalData["TotalCost"]?.ToString(), out int cost))
+				{
+					_gameContext.CargoValue += cost;
+				}
+				break;
+
+			case "MarketSell":
+				if (journalEvent.AdditionalData?.ContainsKey("TotalSale") == true &&
+					int.TryParse(journalEvent.AdditionalData["TotalSale"]?.ToString(), out int sale))
+				{
+					_gameContext.CargoValue = Math.Max(_gameContext.CargoValue - sale, 0);
+				}
+				break;
+		}
+	}
+
+	private void AnalyzeBehavioralPatterns(JournalEvent journalEvent)
+	{
+		if (journalEvent.Event == "UnderAttack")
+		{
+			_gameContext.PlayerAggressiveness += LearningRate;
+		}
+		else if (journalEvent.Event == "FSDJump" && _gameContext.IsUnderAttack)
+		{
+			_gameContext.PlayerCautiousness += LearningRate;
+			_gameContext.PlayerAggressiveness -= LearningRate * 0.5;
+		}
+
+		_gameContext.PlayerAggressiveness = Math.Max(0, Math.Min(1, _gameContext.PlayerAggressiveness));
+		_gameContext.PlayerCautiousness = Math.Max(0, Math.Min(1, _gameContext.PlayerCautiousness));
+	}
+
+	private void UpdatePredictions()
+	{
+		if (!EnablePredictivePatterns || DateTime.UtcNow - _lastAnalysisUpdate < TimeSpan.FromSeconds(30))
+			return;
+
+		_lastAnalysisUpdate = DateTime.UtcNow;
+
+		_gameContext.PredictedNextState = _gameContext.CurrentState switch
+		{
+			GameState.Docked when _gameContext.StateActivityDuration > TimeSpan.FromMinutes(5) => GameState.InSystem,
+			GameState.InSupercruise when _gameContext.HasUnscannedBodies => GameState.InSystem,
+			GameState.InSystem when _gameContext.IsCarryingCargo => GameState.Docked,
+			GameState.InCombat when _gameContext.HullIntegrity < 0.3 => GameState.InSupercruise,
+			_ => null
+		};
+
+		_gameContext.LikelyUpcomingEvents.Clear();
+
+		if (_gameContext.CurrentState == GameState.Docked)
+			_gameContext.LikelyUpcomingEvents.Add("Undocked");
+
+		if (_gameContext.IsInDangerousSituation())
+			_gameContext.LikelyUpcomingEvents.AddRange(new[] { "HullDamage", "ShieldDown", "UnderAttack" });
+
+		if (_gameContext.CurrentState == GameState.InSupercruise && _gameContext.HasUnscannedBodies)
+			_gameContext.LikelyUpcomingEvents.Add("SupercruiseExit");
+	}
+
+	private string GetCriticalDamageMessage(JournalEvent? journalEvent)
+	{
+		var hullPercent = (int)(_gameContext.HullIntegrity * 100);
+
+		if (hullPercent < 15)
+			return "CRITICAL HULL BREACH! Emergency repairs required immediately!";
+		else if (hullPercent < 30)
+			return $"Severe hull damage detected! Hull integrity at {hullPercent}%. Seek repairs!";
+		else
+			return $"Hull damage sustained. Integrity at {hullPercent}%.";
+	}
+
+	private HapticPattern ClonePattern(HapticPattern original)
+	{
+		var json = JsonSerializer.Serialize(original);
+		return JsonSerializer.Deserialize<HapticPattern>(json) ?? original;
+	}
 }

--- a/src/EDButtkicker/Services/StatusMonitorService.cs
+++ b/src/EDButtkicker/Services/StatusMonitorService.cs
@@ -1,0 +1,278 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Watches Elite Dangerous Status.json for real-time flag changes and triggers haptic patterns.
+/// Status.json updates every ~1 second while the game is running.
+/// </summary>
+public class StatusMonitorService : BackgroundService
+{
+	private readonly ILogger<StatusMonitorService> _logger;
+	private readonly AppSettings _settings;
+	private readonly AudioEngineService _audioEngine;
+	private readonly EventMappingService _eventMapping;
+
+	// Path to Status.json alongside the journal files
+	private string _statusFilePath = string.Empty;
+
+	// Track previous flags to detect changes
+	private long _previousFlags = -1;
+	private long _previousFlags2 = -1;
+
+	// Polling interval - Status.json updates ~1s so 250ms gives responsive detection
+	private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+
+	// ED Status.json Flags bit definitions
+	[Flags]
+	private enum StatusFlags : long
+	{
+		Docked              = 1 << 0,   // 1
+		Landed              = 1 << 1,   // 2
+		LandingGearDown     = 1 << 2,   // 4
+		ShieldsUp           = 1 << 3,   // 8
+		Supercruise         = 1 << 4,   // 16
+		FlightAssistOff     = 1 << 5,   // 32
+		HardpointsDeployed  = 1 << 6,   // 64
+		InWing              = 1 << 7,   // 128
+		LightsOn            = 1 << 8,   // 256 - was bit 9 previously
+		CargoScoopDeployed  = 1 << 9,   // 512
+		SilentRunning       = 1 << 10,  // 1024
+		ScoopingFuel        = 1 << 11,  // 2048
+		FsdMassLocked       = 1 << 16,  // 65536
+		FsdCharging         = 1 << 17,  // 131072
+		FsdCooldown         = 1 << 18,  // 262144
+		LowFuel             = 1 << 19,  // 524288
+		Overheating         = 1 << 20,  // 1048576
+		HaveMission         = 1 << 21,
+		Interdicted         = 1 << 23,
+		InMainShip          = 1 << 24,
+		InFighter           = 1 << 25,
+		InSRV               = 1 << 26,
+		NightVision         = 1 << 28,
+	}
+
+	public StatusMonitorService(
+		ILogger<StatusMonitorService> logger,
+		AppSettings settings,
+		AudioEngineService audioEngine,
+		EventMappingService eventMapping)
+	{
+		_logger = logger;
+		_settings = settings;
+		_audioEngine = audioEngine;
+		_eventMapping = eventMapping;
+	}
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		_logger.LogInformation("Starting Status Monitor Service");
+
+		// Resolve Status.json path from journal path
+		var journalDir = _settings.EliteDangerous.JournalPath;
+		_statusFilePath = Path.Combine(journalDir, "Status.json");
+
+		_logger.LogInformation("Watching Status.json at: {Path}", _statusFilePath);
+
+		// Wait until file exists (game may not be running yet)
+		while (!File.Exists(_statusFilePath) && !stoppingToken.IsCancellationRequested)
+		{
+			_logger.LogDebug("Status.json not found yet, waiting...");
+			await Task.Delay(2000, stoppingToken);
+		}
+
+		_logger.LogInformation("Status.json found, beginning monitoring");
+
+		while (!stoppingToken.IsCancellationRequested)
+		{
+			try
+			{
+				await PollStatusFile();
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, "Error polling Status.json");
+			}
+
+			await Task.Delay(PollInterval, stoppingToken);
+		}
+	}
+
+	private async Task PollStatusFile()
+	{
+		if (!File.Exists(_statusFilePath))
+			return;
+
+		try
+		{
+			// Read with shared access since the game also writes this file
+			string json;
+			using (var stream = new FileStream(_statusFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+			using (var reader = new StreamReader(stream))
+			{
+				json = await reader.ReadToEndAsync();
+			}
+
+			if (string.IsNullOrWhiteSpace(json))
+				return;
+
+			var doc = JsonDocument.Parse(json);
+			var root = doc.RootElement;
+
+			if (!root.TryGetProperty("Flags", out var flagsElement))
+				return;
+
+			var flags = flagsElement.GetInt64();
+			var flags2 = root.TryGetProperty("Flags2", out var flags2Element)
+				? flags2Element.GetInt64()
+				: 0;
+
+			// First read - just store state, don't trigger anything
+			if (_previousFlags == -1)
+			{
+				_previousFlags = flags;
+				_previousFlags2 = flags2;
+				return;
+			}
+
+			// Detect changes and trigger patterns
+			if (flags != _previousFlags || flags2 != _previousFlags2)
+			{
+				await ProcessFlagChanges(_previousFlags, flags, _previousFlags2, flags2);
+				_previousFlags = flags;
+				_previousFlags2 = flags2;
+			}
+		}
+		catch (JsonException)
+		{
+			// Status.json can be partially written - just skip this poll
+		}
+		catch (IOException)
+		{
+			// File locked momentarily - skip this poll
+		}
+	}
+
+	private async Task ProcessFlagChanges(long oldFlags, long newFlags, long oldFlags2, long newFlags2)
+	{
+		var changed = oldFlags ^ newFlags;
+		if (changed == 0) return;
+
+		_logger.LogDebug("Status flags changed: {OldFlags} -> {NewFlags} (changed bits: {Changed})",
+			oldFlags, newFlags, changed);
+
+		// Landing Gear
+		if (HasBitChanged(changed, (long)StatusFlags.LandingGearDown))
+		{
+			bool gearDown = HasFlag(newFlags, (long)StatusFlags.LandingGearDown);
+			_logger.LogInformation("Landing gear {State}", gearDown ? "deployed" : "retracted");
+
+			if (gearDown)
+				await Task.Delay(2000); // wait for gear to start moving before feedback
+
+			await TriggerStatusPattern(gearDown ? "LandingGearDown" : "LandingGearUp");
+		}
+
+		// Hardpoints
+		if (HasBitChanged(changed, (long)StatusFlags.HardpointsDeployed))
+		{
+			bool deployed = HasFlag(newFlags, (long)StatusFlags.HardpointsDeployed);
+			_logger.LogInformation("Hardpoints {State}", deployed ? "deployed" : "retracted");
+			await TriggerStatusPattern(deployed ? "HardpointsDeployed" : "HardpointsRetracted");
+		}
+
+		// Cargo Scoop
+		if (HasBitChanged(changed, (long)StatusFlags.CargoScoopDeployed))
+		{
+			bool deployed = HasFlag(newFlags, (long)StatusFlags.CargoScoopDeployed);
+			_logger.LogInformation("Cargo scoop {State}", deployed ? "deployed" : "retracted");
+			await TriggerStatusPattern(deployed ? "CargoScoopDeployed" : "CargoScoopRetracted");
+		}
+
+		// Silent Running
+		if (HasBitChanged(changed, (long)StatusFlags.SilentRunning))
+		{
+			bool enabled = HasFlag(newFlags, (long)StatusFlags.SilentRunning);
+			_logger.LogInformation("Silent running {State}", enabled ? "enabled" : "disabled");
+			await TriggerStatusPattern(enabled ? "SilentRunningOn" : "SilentRunningOff");
+		}
+
+		// FSD Charging
+		if (HasBitChanged(changed, (long)StatusFlags.FsdCharging))
+		{
+			bool charging = HasFlag(newFlags, (long)StatusFlags.FsdCharging);
+			if (charging)
+			{
+				_logger.LogInformation("FSD charging");
+				await TriggerStatusPattern("FsdCharging");
+			}
+		}
+
+		// FSD Cooldown
+		if (HasBitChanged(changed, (long)StatusFlags.FsdCooldown))
+		{
+			bool cooldown = HasFlag(newFlags, (long)StatusFlags.FsdCooldown);
+			if (cooldown)
+			{
+				_logger.LogInformation("FSD cooldown started");
+				await TriggerStatusPattern("FsdCooldown");
+			}
+		}
+
+		// Low Fuel warning
+		if (HasBitChanged(changed, (long)StatusFlags.LowFuel))
+		{
+			bool lowFuel = HasFlag(newFlags, (long)StatusFlags.LowFuel);
+			if (lowFuel)
+			{
+				_logger.LogInformation("Low fuel warning");
+				await TriggerStatusPattern("LowFuel");
+			}
+		}
+
+		// Overheating
+		if (HasBitChanged(changed, (long)StatusFlags.Overheating))
+		{
+			bool overheating = HasFlag(newFlags, (long)StatusFlags.Overheating);
+			if (overheating)
+			{
+				_logger.LogInformation("Ship overheating");
+				await TriggerStatusPattern("Overheating");
+			}
+		}
+
+		// Night Vision
+		if (HasBitChanged(changed, (long)StatusFlags.NightVision))
+		{
+			bool enabled = HasFlag(newFlags, (long)StatusFlags.NightVision);
+			_logger.LogInformation("Night vision {State}", enabled ? "on" : "off");
+			await TriggerStatusPattern(enabled ? "NightVisionOn" : "NightVisionOff");
+		}
+	}
+
+	private async Task TriggerStatusPattern(string eventType)
+	{
+		try
+		{
+			var pattern = _eventMapping.GetDefaultPatternForEvent(eventType);
+			if (pattern == null)
+			{
+				_logger.LogDebug("No pattern mapped for status event: {EventType}", eventType);
+				return;
+			}
+
+			_logger.LogDebug("Triggering haptic pattern for status event: {EventType}", eventType);
+			await _audioEngine.PlayHapticPattern(pattern);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Error triggering haptic pattern for status event: {EventType}", eventType);
+		}
+	}
+
+	private static bool HasBitChanged(long changed, long flag) => (changed & flag) != 0;
+	private static bool HasFlag(long flags, long flag) => (flags & flag) != 0;
+}


### PR DESCRIPTION
New: StatusMonitorService
Adds real-time monitoring of Status.json for flag-based events that don't appear in the journal — landing gear deploy/retract, hardpoints, cargo scoop, silent running, FSD cooldown, low fuel, overheating, and night vision. Polls every 250ms with shared file access so it doesn't conflict with the game.

New haptic patterns:
FSDJump — hyperspace arrival (3-stage: exit impact → system entry rumble → FSD cooldown fade)
LandingGearDown/Up — 6-stage sequences with hydraulic extension, mid-travel vibration, and locking pins
Docked — 8-stage station docking: pad contact weight, ship settling, magnetic clamps, fuel hose connect, fuel flow
Undocked — lighter 4-stage release sequence
Touchdown — 8-stage planetary landing: ground impact, mass transfer, terrain texture, clamps, pad services
Liftoff — 6-stage lighter departure
Hardpoints, cargo scoop, silent running, FSD cooldown, low fuel, overheating, night vision
Colonisation events: DockingGranted, SupercruiseDestinationDrop, ColonisationContribution, RefuelAll, MarketBuy

Bug fixes
MaxIntensity = 0 silently clipped all multi-layer pattern output to zero — fixed in MultiLayerPatternGenerator
AudioEngineService ignored AudioDeviceName config and always used default device — fixed with WASAPI name matching
ContextualIntelligenceService not registered in WebConfigurationService inner DI container
StreamWriter sync flush blocked Kestrel in ContextualIntelligenceApiController — replaced with WriteAsync
Circular dependency between AppSettings and ContextualIntelligenceService namespaces — resolved by moving config class