### PR TITLE
chore: ignore Claude folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,7 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# Claude local folders (keep claude.md files tracked)
+**/.[Cc][Ll][Aa][Uu][Dd][Ee]/
+**/[Cc][Ll][Aa][Uu][Dd][Ee]/


### PR DESCRIPTION
## Summary
- Ignore `.claude/` directories at any depth
- Ignore case variants of `claude/` directories
- Keep `claude.md` files tracked

## Verification
- Confirmed Claude folder paths are ignored with `git check-ignore`
- Confirmed `claude.md` remains tracked