### PR TITLE
fix: enforce Audio.MaxIntensity as a final hardware safety cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,24 @@ jobs:
             throw "Dependency vulnerability audit failed"
           }
 
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore EDButtkicker.sln
+
+      - name: Test
+        run: dotnet test EDButtkicker.sln --configuration Release --no-restore
+
   build-and-package:
     name: Build and package (${{ matrix.rid }})
     runs-on: windows-latest

--- a/EDButtkicker.sln
+++ b/EDButtkicker.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EDButtkicker", "src\EDButtkicker\EDButtkicker.csproj", "{939035E1-A645-4A17-96B2-71101FDFF950}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{424C7037-318A-44FE-A3C6-A1A29CA19DEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EDButtkicker.Tests", "tests\EDButtkicker.Tests\EDButtkicker.Tests.csproj", "{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +33,24 @@ Global
 		{939035E1-A645-4A17-96B2-71101FDFF950}.Release|x64.Build.0 = Release|Any CPU
 		{939035E1-A645-4A17-96B2-71101FDFF950}.Release|x86.ActiveCfg = Release|Any CPU
 		{939035E1-A645-4A17-96B2-71101FDFF950}.Release|x86.Build.0 = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|x64.Build.0 = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Debug|x86.Build.0 = Debug|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|x64.ActiveCfg = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|x64.Build.0 = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|x86.ActiveCfg = Release|Any CPU
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{939035E1-A645-4A17-96B2-71101FDFF950} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{761B5434-9DD2-48F9-B6E4-4BF4527A9C36} = {424C7037-318A-44FE-A3C6-A1A29CA19DEF}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The value must match the first value in the downloaded `.sha256` file. Windows m
 ## Safety Notes
 
 - Audio levels are capped at configured maximum
+- The cap is applied after mixing for all pattern types and honors `Audio.MaxIntensity`
 - Smooth sine waves prevent speaker damage
 - Rate limiting prevents audio spam
 - Graceful error handling for device disconnection

--- a/src/EDButtkicker/Models/GameContext.cs
+++ b/src/EDButtkicker/Models/GameContext.cs
@@ -155,3 +155,20 @@ public class GameContext
         return Math.Min(multiplier, 2.5); // Cap at 2.5x
     }
 }
+
+/// <summary>
+/// Persisted slice of <see cref="GameContext"/> — learned behavioural data that should
+/// survive a restart. Transient state (current system activity, threat level, ...) is not saved.
+/// </summary>
+public class GameContextSnapshot
+{
+    public double PlayerAggressiveness { get; set; }
+    public double PlayerCautiousness { get; set; }
+    public int SystemsVisited { get; set; }
+    public int BodiesScanned { get; set; }
+    public double LastHullIntegrity { get; set; } = 1.0;
+    public string? LastKnownSystem { get; set; }
+    public Dictionary<string, int> RecentEventFrequency { get; set; } = new();
+    public Dictionary<string, TimeSpan> StateTimeSpent { get; set; } = new();
+    public DateTime SavedAt { get; set; }
+}

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -154,15 +154,14 @@ public class AudioEngineService : IDisposable
                     _activeGenerators.Count, _mixer?.MixerInputs?.Count() ?? 0);
             }
 
-            // Create appropriate sample provider based on pattern type
-            ISampleProvider sampleProvider = pattern.Pattern switch
-            {
-                PatternType.MultiLayer => CreateMultiLayerPattern(pattern),
-                PatternType.Sequence => CreateMultiLayerPattern(pattern), // Sequence uses same timing logic as MultiLayer
-                _ => CreateStandardPattern(pattern, intensity, frequency)
-            };
+            // Create appropriate sample provider based on pattern type.
+            // The factory applies the app-level hardware safety limiter as the final stage for
+            // every pattern type, so nothing reaches the mixer above Audio.MaxIntensity.
+            ISampleProvider sampleProvider = HapticSampleFactory.Create(
+                pattern, intensity, frequency, _settings.Audio.SampleRate, _settings.Audio.MaxIntensity);
 
