### PR TITLE
ci: publish downloadable Windows releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-audit:
+    name: Dependency vulnerability audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore src/EDButtkicker/EDButtkicker.csproj
+
+      - name: Fail on known vulnerable packages
+        shell: pwsh
+        run: |
+          dotnet list src/EDButtkicker/EDButtkicker.csproj package --vulnerable --include-transitive --format json | Set-Content audit.json
+          $audit = Get-Content audit.json -Raw | ConvertFrom-Json
+          $vulnerable = @(
+            foreach ($project in $audit.projects) {
+              foreach ($framework in $project.frameworks) {
+                @($framework.topLevelPackages)
+                @($framework.transitivePackages)
+              }
+            }
+          ) | Where-Object { $_ -ne $null }
+          if ($vulnerable.Count -gt 0) {
+            $vulnerable | ForEach-Object { Write-Error "$($_.id) $($_.resolvedVersion) has known vulnerabilities" }
+            throw "Dependency vulnerability audit failed"
+          }
+
+  build-and-package:
+    name: Build and package (${{ matrix.rid }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [win-x64, win-arm64, win-x86]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore src/EDButtkicker/EDButtkicker.csproj --runtime "${{ matrix.rid }}"
+
+      - name: Build
+        run: dotnet build src/EDButtkicker/EDButtkicker.csproj --configuration Release --runtime "${{ matrix.rid }}" --no-restore
+
+      - name: Publish self-contained application
+        shell: pwsh
+        run: |
+          dotnet publish src/EDButtkicker/EDButtkicker.csproj `
+            --configuration Release `
+            --runtime "${{ matrix.rid }}" `
+            --self-contained true `
+            --no-restore `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -p:ContinuousIntegrationBuild=true `
+            --output "publish/${{ matrix.rid }}"
+
+      - name: Verify distributable contents
+        shell: pwsh
+        run: |
+          $required = @(
+            "publish/${{ matrix.rid }}/EDButtkicker.exe",
+            "publish/${{ matrix.rid }}/wwwroot/index.html",
+            "publish/${{ matrix.rid }}/patterns/default-patterns.json"
+          )
+          foreach ($path in $required) {
+            if (-not (Test-Path $path)) {
+              throw "Required publish output is missing: $path"
+            }
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing vMAJOR.MINOR.PATCH tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Resolve and validate version
+        id: version
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag must match vMAJOR.MINOR.PATCH; got: $tag" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish ${{ matrix.rid }}
+    needs: validate
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [win-x64, win-arm64, win-x86]
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Publish and package
+        shell: pwsh
+        env:
+          RID: ${{ matrix.rid }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          dotnet restore src/EDButtkicker/EDButtkicker.csproj -r $env:RID
+          dotnet publish src/EDButtkicker/EDButtkicker.csproj `
+            --configuration Release `
+            --runtime $env:RID `
+            --self-contained true `
+            --no-restore `
+            -p:Version=$env:VERSION `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -p:ContinuousIntegrationBuild=true `
+            --output "publish/$env:RID"
+
+          $required = @(
+            "publish/$env:RID/EDButtkicker.exe",
+            "publish/$env:RID/wwwroot/index.html",
+            "publish/$env:RID/patterns/default-patterns.json"
+          )
+          foreach ($path in $required) {
+            if (-not (Test-Path $path)) { throw "Required publish output is missing: $path" }
+          }
+
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $archive = "dist/Elite-Buttkicker-v$env:VERSION-$env:RID.zip"
+          Compress-Archive -Path "publish/$env:RID/*" -DestinationPath $archive
+          $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          "$hash  $(Split-Path $archive -Leaf)" | Set-Content -NoNewline "$archive.sha256"
+
+      - name: Upload packaged build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: Elite-Buttkicker-${{ matrix.rid }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub Release
+    needs: [validate, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packaged builds
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: Elite-Buttkicker-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        shell: bash
+        run: |
+          gh release view "$TAG" --repo "$REPOSITORY" >/dev/null 2>&1 || \
+            gh release create "$TAG" --repo "$REPOSITORY" --verify-tag --generate-notes --title "$TAG"
+          gh release upload "$TAG" dist/* --repo "$REPOSITORY" --clobber

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ A C# application that monitors Elite Dangerous journal files and generates bass 
 
 ## Quick Start
 
+### Download a ready-to-run Windows build
+
+1. Open the [latest GitHub Release](https://github.com/jwilson411/Elite-Buttkicker/releases/latest).
+2. Download the ZIP for your Windows architecture. Most users should choose `win-x64`; Windows on ARM users should choose `win-arm64`.
+3. Extract the entire ZIP to a writable folder.
+4. Run `EDButtkicker.exe`, then use the automatically opened browser interface to select your audio device and verify the journal path.
+
+Each ZIP has a matching `.sha256` file. You can verify it in PowerShell with:
+
+```powershell
+(Get-FileHash .\Elite-Buttkicker-vX.Y.Z-win-x64.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+```
+
+The value must match the first value in the downloaded `.sha256` file. Windows may warn about the unsigned executable; verify the checksum and that the download came from this repository before choosing to run it.
+
+### Build from source
+
 1. **Build the project**:
    ```bash
    dotnet build

--- a/src/EDButtkicker/EDButtkicker.csproj
+++ b/src/EDButtkicker/EDButtkicker.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="System.Speech" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +43,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Include="..\..\patterns\**\*">
+      <Link>patterns\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
## Summary
- Add Windows CI builds for x64, ARM64, and x86 on pull requests and `main`
- Add tag-driven GitHub Releases with self-contained ZIPs and SHA-256 checksum files
- Package the required `wwwroot` and default pattern files with every build
- Document ready-to-run downloads and checksum verification
- Pin every third-party GitHub Action to an immutable commit SHA

## Verification
- [x] Local .NET 8 restore and Release build succeeded
- [x] Local self-contained publish succeeded for `win-x64`, `win-arm64`, and `win-x86`
- [x] Each local publish contains `EDButtkicker.exe`, `wwwroot/index.html`, and `patterns/default-patterns.json`
- [ ] GitHub Actions matrix is green
- [ ] A semantic version tag publishes ZIP and `.sha256` assets

Closes #2
