### PR TITLE
fix: serialize journal watcher and retain partial lines

### DIFF
--- a/src/EDButtkicker/Services/JournalMonitorService.cs
+++ b/src/EDButtkicker/Services/JournalMonitorService.cs
@@ -8,13 +8,15 @@ namespace EDButtkicker.Services;
 
 public class JournalMonitorService : BackgroundService
 {
+    private static readonly TimeSpan RotationCheckInterval = TimeSpan.FromSeconds(1);
+
     private readonly ILogger<JournalMonitorService> _logger;
     private readonly AppSettings _settings;
     private readonly EventMappingService _eventMappingService;
     private readonly ShipTrackingService _shipTrackingService;
     private FileSystemWatcher? _fileWatcher;
-    private string? _currentJournalFile;
-    private long _lastPosition = 0;
+    private JournalSignalPump? _pump;
+    private JournalTailReader? _reader;
 
     public event Action<JournalEvent>? JournalEventReceived;
 
@@ -34,179 +36,100 @@ public class JournalMonitorService : BackgroundService
     {
         _logger.LogInformation("Starting Journal Monitor Service");
 
-        if (!Directory.Exists(_settings.EliteDangerous.JournalPath))
+        var journalPath = _settings.EliteDangerous.JournalPath;
+        if (!Directory.Exists(journalPath))
         {
-            _logger.LogError("Journal path does not exist: {Path}", _settings.EliteDangerous.JournalPath);
+            _logger.LogError("Journal path does not exist: {Path}", journalPath);
             return;
         }
 
-        // Find and monitor the latest journal file
-        await StartMonitoring(stoppingToken);
+        await StartMonitoring(journalPath, stoppingToken);
     }
 
-    private async Task StartMonitoring(CancellationToken stoppingToken)
+    private async Task StartMonitoring(string journalPath, CancellationToken stoppingToken)
     {
+        _reader = new JournalTailReader(journalPath, _settings.EliteDangerous.MonitorLatestOnly, _logger);
+        _pump = new JournalSignalPump(DrainJournalAsync, _logger);
+
+        if (_reader.FindLatestJournalFile() == null)
+        {
+            _logger.LogWarning("No journal files found in {Path}; waiting for one to appear", journalPath);
+        }
+
+        // Watcher signals and the periodic rotation check both feed the same single-reader queue,
+        // so overlapping Changed callbacks can never run two reads (or two cursor updates) at once.
+        SetupFileWatcher(journalPath);
+
+        var pumpTask = _pump.RunAsync(stoppingToken);
+
         try
         {
-            // Find the latest journal file
-            var latestJournal = FindLatestJournalFile();
-            if (latestJournal == null)
-            {
-                _logger.LogWarning("No journal files found in {Path}", _settings.EliteDangerous.JournalPath);
-                await Task.Delay(5000, stoppingToken);
-                return;
-            }
+            // Kick off an initial pass so we attach to the current journal immediately.
+            _pump.Signal();
 
-            _currentJournalFile = latestJournal;
-            _logger.LogInformation("Monitoring journal file: {File}", Path.GetFileName(_currentJournalFile));
-
-            // Read existing entries if monitoring latest only
-            if (_settings.EliteDangerous.MonitorLatestOnly)
-            {
-                _lastPosition = new FileInfo(_currentJournalFile).Length;
-                _logger.LogInformation("Starting from end of file (position {Position})", _lastPosition);
-            }
-            else
-            {
-                // Process entire file
-                await ProcessExistingEntries(_currentJournalFile, stoppingToken);
-            }
-
-            // Set up file watcher
-            SetupFileWatcher();
-
-            // Keep service running
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(1000, stoppingToken);
-                
-                // Check for new journal files periodically
-                var newLatestJournal = FindLatestJournalFile();
-                if (newLatestJournal != _currentJournalFile)
-                {
-                    _logger.LogInformation("New journal file detected: {File}", Path.GetFileName(newLatestJournal));
-                    _currentJournalFile = newLatestJournal;
-                    _lastPosition = 0;
-                    SetupFileWatcher();
-                }
+                await Task.Delay(RotationCheckInterval, stoppingToken);
+                _pump.Signal();
             }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error in journal monitoring");
             throw;
         }
-    }
-
-    private string? FindLatestJournalFile()
-    {
-        try
+        finally
         {
-            var journalFiles = Directory.GetFiles(_settings.EliteDangerous.JournalPath, "Journal.*.log")
-                                      .OrderByDescending(f => new FileInfo(f).CreationTime)
-                                      .ToList();
-
-            return journalFiles.FirstOrDefault();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error finding journal files");
-            return null;
+            _fileWatcher?.Dispose();
+            _fileWatcher = null;
+            _pump.Dispose();
+            await pumpTask.ConfigureAwait(false);
         }
     }
 