-            _logger.LogDebug("Created sample provider type: {SampleProviderType}", sampleProvider.GetType().Name);
+            _logger.LogDebug("Created sample provider type: {SampleProviderType}, limited to {MaxIntensity}% max intensity",
+                sampleProvider.GetType().Name, _settings.Audio.MaxIntensity);
 
             lock (_lock)
             {
@@ -231,129 +230,6 @@ public class AudioEngineService : IDisposable
         return Math.Min(scaledIntensity, _settings.Audio.MaxIntensity);
     }
 
-    private SignalGenerator CreateSignalGenerator(HapticPattern pattern, int intensity, int frequency)
-    {
-        var gain = intensity / 100.0;
-        // Temporarily boost gain to debug audio issues
-        var boostedGain = Math.Min(gain * 2.0, 1.0); // Double the gain but cap at 1.0
-        
-        var generator = new SignalGenerator(_settings.Audio.SampleRate, 1)
-        {
-            Gain = boostedGain,
-            Frequency = frequency,
-            Type = SignalGeneratorType.Sin // Smooth sine wave for buttkicker
-        };
-
-        _logger.LogDebug("Created signal generator - Intensity: {Intensity}%, Gain: {Gain}, Frequency: {Frequency}Hz, SampleRate: {SampleRate}", 
-            intensity, gain, frequency, _settings.Audio.SampleRate);
-
-        return generator;
-    }
-
-    private ISampleProvider ApplyEnvelope(SignalGenerator generator, HapticPattern pattern)
-    {
-        ISampleProvider sampleProvider = generator;
-
-        // Apply pattern-specific modifications
-        switch (pattern.Pattern)
-        {
-            case PatternType.SharpPulse:
-                sampleProvider = ApplySharpPulse(generator, pattern);
-                break;
-                
-            case PatternType.BuildupRumble:
-                sampleProvider = ApplyBuildupRumble(generator, pattern);
-                break;
-                
-            case PatternType.SustainedRumble:
-                sampleProvider = ApplySustainedRumble(generator, pattern);
-                break;
-                
-            case PatternType.Oscillating:
-                sampleProvider = ApplyOscillating(generator, pattern);
-                break;
-                
-            case PatternType.Impact:
-                sampleProvider = ApplyImpact(generator, pattern);
-                break;
-                
-            case PatternType.Fade:
-                sampleProvider = ApplyFade(generator, pattern);
-                break;
-        }
-
-        // Apply overall fade in/out envelope
-        if (pattern.FadeIn > 0 || pattern.FadeOut > 0)
-        {
-            // For now, just use the base sample provider - fade will be implemented later
-            // sampleProvider = ApplyFadeEnvelope(sampleProvider, pattern);
-        }
-
-        // Limit duration
-        var durationSamples = (int)(_settings.Audio.SampleRate * (pattern.Duration / 1000.0));
-        sampleProvider = sampleProvider.Take(TimeSpan.FromMilliseconds(pattern.Duration));
-
-        return sampleProvider;
-    }
-
-    private ISampleProvider ApplySharpPulse(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Quick attack, quick decay for sharp impacts
-        // For now, just return the generator - envelope shaping will be implemented later
-        return generator;
-    }
-
-    private ISampleProvider ApplyBuildupRumble(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Gradual buildup over the first 60% of duration, then sustain
-        // For now, just return the generator - envelope shaping will be implemented later
-        return generator;
-    }
-
-    private ISampleProvider ApplySustainedRumble(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Just apply basic fade envelope, maintain consistent output
-        return generator;
-    }
-
-    private ISampleProvider ApplyOscillating(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Create oscillating amplitude effect with different rates for different events
-        var oscFreq = pattern.Name switch
-        {
-            "Overheating Warning" => 3.0, // Fast oscillation for heat warnings
-            "Heat Damage" => 5.0, // Very fast for heat damage
-            "Being Interdicted" => 2.5, // Medium for interdiction
-            "Neutron Boost" => 1.5, // Slow deep rumble for neutron stars
-            _ => 2.0 // Default oscillation rate
-        };
-        
-        var modulationDepth = pattern.Name switch
-        {
-            "Heat Damage" => 0.8f, // Deep modulation for damage
-            "Overheating Warning" => 0.6f, // Moderate for warnings
-            "Being Interdicted" => 0.7f, // Strong for interdiction stress
-            "Neutron Boost" => 0.4f, // Gentle for neutron boost
-            _ => 0.5f // Default depth
-        };
-        
-        return new AmplitudeModulationSampleProvider(generator, oscFreq, modulationDepth);
-    }
-
-    private ISampleProvider ApplyImpact(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Sharp attack, longer decay
-        // For now, just return the generator - envelope shaping will be implemented later
-        return generator;
-    }
-
-    private ISampleProvider ApplyFade(SignalGenerator generator, HapticPattern pattern)
-    {
-        // Gentle fade in and out
-        // For now, just return the generator - envelope shaping will be implemented later
-        return generator;
-    }
-
     private void CleanupEffect(string effectId)
     {
         lock (_lock)
@@ -398,34 +274,6 @@ public class AudioEngineService : IDisposable
             // Clear mixer
             _mixer?.RemoveAllMixerInputs();
         }
