### PR TITLE
docs: add MIT license badge under README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elite Dangerous Buttkicker Extension
 
+[![License: MIT](https://img.shields.io/github/license/jwilson411/Elite-Buttkicker)](LICENSE)
+
 A C# application that monitors Elite Dangerous journal files and generates bass audio signals for buttkicker haptic feedback.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add the GitHub MIT license badge under the README H1.
- Keep the existing one-sentence description.
- No CI added (this repo has none).

## Test Plan
- [x] README starts with H1, badge, then the description sentence.
- [x] Badge links to LICENSE.
- [x] No em-dashes introduced.

Closes EBK-04.