-    private void SetupFileWatcher()
+    private void SetupFileWatcher(string journalPath)
     {
         _fileWatcher?.Dispose();
 
-        if (_currentJournalFile == null) return;
-
-        var directory = Path.GetDirectoryName(_currentJournalFile)!;
-        var fileName = Path.GetFileName(_currentJournalFile);
-
-        _fileWatcher = new FileSystemWatcher(directory, fileName)
+        // Watching the directory (rather than one file) means rotation needs no watcher rebuild.
+        _fileWatcher = new FileSystemWatcher(journalPath, JournalTailReader.JournalSearchPattern)
         {
-            NotifyFilter = NotifyFilters.Size | NotifyFilters.LastWrite,
+            NotifyFilter = NotifyFilters.Size | NotifyFilters.LastWrite | NotifyFilters.FileName,
             EnableRaisingEvents = true
         };
 
-        _fileWatcher.Changed += async (sender, e) =>
-        {
-            try
-            {
-                await ProcessNewEntries(e.FullPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error processing file changes");
-            }
-        };
+        _fileWatcher.Changed += (_, _) => _pump?.Signal();
+        _fileWatcher.Created += (_, _) => _pump?.Signal();
+        _fileWatcher.Renamed += (_, _) => _pump?.Signal();
+        _fileWatcher.Error += (_, e) => _logger.LogWarning(e.GetException(), "Journal file watcher error");
 
-        _logger.LogDebug("File watcher setup for: {File}", fileName);
+        _logger.LogDebug("File watcher setup for: {Path}", journalPath);
     }
 
-    private async Task ProcessExistingEntries(string filePath, CancellationToken stoppingToken)
+    private async Task DrainJournalAsync(CancellationToken cancellationToken)
     {
-        try
+        if (_reader == null)
+            return;
+
+        var lines = await _reader.ReadNewLinesAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var line in lines)
         {
-            using var reader = new StreamReader(filePath);
-            string? line;
-            int lineCount = 0;
-
-            while ((line = await reader.ReadLineAsync()) != null && !stoppingToken.IsCancellationRequested)
-            {
-                lineCount++;
-                await ProcessJournalLine(line, lineCount);
-            }
-
-            _lastPosition = reader.BaseStream.Position;
-            _logger.LogInformation("Processed {Count} existing journal entries", lineCount);
+            cancellationToken.ThrowIfCancellationRequested();
+            await ProcessJournalLine(line);
         }
-        catch (Exception ex)
+
+        if (lines.Count > 0)
         {
-            _logger.LogError(ex, "Error processing existing entries");
+            _logger.LogDebug("Processed {Count} new journal entries", lines.Count);
         }
     }
 
-    private async Task ProcessNewEntries(string filePath)
-    {
-        try
-        {
-            using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            
-            if (fileStream.Length <= _lastPosition)
-                return;
-
-            fileStream.Seek(_lastPosition, SeekOrigin.Begin);
-            using var reader = new StreamReader(fileStream);
-
-            string? line;
-            int newLines = 0;
-            while ((line = await reader.ReadLineAsync()) != null)
-            {
-                newLines++;
-                await ProcessJournalLine(line, -1); // -1 indicates new entry
-            }
-
-            _lastPosition = fileStream.Position;
-            
-            if (newLines > 0)
-            {
-                _logger.LogDebug("Processed {Count} new journal entries", newLines);
-            }
-        }
-        catch (IOException)
-        {
-            // File might be locked, try again later
-            await Task.Delay(100);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing new entries");
-        }
-    }
-
-    private async Task ProcessJournalLine(string line, int lineNumber)
+    private async Task ProcessJournalLine(string line)
     {
         try
         {
@@ -231,18 +154,19 @@ public class JournalMonitorService : BackgroundService
         }
         catch (JsonException ex)
         {
-            _logger.LogWarning("Failed to parse journal line {LineNumber}: {Error}", lineNumber, ex.Message);
+            _logger.LogWarning("Failed to parse journal line: {Error}", ex.Message);
             _logger.LogDebug("Problematic line: {Line}", line);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing journal line {LineNumber}", lineNumber);
+            _logger.LogError(ex, "Error processing journal line");
         }
     }
 
     public override void Dispose()
     {
         _fileWatcher?.Dispose();
+        _pump?.Dispose();
         base.Dispose();
     }
 }