-    }
-
-    private ISampleProvider CreateMultiLayerPattern(HapticPattern pattern)
-    {
-        return new MultiLayerPatternGenerator(pattern, _settings.Audio.SampleRate, 1);
-    }
-
-    private ISampleProvider CreateStandardPattern(HapticPattern pattern, int intensity, int frequency)
-    {
-        // Create base generator
-        var generator = CreateSignalGenerator(pattern, intensity, frequency);
-        
-        // Apply envelope based on pattern type
-        var sampleProvider = ApplyEnvelope(generator, pattern);
-        
-        // Apply intensity curve if specified
-        if (pattern.IntensityCurve != IntensityCurve.Linear)
-        {
-            sampleProvider = new CurveEnvelopeSampleProvider(
-                sampleProvider, 
-                pattern.IntensityCurve, 
-                pattern.Duration, 
-                intensity / 100.0f, 
-                pattern.CustomCurvePoints
-            );
-        }
-        
-        return sampleProvider;
     }
 
     public void Reinitialize()

--- a/src/EDButtkicker/Services/HapticSampleFactory.cs
+++ b/src/EDButtkicker/Services/HapticSampleFactory.cs
@@ -1,0 +1,172 @@
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Builds the sample provider for a haptic pattern. Kept free of any audio device dependency so
+/// the generation path can be exercised without opening WASAPI/WaveOut.
+/// </summary>
+public static class HapticSampleFactory
+{
+    /// <summary>
+    /// Creates the fully assembled provider for a pattern and applies the app-level hardware
+    /// safety limiter as the final stage for every pattern type.
+    /// </summary>
+    public static ISampleProvider Create(HapticPattern pattern, int intensity, int frequency, int sampleRate, int appMaxIntensity)
+    {
+        ISampleProvider sampleProvider = pattern.Pattern switch
+        {
+            PatternType.MultiLayer => CreateMultiLayerPattern(pattern, sampleRate),
+            PatternType.Sequence => CreateMultiLayerPattern(pattern, sampleRate), // Sequence uses same timing logic as MultiLayer
+            _ => CreateStandardPattern(pattern, intensity, frequency, sampleRate)
+        };
+
+        // Final app-level bound, after all mixing and envelopes.
+        return AudioSafety.Limit(sampleProvider, appMaxIntensity);
+    }
+
+    public static ISampleProvider CreateMultiLayerPattern(HapticPattern pattern, int sampleRate)
+    {
+        return new MultiLayerPatternGenerator(pattern, sampleRate, 1);
+    }
+
+    public static ISampleProvider CreateStandardPattern(HapticPattern pattern, int intensity, int frequency, int sampleRate)
+    {
+        // Create base generator
+        var generator = CreateSignalGenerator(intensity, frequency, sampleRate);
+
+        // Apply envelope based on pattern type
+        var sampleProvider = ApplyEnvelope(generator, pattern, sampleRate);
+
+        // Apply intensity curve if specified
+        if (pattern.IntensityCurve != IntensityCurve.Linear)
+        {
+            sampleProvider = new CurveEnvelopeSampleProvider(
+                sampleProvider,
+                pattern.IntensityCurve,
+                pattern.Duration,
+                intensity / 100.0f,
+                pattern.CustomCurvePoints
+            );
+        }
+
+        return sampleProvider;
+    }
+
+    public static SignalGenerator CreateSignalGenerator(int intensity, int frequency, int sampleRate)
+    {
+        var gain = Math.Clamp(intensity / 100.0, 0.0, 1.0);
+
+        return new SignalGenerator(sampleRate, 1)
+        {
+            Gain = gain,
+            Frequency = frequency,
+            Type = SignalGeneratorType.Sin // Smooth sine wave for buttkicker
+        };
+    }
+
+    private static ISampleProvider ApplyEnvelope(SignalGenerator generator, HapticPattern pattern, int sampleRate)
+    {
+        ISampleProvider sampleProvider = generator;
+
+        // Apply pattern-specific modifications
+        switch (pattern.Pattern)
+        {
+            case PatternType.SharpPulse:
+                sampleProvider = ApplySharpPulse(generator, pattern);
+                break;
+
+            case PatternType.BuildupRumble:
+                sampleProvider = ApplyBuildupRumble(generator, pattern);
+                break;
+
+            case PatternType.SustainedRumble:
+                sampleProvider = ApplySustainedRumble(generator, pattern);
+                break;
+
+            case PatternType.Oscillating:
+                sampleProvider = ApplyOscillating(generator, pattern);
+                break;
+
+            case PatternType.Impact:
+                sampleProvider = ApplyImpact(generator, pattern);
+                break;
+
+            case PatternType.Fade:
+                sampleProvider = ApplyFade(generator, pattern);
+                break;
+        }
+
+        // Apply overall fade in/out envelope
+        if (pattern.FadeIn > 0 || pattern.FadeOut > 0)
+        {
+            // For now, just use the base sample provider - fade will be implemented later
+            // sampleProvider = ApplyFadeEnvelope(sampleProvider, pattern);
+        }
+
+        // Limit duration
+        sampleProvider = sampleProvider.Take(TimeSpan.FromMilliseconds(pattern.Duration));
+
+        return sampleProvider;
+    }
+
+    private static ISampleProvider ApplySharpPulse(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Quick attack, quick decay for sharp impacts
+        // For now, just return the generator - envelope shaping will be implemented later
+        return generator;
+    }
+
+    private static ISampleProvider ApplyBuildupRumble(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Gradual buildup over the first 60% of duration, then sustain
+        // For now, just return the generator - envelope shaping will be implemented later
+        return generator;
+    }
+
+    private static ISampleProvider ApplySustainedRumble(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Just apply basic fade envelope, maintain consistent output
+        return generator;
+    }
+
+    private static ISampleProvider ApplyOscillating(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Create oscillating amplitude effect with different rates for different events
+        var oscFreq = pattern.Name switch
+        {
+            "Overheating Warning" => 3.0, // Fast oscillation for heat warnings
+            "Heat Damage" => 5.0, // Very fast for heat damage
+            "Being Interdicted" => 2.5, // Medium for interdiction
+            "Neutron Boost" => 1.5, // Slow deep rumble for neutron stars
+            _ => 2.0 // Default oscillation rate
+        };
+
+        var modulationDepth = pattern.Name switch
+        {
+            "Heat Damage" => 0.8f, // Deep modulation for damage
+            "Overheating Warning" => 0.6f, // Moderate for warnings
+            "Being Interdicted" => 0.7f, // Strong for interdiction stress
+            "Neutron Boost" => 0.4f, // Gentle for neutron boost
+            _ => 0.5f // Default depth
+        };
+
+        return new AmplitudeModulationSampleProvider(generator, oscFreq, modulationDepth);
+    }
+
+    private static ISampleProvider ApplyImpact(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Sharp attack, longer decay
+        // For now, just return the generator - envelope shaping will be implemented later
+        return generator;
+    }
+
+    private static ISampleProvider ApplyFade(SignalGenerator generator, HapticPattern pattern)
+    {
+        // Gentle fade in and out
+        // For now, just return the generator - envelope shaping will be implemented later
+        return generator;
+    }
+}

--- a/src/EDButtkicker/Services/HardwareSafetyLimiter.cs
+++ b/src/EDButtkicker/Services/HardwareSafetyLimiter.cs
@@ -1,0 +1,69 @@
+using NAudio.Wave;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Final, app-wide output bound. Wraps any sample provider and clamps every sample to
+/// ±(MaxIntensity / 100) so no pattern type can drive the transducer past the configured
+/// Audio.MaxIntensity, regardless of how loud the upstream mix got.
+/// </summary>
+public class HardwareSafetyLimiter : ISampleProvider
+{
+    private readonly ISampleProvider _source;
+    private readonly float _ceiling;
+
+    /// <summary>Configured app maximum intensity (0-100) enforced by this limiter.</summary>
+    public int MaxIntensity { get; }
+
+    public WaveFormat WaveFormat => _source.WaveFormat;
+
+    public HardwareSafetyLimiter(ISampleProvider source, int maxIntensity)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        MaxIntensity = Math.Clamp(maxIntensity, 0, 100);
+        _ceiling = MaxIntensity / 100f;
+    }
+
+    public int Read(float[] buffer, int offset, int count)
+    {
+        var samplesRead = _source.Read(buffer, offset, count);
+        if (samplesRead <= 0) return samplesRead;
+
+        // A zero ceiling means silence - never let rounding leave a residual signal.
+        if (_ceiling <= 0f)
+        {
+            Array.Clear(buffer, offset, samplesRead);
+            return samplesRead;
+        }
+
+        for (int i = 0; i < samplesRead; i++)
+        {
+            var sample = buffer[offset + i];
+
+            // NaN/Infinity from an upstream envelope must not reach the hardware.
+            if (float.IsNaN(sample))
+            {
+                buffer[offset + i] = 0f;
+                continue;
+            }
+
+            if (sample > _ceiling) buffer[offset + i] = _ceiling;
+            else if (sample < -_ceiling) buffer[offset + i] = -_ceiling;
+        }
+
+        return samplesRead;
+    }
+}
+
+/// <summary>
+/// Single entry point for applying the app-level hardware safety cap.
+/// </summary>
+public static class AudioSafety
+{
+    /// <summary>
+    /// Bounds <paramref name="source"/> to the configured app maximum intensity (0-100).
+    /// This is the last stage applied to every pattern, after all mixing and envelopes.
+    /// </summary>
+    public static ISampleProvider Limit(ISampleProvider source, int maxIntensity)
+        => new HardwareSafetyLimiter(source, maxIntensity);
+}