--- a/src/EDButtkicker/Services/JournalSignalPump.cs
+++ b/src/EDButtkicker/Services/JournalSignalPump.cs
@@ -1,0 +1,75 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Single-reader queue for journal wake-up signals.
+///
+/// FileSystemWatcher raises Changed on thread-pool threads and can fire several times for one
+/// write; periodic rotation checks add more. Every producer just calls <see cref="Signal"/>, and
+/// one consumer loop runs the handler - handlers never overlap, so the read cursor is never raced.
+/// Signals are coalesced (a bounded capacity-1 channel): pending signals collapse into a single
+/// follow-up pass, and a signal raised while the handler is running always triggers another pass.
+/// </summary>
+public sealed class JournalSignalPump : IDisposable
+{
+    private readonly Channel<byte> _signals = Channel.CreateBounded<byte>(
+        new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+    private readonly Func<CancellationToken, Task> _handler;
+    private readonly ILogger _logger;
+
+    public JournalSignalPump(Func<CancellationToken, Task> handler, ILogger? logger = null)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>Queues a wake-up. Never blocks; extra signals coalesce into the pending one.</summary>
+    public void Signal() => _signals.Writer.TryWrite(0);
+
+    /// <summary>Runs the single consumer loop until <paramref name="cancellationToken"/> fires.</summary>
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await _signals.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // Collapse everything queued so far into this single pass.
+                while (_signals.Reader.TryRead(out _))
+                {
+                }
+
+                try
+                {
+                    await _handler(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error handling journal signal");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        finally
+        {
+            _signals.Writer.TryComplete();
+        }
+    }
+
+    public void Dispose() => _signals.Writer.TryComplete();
+}

--- a/src/EDButtkicker/Services/JournalTailReader.cs
+++ b/src/EDButtkicker/Services/JournalTailReader.cs
@@ -1,0 +1,288 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Hardware-independent tail reader for Elite Dangerous journal files.
+///
+/// It owns the read cursor and guarantees that:
+///  - a line is only ever emitted once it is terminated by a newline (a truncated trailing
+///    JSON object stays buffered in the file until the writer finishes it),
+///  - the cursor is only committed through the last complete newline, so partial bytes are
+///    naturally retained and re-read on the next pass,
+///  - overlapping callers (e.g. two FileSystemWatcher.Changed events for the same write) are
+///    serialized, so no line is emitted twice and the cursor never races.
+/// </summary>
+public class JournalTailReader
+{
+    public const string JournalSearchPattern = "Journal.*.log";
+
+    private const int ScanChunkSize = 8192;
+
+    private static readonly UTF8Encoding Utf8 = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly string _directory;
+    private readonly bool _monitorLatestOnly;
+    private readonly ILogger _logger;
+    private readonly int _maxReadAttempts;
+    private readonly TimeSpan _retryDelay;
+
+    private string? _currentFile;
+    private long _cursor;
+
+    public JournalTailReader(
+        string directory,
+        bool monitorLatestOnly,
+        ILogger? logger = null,
+        int maxReadAttempts = 5,
+        TimeSpan? retryDelay = null)
+    {
+        _directory = directory ?? throw new ArgumentNullException(nameof(directory));
+        _monitorLatestOnly = monitorLatestOnly;
+        _logger = logger ?? NullLogger.Instance;
+        _maxReadAttempts = Math.Max(1, maxReadAttempts);
+        _retryDelay = retryDelay ?? TimeSpan.FromMilliseconds(100);
+    }
+
+    /// <summary>Journal file the cursor currently belongs to, or null before the first attach.</summary>
+    public string? CurrentFile => _currentFile;
+
+    /// <summary>Byte offset just past the last committed newline of <see cref="CurrentFile"/>.</summary>
+    public long Cursor => Interlocked.Read(ref _cursor);
+
+    /// <summary>
+    /// Returns every complete line that became available since the last call, following rotation
+    /// to a newer Journal.*.log. Calls are serialized; concurrent callers each receive a disjoint
+    /// slice of the stream in order.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> ReadNewLinesAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var lines = new List<string>();
+
+            var latest = FindLatestJournalFile();
+            if (latest == null)
+                return lines;
+
+            if (_currentFile == null)
+            {
+                _currentFile = latest;
+                // MonitorLatestOnly starts at the last newline rather than at raw EOF so that a
+                // trailing partial line is still completed (and emitted) once the writer finishes it.
+                _cursor = _monitorLatestOnly
+                    ? await FindLastNewlineOffsetAsync(latest, cancellationToken).ConfigureAwait(false)
+                    : 0;
+
+                _logger.LogInformation("Tailing journal {File} from offset {Offset}",
+                    Path.GetFileName(latest), _cursor);
+            }
+            else if (!string.Equals(latest, _currentFile, StringComparison.Ordinal))
+            {
+                // Drain whatever complete lines are still sitting in the old file before switching,
+                // so rotation never drops events. A new journal is a new logical stream, so any
+                // partial bytes left in the old file are abandoned and the new file starts at 0.
+                await ReadCompleteLinesAsync(_currentFile, lines, cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation("Journal rotated: {Old} -> {New}",
+                    Path.GetFileName(_currentFile), Path.GetFileName(latest));
+
+                _currentFile = latest;
+                _cursor = 0;
+            }
+
+            await ReadCompleteLinesAsync(_currentFile, lines, cancellationToken).ConfigureAwait(false);
+            return lines;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Opens a journal file for shared reading. Overridable so tests can inject IO faults.</summary>
+    protected virtual FileStream OpenRead(string path) =>
+        new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, ScanChunkSize, useAsync: true);
+
+    public string? FindLatestJournalFile()
+    {
+        try
+        {
+            if (!Directory.Exists(_directory))
+                return null;
+
+            // Elite journal names embed their timestamp (Journal.2026-08-27T114250.01.log), so an
+            // ordinal name sort is both newest-first and deterministic - unlike creation timestamps,
+            // which are unreliable on some filesystems and shift when a file is appended to.
+            return Directory.GetFiles(_directory, JournalSearchPattern)
+                .OrderByDescending(Path.GetFileName, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error finding journal files in {Path}", _directory);
+            return null;
+        }
+    }
+
+    private async Task ReadCompleteLinesAsync(string path, List<string> lines, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= _maxReadAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                using var stream = OpenRead(path);
+
+                var length = stream.Length;
+                var cursor = Interlocked.Read(ref _cursor);
+
+                if (length < cursor)
+                {
+                    // The file shrank below what we already committed: the writer restarted it
+                    // (or it was rewritten). Rewind to the start and re-read the current content.
+                    _logger.LogWarning("Journal {File} truncated ({Length} < {Cursor}); restarting from offset 0",
+                        Path.GetFileName(path), length, cursor);
+                    cursor = 0;
+                    Interlocked.Exchange(ref _cursor, 0);
+                }
+
+                if (length == cursor)
+                    return;
+
+                stream.Seek(cursor, SeekOrigin.Begin);
+
+                var pending = (int)Math.Min(length - cursor, int.MaxValue);
+                var buffer = new byte[pending];
+                var read = 0;
+                while (read < pending)
+                {
+                    var n = await stream.ReadAsync(buffer.AsMemory(read, pending - read), cancellationToken)
+                        .ConfigureAwait(false);
+                    if (n == 0)
+                        break;
+                    read += n;
+                }
+
+                var lastNewline = Array.LastIndexOf(buffer, (byte)'\n', Math.Max(read - 1, 0), read);
+                if (lastNewline < 0)
+                    return; // Nothing complete yet - leave the cursor where it is and retain the partial bytes.
+
+                var committed = lastNewline + 1;
+                AppendLines(buffer, committed, cursor == 0, lines);
+                Interlocked.Exchange(ref _cursor, cursor + committed);
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (FileNotFoundException)
+            {
+                return; // Rotated away underneath us; the next pass picks up the new file.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+            catch (IOException ex)
+            {
+                if (attempt >= _maxReadAttempts)
+                {
+                    // Stay alive: the next signal retries from the same cursor, so nothing is lost.
+                    _logger.LogWarning(ex, "Giving up reading {File} after {Attempts} attempts; will retry on next signal",
+                        Path.GetFileName(path), attempt);
+                    return;
+                }
+
+                _logger.LogDebug("Journal {File} is locked (attempt {Attempt}); retrying", Path.GetFileName(path), attempt);
+                await Task.Delay(_retryDelay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogWarning(ex, "Access denied reading journal {File}", Path.GetFileName(path));
+                return;
+            }
+        }
+    }
+
+    private static void AppendLines(byte[] buffer, int count, bool atFileStart, List<string> lines)
+    {
+        var offset = 0;
+        if (atFileStart && count >= 3 && buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+            offset = 3;
+
+        // The range always ends on a newline, so it can never split a multi-byte UTF-8 sequence.
+        var text = Utf8.GetString(buffer, offset, count - offset);
+
+        foreach (var line in text.Split('\n'))
+        {
+            var trimmed = line.TrimEnd('\r');
+            if (!string.IsNullOrWhiteSpace(trimmed))
+                lines.Add(trimmed);
+        }
+    }
+
+    /// <summary>Offset just past the file's last newline, i.e. where a trailing partial line begins.</summary>
+    private async Task<long> FindLastNewlineOffsetAsync(string path, CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= _maxReadAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                using var stream = OpenRead(path);
+
+                var length = stream.Length;
+                var buffer = new byte[ScanChunkSize];
+                var end = length;
+
+                while (end > 0)
+                {
+                    var start = Math.Max(0, end - ScanChunkSize);
+                    var size = (int)(end - start);
+
+                    stream.Seek(start, SeekOrigin.Begin);
+                    var read = 0;
+                    while (read < size)
+                    {
+                        var n = await stream.ReadAsync(buffer.AsMemory(read, size - read), cancellationToken)
+                            .ConfigureAwait(false);
+                        if (n == 0)
+                            break;
+                        read += n;
+                    }
+
+                    var idx = Array.LastIndexOf(buffer, (byte)'\n', Math.Max(read - 1, 0), read);
+                    if (idx >= 0)
+                        return start + idx + 1;
+
+                    end = start;
+                }
+
+                return 0;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (IOException) when (attempt < _maxReadAttempts)
+            {
+                await Task.Delay(_retryDelay, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not determine tail offset for {File}; starting at 0", Path.GetFileName(path));
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/tests/EDButtkicker.Tests/JournalTailReaderTests.cs
+++ b/tests/EDButtkicker.Tests/JournalTailReaderTests.cs
@@ -1,0 +1,326 @@
+using System.Text;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Journal tailing must be lossless: never emit a line that has not been terminated by a newline,
+/// never emit the same line twice, and never lose complete lines across rotation or truncation.
+/// Everything here drives the reader/pump seam directly - no FileSystemWatcher, no audio stack.
+/// </summary>
+public class JournalTailReaderTests
+{
+    private const string FileA = "Journal.2026-08-27T114250.01.log";
+    private const string FileB = "Journal.2026-08-27T120000.01.log";
+
+    [Fact]
+    public async Task PartialLine_IsNotEmittedUntilNewlineArrives()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Event("LoadGame") + "\n" + "{\"event\":\"FSDJump\"");
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+
+        var first = await reader.ReadNewLinesAsync();
+        Assert.Equal(new[] { Event("LoadGame") }, first);
+
+        // The truncated JSON must stay buffered - re-reading yields nothing new.
+        Assert.Empty(await reader.ReadNewLinesAsync());
+
+        dir.Append(FileA, "}\n");
+
+        var second = await reader.ReadNewLinesAsync();
+        Assert.Equal(new[] { Event("FSDJump") }, second);
+        Assert.Empty(await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task ConcurrentReads_EmitEachLineExactlyOnce()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("A"), Event("B"), Event("C")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+
+        // Two overlapping "Changed" style reads for the same write.
+        var t1 = Task.Run(() => reader.ReadNewLinesAsync());
+        var t2 = Task.Run(() => reader.ReadNewLinesAsync());
+        var emitted = (await t1).Concat(await t2).ToList();
+
+        Assert.Equal(new[] { Event("A"), Event("B"), Event("C") }, emitted);
+        Assert.Empty(await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task MonitorLatestOnly_SkipsHistoryButReadsLaterAppends()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("Historical")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: true);
+
+        Assert.Empty(await reader.ReadNewLinesAsync());
+
+        dir.Append(FileA, Lines(Event("FSDJump")));
+
+        Assert.Equal(new[] { Event("FSDJump") }, await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task MonitorLatestOnly_RetainsTrailingPartialLine()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("Historical")) + "{\"event\":\"Part");
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: true);
+
+        Assert.Empty(await reader.ReadNewLinesAsync());
+
+        dir.Append(FileA, "ial\"}\n");
+
+        Assert.Equal(new[] { Event("Partial") }, await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task MonitorLatestOnly_False_ReadsExistingLines()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("A"), Event("B")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+
+        Assert.Equal(new[] { Event("A"), Event("B") }, await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task Rotation_DrainsOldFileThenReadsNewFile()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("A1")) + "{\"event\":\"A2\"");
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+        Assert.Equal(new[] { Event("A1") }, await reader.ReadNewLinesAsync());
+
+        // The buffered partial completes at the same moment a newer journal appears.
+        dir.Append(FileA, "}\n");
+        dir.Write(FileB, Lines(Event("B1")));
+
+        var afterRotation = await reader.ReadNewLinesAsync();
+        Assert.Equal(new[] { Event("A2"), Event("B1") }, afterRotation);
+        Assert.Equal(Path.Combine(dir.Path, FileB), reader.CurrentFile);
+
+        dir.Append(FileB, Lines(Event("B2")));
+        Assert.Equal(new[] { Event("B2") }, await reader.ReadNewLinesAsync());
+        Assert.Empty(await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task Truncation_RewindsAndReadsRewrittenContent()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("A"), Event("B")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+        Assert.Equal(new[] { Event("A"), Event("B") }, await reader.ReadNewLinesAsync());
+
+        // File shrinks below the committed cursor - treat it as a restarted stream.
+        dir.Write(FileA, Lines(Event("AfterTruncate")));
+
+        Assert.Equal(new[] { Event("AfterTruncate") }, await reader.ReadNewLinesAsync());
+        Assert.Empty(await reader.ReadNewLinesAsync());
+    }
+
+    [Fact]
+    public async Task LockedFile_IsRetriedRatherThanTearingDown()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("Locked")));
+
+        var reader = new FlakyOpenJournalTailReader(dir.Path, failuresBeforeSuccess: 3);
+
+        Assert.Equal(new[] { Event("Locked") }, await reader.ReadNewLinesAsync());
+        Assert.True(reader.OpenAttempts > 1, "reader should have retried the failed opens");
+    }
+
+    [Fact]
+    public async Task ExclusivelyLockedFile_IsReadOnceTheLockIsReleased()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("Unlocked")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false,
+            maxReadAttempts: 40, retryDelay: TimeSpan.FromMilliseconds(25));
+
+        var locker = new FileStream(Path.Combine(dir.Path, FileA), FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        var release = Task.Run(async () =>
+        {
+            await Task.Delay(150);
+            locker.Dispose();
+        });
+
+        var lines = await reader.ReadNewLinesAsync().WaitAsync(TimeSpan.FromSeconds(15));
+        await release;
+
+        Assert.Equal(new[] { Event("Unlocked") }, lines);
+    }
+
+    [Fact]
+    public async Task ReadNewLinesAsync_HonorsCancellation()
+    {
+        using var dir = new TempJournalDirectory();
+        dir.Write(FileA, Lines(Event("A")));
+
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.ReadNewLinesAsync(cts.Token).WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task EmptyDirectory_YieldsNothing()
+    {
+        using var dir = new TempJournalDirectory();
+        var reader = new JournalTailReader(dir.Path, monitorLatestOnly: false);
+
+        Assert.Empty(await reader.ReadNewLinesAsync());
+        Assert.Null(reader.CurrentFile);
+    }
+
+    [Fact]
+    public async Task Pump_SerializesOverlappingSignals()
+    {
+        var entered = new SemaphoreSlim(0);
+        var release = new SemaphoreSlim(0);
+        var concurrent = 0;
+        var maxConcurrent = 0;
+        var invocations = 0;
+
+        using var pump = new JournalSignalPump(async _ =>
+        {
+            var now = Interlocked.Increment(ref concurrent);
+            maxConcurrent = Math.Max(maxConcurrent, now);
+            Interlocked.Increment(ref invocations);
+            entered.Release();
+            await release.WaitAsync();
+            Interlocked.Decrement(ref concurrent);
+        });
+
+        using var cts = new CancellationTokenSource();
+        var run = pump.RunAsync(cts.Token);
+
+        pump.Signal();
+        Assert.True(await entered.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        // Second signal arrives while the first handler is still running.
+        pump.Signal();
+        Assert.False(await entered.WaitAsync(TimeSpan.FromMilliseconds(200)), "handlers must not overlap");
+
+        release.Release();
+        Assert.True(await entered.WaitAsync(TimeSpan.FromSeconds(5)));
+        release.Release();
+
+        cts.Cancel();
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(2, invocations);
+        Assert.Equal(1, maxConcurrent);
+    }
+
+    [Fact]
+    public async Task Pump_StopsOnCancellationWithoutHanging()
+    {
+        using var pump = new JournalSignalPump(_ => Task.CompletedTask);
+        using var cts = new CancellationTokenSource();
+
+        var run = pump.RunAsync(cts.Token);
+        pump.Signal();
+        cts.Cancel();
+
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(run.IsCompleted);
+    }
+
+    [Fact]
+    public async Task Pump_KeepsRunningWhenHandlerThrows()
+    {
+        var succeeded = new TaskCompletionSource();
+        var calls = 0;
+
+        using var pump = new JournalSignalPump(_ =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+                throw new IOException("boom");
+
+            succeeded.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        using var cts = new CancellationTokenSource();
+        var run = pump.RunAsync(cts.Token);
+
+        pump.Signal();
+        await Task.Delay(50);
+        pump.Signal();
+
+        await succeeded.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static string Event(string name) => $"{{\"event\":\"{name}\"}}";
+
+    private static string Lines(params string[] lines) =>
+        string.Concat(lines.Select(l => l + "\n"));
+
+    /// <summary>Reader whose first N opens fail with IOException, mimicking a briefly locked file.</summary>
+    private sealed class FlakyOpenJournalTailReader : JournalTailReader
+    {
+        private readonly int _failuresBeforeSuccess;
+        private int _openAttempts;
+
+        public FlakyOpenJournalTailReader(string directory, int failuresBeforeSuccess)
+            : base(directory, monitorLatestOnly: false, maxReadAttempts: 10,
+                   retryDelay: TimeSpan.FromMilliseconds(1))
+        {
+            _failuresBeforeSuccess = failuresBeforeSuccess;
+        }
+
+        public int OpenAttempts => _openAttempts;
+
+        protected override FileStream OpenRead(string path)
+        {
+            if (Interlocked.Increment(ref _openAttempts) <= _failuresBeforeSuccess)
+                throw new IOException("file is locked");
+
+            return base.OpenRead(path);
+        }
+    }
+
+    private sealed class TempJournalDirectory : IDisposable
+    {
+        public TempJournalDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "edbk-journal-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Write(string fileName, string content) =>
+            File.WriteAllText(System.IO.Path.Combine(Path, fileName), content, new UTF8Encoding(false));
+
+        public void Append(string fileName, string content) =>
+            File.AppendAllText(System.IO.Path.Combine(Path, fileName), content, new UTF8Encoding(false));
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch (IOException) { /* best effort cleanup */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Feed FileSystemWatcher signals through a single-reader queue so overlapping Changed callbacks cannot race the journal cursor.
- Commit the cursor only through the last complete newline and retain trailing partial JSON until the rest of the line arrives.
- Drain remaining complete lines on journal rotation, recover from truncation, and retry short exclusive locks.

Closes #45

## Test Plan
- [x] `dotnet test EDButtkicker.sln --configuration Release` on Linux (67 passed, 0 failed) — hardware-independent journal tests only; no Windows/ButtKicker validation.
- [ ] GitHub Actions CI green (this PR).

## Notes
Linux unit tests only. Do not treat this as hardware validation.