--- a/src/EDButtkicker/Services/UserSettingsService.cs
+++ b/src/EDButtkicker/Services/UserSettingsService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using EDButtkicker.Configuration;
+using EDButtkicker.Models;
 
 namespace EDButtkicker.Services;
 
@@ -8,6 +9,7 @@ public class UserSettingsService
 {
     private readonly ILogger<UserSettingsService> _logger;
     private readonly string _userSettingsPath;
+    private readonly string _gameContextPath;
     private readonly JsonSerializerOptions _jsonOptions;
 
     public UserSettingsService(ILogger<UserSettingsService> logger)
@@ -20,6 +22,7 @@ public class UserSettingsService
         Directory.CreateDirectory(settingsDir);
         
         _userSettingsPath = Path.Combine(settingsDir, "user-settings.json");
+        _gameContextPath = Path.Combine(settingsDir, "game-context.json");
         
         _jsonOptions = new JsonSerializerOptions
         {
@@ -190,7 +193,52 @@ public class UserSettingsService
     public string GetUserSettingsPath() => _userSettingsPath;
 
     public bool UserSettingsExist() => File.Exists(_userSettingsPath);
+
+    public async Task<GameContextSnapshot?> LoadGameContextAsync()
+    {
+        try
+        {
+            if (!File.Exists(_gameContextPath))
+            {
+                _logger.LogDebug("No saved game context found at {GameContextPath}", _gameContextPath);
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(_gameContextPath);
+            var snapshot = JsonSerializer.Deserialize<GameContextSnapshot>(json, _jsonOptions);
+
+            if (snapshot == null)
+            {
+                _logger.LogWarning("Failed to deserialize game context, starting fresh");
+                return null;
+            }
+
+            _logger.LogDebug("Loaded game context saved at {SavedAt}", snapshot.SavedAt);
+            return snapshot;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading game context, starting fresh");
+            return null;
+        }
+    }
+
+    public async Task SaveGameContextAsync(GameContextSnapshot snapshot)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(snapshot, _jsonOptions);
+            await File.WriteAllTextAsync(_gameContextPath, json);
+
+            _logger.LogDebug("Saved game context to {GameContextPath}", _gameContextPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving game context");
+        }
+    }
 }
+
 
 public class UserPreferences
 {

--- a/tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj
+++ b/tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EDButtkicker\EDButtkicker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EDButtkicker.Tests/HardwareSafetyLimiterTests.cs
+++ b/tests/EDButtkicker.Tests/HardwareSafetyLimiterTests.cs
@@ -1,0 +1,206 @@
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using NAudio.Wave;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Verifies that the app-level hardware safety cap bounds every pattern type after mixing.
+/// Everything here runs on plain sample providers - no WASAPI, no WaveOut, no real device.
+/// </summary>
+public class HardwareSafetyLimiterTests
+{
+    private const int SampleRate = 44100;
+    private const int DurationMs = 200;
+    private const float Tolerance = 1e-5f;
+
+    public static TheoryData<int> MaxIntensities => new() { 0, 25, 80, 100 };
+
+    [Theory]
+    [MemberData(nameof(MaxIntensities))]
+    public void Limiter_BoundsConstantAmplitudeSource(int maxIntensity)
+    {
+        // A source pinned to +/-1.0 - louder than every cap under test except 100.
+        var source = new ConstantAmplitudeSampleProvider(SampleRate, TotalSamples());
+        var limited = AudioSafety.Limit(source, maxIntensity);
+
+        AssertBoundedByCap(ReadAll(limited), maxIntensity);
+    }
+
+    [Theory]
+    [MemberData(nameof(MaxIntensities))]
+    public void Create_BoundsStandardPattern(int maxIntensity)
+    {
+        var pattern = new HapticPattern
+        {
+            Name = "Test Sustained",
+            Pattern = PatternType.SustainedRumble,
+            Frequency = 40,
+            Duration = DurationMs,
+            Intensity = 100
+        };
+
+        var provider = HapticSampleFactory.Create(pattern, 100, 40, SampleRate, maxIntensity);
+
+        AssertBoundedByCap(ReadAll(provider), maxIntensity);
+    }
+
+    [Theory]
+    [MemberData(nameof(MaxIntensities))]
+    public void Create_BoundsOscillatingPattern(int maxIntensity)
+    {
+        var pattern = new HapticPattern
+        {
+            Name = "Overheating Warning",
+            Pattern = PatternType.Oscillating,
+            Frequency = 40,
+            Duration = DurationMs,
+            Intensity = 100
+        };
+
+        var provider = HapticSampleFactory.Create(pattern, 100, 40, SampleRate, maxIntensity);
+
+        AssertBoundedByCap(ReadAll(provider), maxIntensity);
+    }
+
+    [Theory]
+    [MemberData(nameof(MaxIntensities))]
+    public void Create_BoundsSequencePattern(int maxIntensity)
+    {
+        var provider = HapticSampleFactory.Create(BuildSequencePattern(), 100, 40, SampleRate, maxIntensity);
+
+        AssertBoundedByCap(ReadAll(provider), maxIntensity);
+    }
+
+    [Theory]
+    [MemberData(nameof(MaxIntensities))]
+    public void Create_BoundsMultiLayerPattern(int maxIntensity)
+    {
+        var provider = HapticSampleFactory.Create(BuildMultiLayerPattern(), 100, 40, SampleRate, maxIntensity);
+
+        AssertBoundedByCap(ReadAll(provider), maxIntensity);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(25)]
+    [InlineData(80)]
+    public void MultiLayerMixWouldExceedCapWithoutTheLimiter(int maxIntensity)
+    {
+        // Two in-phase layers at amplitude 1.0 mix well past the cap; only the limiter pulls it back.
+        var unlimited = HapticSampleFactory.CreateMultiLayerPattern(BuildMultiLayerPattern(), SampleRate);
+
+        var peak = ReadAll(unlimited).Max(Math.Abs);
+
+        Assert.True(peak > maxIntensity / 100f + Tolerance,
+            $"Expected the unlimited mix to exceed the {maxIntensity}% cap, but its peak was {peak}.");
+    }
+
+    /// <summary>Two overlapping full-amplitude layers, so the mixed peak exceeds the cap on its own.</summary>
+    private static HapticPattern BuildMultiLayerPattern() => new()
+    {
+        Name = "Test MultiLayer",
+        Pattern = PatternType.MultiLayer,
+        Frequency = 40,
+        Duration = DurationMs,
+        Intensity = 100,
+        Layers =
+        {
+            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 40, Amplitude = 1.0f },
+            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 40, Amplitude = 1.0f }
+        }
+    };
+
+    /// <summary>Staggered layer start times, with an overlapping window in the middle.</summary>
+    private static HapticPattern BuildSequencePattern() => new()
+    {
+        Name = "Test Sequence",
+        Pattern = PatternType.Sequence,
+        Frequency = 40,
+        Duration = DurationMs,
+        Intensity = 100,
+        Layers =
+        {
+            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 40, Amplitude = 1.0f, StartTime = 0, Duration = 120 },
+            new PatternLayer { Waveform = WaveformType.Sine, Frequency = 40, Amplitude = 1.0f, StartTime = 80, Duration = 120 }
+        }
+    };
+
+    private static void AssertBoundedByCap(IReadOnlyList<float> samples, int maxIntensity)
+    {
+        Assert.NotEmpty(samples);
+
+        var cap = maxIntensity / 100f + Tolerance;
+
+        for (int i = 0; i < samples.Count; i++)
+        {
+            var sample = samples[i];
+
+            Assert.False(float.IsNaN(sample) || float.IsInfinity(sample),
+                $"Sample {i} was not a finite value ({sample}).");
+
+            if (maxIntensity == 0)
+            {
+                Assert.Equal(0f, sample);
+                continue;
+            }
+
+            Assert.True(Math.Abs(sample) <= cap,
+                $"Sample {i} was {sample}, above the {maxIntensity}% cap.");
+        }
+    }
+
+    private static int TotalSamples() => (int)(DurationMs / 1000.0 * SampleRate);
+
+    private static List<float> ReadAll(ISampleProvider provider)
+    {
+        var samples = new List<float>();
+        var buffer = new float[1024];
+
+        // Bounded so a misbehaving provider fails the test instead of hanging it.
+        var limit = TotalSamples() * 4;
+
+        while (samples.Count < limit)
+        {
+            var read = provider.Read(buffer, 0, buffer.Length);
+            if (read <= 0) break;
+
+            for (int i = 0; i < read; i++)
+            {
+                samples.Add(buffer[i]);
+            }
+        }
+
+        return samples;
+    }
+
+    /// <summary>Full-scale square source: the loudest thing the limiter can be handed.</summary>
+    private sealed class ConstantAmplitudeSampleProvider : ISampleProvider
+    {
+        private readonly int _totalSamples;
+        private int _position;
+
+        public WaveFormat WaveFormat { get; }
+
+        public ConstantAmplitudeSampleProvider(int sampleRate, int totalSamples)
+        {
+            _totalSamples = totalSamples;
+            WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
+        }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var toRead = Math.Min(count, _totalSamples - _position);
+            if (toRead <= 0) return 0;
+
+            for (int i = 0; i < toRead; i++)
+            {
+                buffer[offset + i] = (_position + i) % 2 == 0 ? 1.0f : -1.0f;
+            }
+
+            _position += toRead;
+            return toRead;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a final app-level `HardwareSafetyLimiter` after mixing/envelopes for every pattern type (standard, oscillating, sequence, multi-layer).
- Removes the debug 2x gain boost in signal generation so configured `Audio.MaxIntensity` is actually the hardware ceiling.
- Adds hardware-independent sample tests at max intensity 0, 25, 80, and 100. No WASAPI/WaveOut; Linux tests do not claim ButtKicker validation.
- Restores `GameContextSnapshot` persistence APIs that PR #4 called but did not land, so the solution compiles on main.

Closes #42

## Test Plan
- [x] `dotnet test EDButtkicker.sln --configuration Release` — 23 passed locally (Linux, .NET 8)
- [ ] GitHub Actions CI green (unit tests + Windows publish)
- [ ] Do not treat Linux CI as hardware validation
