### PR TITLE
fix: connect journal events through one ordered pipeline

### DIFF
--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -11,20 +11,24 @@ public class JournalApiController
 {
     private readonly ILogger<JournalApiController> _logger;
     private readonly AppSettings _settings;
-    private readonly EventMappingService _eventMappingService;
-    private static readonly List<JournalEvent> RecentEvents = new();
-    private static readonly object EventsLock = new object();
-    
-    // Replay functionality
-    private static CancellationTokenSource? _replayTokenSource;
-    private static Task? _replayTask;
-    private static readonly object ReplayLock = new object();
+    private readonly IJournalEventStore _eventStore;
+    private readonly IJournalEventPipeline _pipeline;
 
-    public JournalApiController(ILogger<JournalApiController> logger, AppSettings settings, EventMappingService eventMappingService)
+    // Replay functionality
+    private CancellationTokenSource? _replayTokenSource;
+    private Task? _replayTask;
+    private readonly object ReplayLock = new object();
+
+    public JournalApiController(
+        ILogger<JournalApiController> logger,
+        AppSettings settings,
+        IJournalEventStore eventStore,
+        IJournalEventPipeline pipeline)
     {
         _logger = logger;
         _settings = settings;
-        _eventMappingService = eventMappingService;
+        _eventStore = eventStore;
+        _pipeline = pipeline;
     }
 
     public async Task GetJournalStatus(HttpContext context)
@@ -175,25 +179,19 @@ public class JournalApiController
                 }
             }
 
-            List<object> events;
-            lock (EventsLock)
-            {
-                events = RecentEvents
-                    .OrderByDescending(e => e.Timestamp)
-                    .Take(limit)
-                    .Select(e => new
-                    {
-                        timestamp = e.Timestamp,
-                        @event = e.Event,
-                        star_system = e.StarSystem,
-                        station_name = e.StationName,
-                        health = e.Health,
-                        hull_damage = e.HullDamage,
-                        additional_data = e.AdditionalData
-                    })
-                    .Cast<object>()
-                    .ToList();
-            }
+            var events = _eventStore.GetRecent(limit)
+                .Select(e => new
+                {
+                    timestamp = e.Timestamp,
+                    @event = e.Event,
+                    star_system = e.StarSystem,
+                    station_name = e.StationName,
+                    health = e.Health,
+                    hull_damage = e.HullDamage,
+                    additional_data = e.AdditionalData
+                })
+                .Cast<object>()
+                .ToList();
 
             var response = new
             {
@@ -221,35 +219,9 @@ public class JournalApiController
         }
     }
 
-    public static void AddRecentEvent(JournalEvent journalEvent)
-    {
-        lock (EventsLock)
-        {
-            RecentEvents.Insert(0, journalEvent);
-            
-            // Keep only recent events (last 1000)
-            if (RecentEvents.Count > 1000)
-            {
-                RecentEvents.RemoveRange(1000, RecentEvents.Count - 1000);
-            }
-        }
-    }
+    private int GetRecentEventsCount() => _eventStore.Count;
 
-    private int GetRecentEventsCount()
-    {
-        lock (EventsLock)
-        {
-            return RecentEvents.Count;
-        }
-    }
-
-    private DateTime? GetLastEventTime()
-    {
-        lock (EventsLock)
-        {
-            return RecentEvents.FirstOrDefault()?.Timestamp;
-        }
-    }
+    private DateTime? GetLastEventTime() => _eventStore.LastTimestamp;
 
     public async Task StartJournalReplay(HttpContext context)
     {
@@ -281,13 +253,7 @@ public class JournalApiController
             {
                 // Fallback to recent events from memory (last 5 minutes of real time)
                 var cutoffTime = DateTime.UtcNow.AddMinutes(-5);
-                lock (EventsLock)
-                {
-                    eventsToReplay = RecentEvents
-                        .Where(e => e.Timestamp >= cutoffTime)
-                        .OrderBy(e => e.Timestamp)
-                        .ToList();
-                }
+                eventsToReplay = _eventStore.GetSince(cutoffTime).ToList();
             }
             
             // Now handle replay start/stop in lock
@@ -410,8 +376,9 @@ public class JournalApiController
                 if (cancellationToken.IsCancellationRequested)
                     break;
 
-                // Process the event through the normal event mapping system
-                await Task.Run(() => _eventMappingService.ProcessEvent(journalEvent), cancellationToken);
+                // Same ordered pipeline as live monitoring, minus the history write - these
+                // events are historical and (for the in-memory source) already in the store.
+                await _pipeline.ProcessAsync(journalEvent, skipHistory: true);
                 
                 _logger.LogDebug("Replayed event: {EventType} at {Timestamp}", journalEvent.Event, journalEvent.Timestamp);
 
@@ -431,22 +398,12 @@ public class JournalApiController
         }
     }
 
-    private int GetEventsToReplayCount()
-    {
-        var cutoffTime = DateTime.UtcNow.AddMinutes(-5);
-        lock (EventsLock)
-        {
-            return RecentEvents.Count(e => e.Timestamp >= cutoffTime);
-        }
-    }
+    private int GetEventsToReplayCount() => GetEventsInLast5Minutes();
 
     private int GetEventsInLast5Minutes()
     {
         var cutoffTime = DateTime.UtcNow.AddMinutes(-5);
-        lock (EventsLock)
-        {
-            return RecentEvents.Count(e => e.Timestamp >= cutoffTime);
-        }
+        return _eventStore.GetSince(cutoffTime).Count;
     }
 
     private async Task<List<JournalEvent>> ReadLastFiveMinutesFromJournalFile(string journalFileName)

--- a/src/EDButtkicker/Controllers/PatternSelectionApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternSelectionApiController.cs
@@ -11,16 +11,16 @@ public class PatternSelectionController : ControllerBase
 {
     private readonly ILogger<PatternSelectionController> _logger;
     private readonly PatternSelectionService _patternSelectionService;
-    private readonly PatternFileService _patternFileService;
+    private readonly PatternSourceCatalogReconciler _catalogReconciler;
 
     public PatternSelectionController(
         ILogger<PatternSelectionController> logger,
         PatternSelectionService patternSelectionService,
-        PatternFileService patternFileService)
+        PatternSourceCatalogReconciler catalogReconciler)
     {
         _logger = logger;
         _patternSelectionService = patternSelectionService;
-        _patternFileService = patternFileService;
+        _catalogReconciler = catalogReconciler;
     }
 
     [HttpGet("conflicts")]
@@ -195,76 +195,17 @@ public class PatternSelectionController : ControllerBase
     {
         try
         {
-            // Get all current pattern sources from various places
-            var allSourceIds = new HashSet<string>();
-            
-            // Add sources from pattern files by getting all ship types
-            var allShipTypes = new HashSet<string>();
-            
-            // Get all available ship types from the pattern file service
-            var allPacks = _patternFileService.GetAllPatternPacks();
-            foreach (var pack in allPacks)
-            {
-                // We need to iterate through all pattern data to find ship types
-                // This is a limitation of the current pattern file structure
-            }
-            
-            // For now, we'll use a more direct approach by getting patterns for known ship types
-            // In a real implementation, we'd want the pattern service to provide a list of all ship types
-            var knownShipTypes = new[]
-            {
-                "sidewinder", "eagle", "hauler", "adder", "viper", "cobra_mkiii", "type6", 
-                "asp", "vulture", "python", "type7", "anaconda", "federation_corvette", 
-                "cutter", "type9", "krait_mkii", "chieftain", "challenger"
-                // Add more as needed
-            };
-            
-            foreach (var shipType in knownShipTypes)
-            {
-                var shipPatterns = _patternFileService.GetPatternsForShip(shipType);
-                foreach (var shipPattern in shipPatterns)
-                {
-                    foreach (var eventName in shipPattern.Events.Keys)
-                    {
-                        var sourceId = GenerateSourceId(PatternSourceType.FileSystem, shipPattern.PackName, shipType, eventName);
-                        allSourceIds.Add(sourceId);
-                        
-                        // Register this pattern source
-                        var sourceInfo = new PatternSourceInfo
-                        {
-                            SourceId = sourceId,
-                            SourceName = $"{shipPattern.PackName} - {shipPattern.DisplayName}",
-                            SourceType = PatternSourceType.FileSystem,
-                            PackName = shipPattern.PackName,
-                            Author = shipPattern.Author,
-                            Version = shipPattern.Version,
-                            LastModified = DateTime.UtcNow, // Would be file modified time in real implementation
-                            Description = "", // ShipPatternDefinition doesn't have description
-                            Tags = shipPattern.Tags,
-                            PatternType = shipPattern.Events[eventName].Pattern.ToString(),
-                            Frequency = shipPattern.Events[eventName].Frequency,
-                            Intensity = shipPattern.Events[eventName].Intensity,
-                            Duration = shipPattern.Events[eventName].Duration
-                        };
-                        
-                        _patternSelectionService.RegisterPatternSource(shipType, eventName, sourceInfo);
-                    }
-                }
-            }
-            
-            // Clean up any sources that no longer exist
-            _patternSelectionService.CleanupMissingSources(allSourceIds);
-            
-            // Save the updated selections
-            await _patternSelectionService.SaveSelectionsAsync();
-            
+            // Registers every ship type the pattern catalog knows about, cleans up dead
+            // selections and saves - the same reconcile that runs at startup and on file changes.
+            var totalSources = await _catalogReconciler.ReconcileAsync();
+
             var stats = _patternSelectionService.GetStats();
             var conflicts = _patternSelectionService.GetConflicts();
-            
+
             return Ok(new RefreshSourcesResponse
             {
                 Message = "Pattern sources refreshed successfully",
-                TotalSources = allSourceIds.Count,
+                TotalSources = totalSources,
                 TotalConflicts = conflicts.TotalConflicts,
                 Stats = stats
             });
@@ -274,11 +215,6 @@ public class PatternSelectionController : ControllerBase
             _logger.LogError(ex, "Error refreshing pattern sources");
             return StatusCode(500, new { error = "Failed to refresh sources", details = ex.Message });
         }
-    }
-
-    private static string GenerateSourceId(PatternSourceType sourceType, string packName, string shipType, string eventName)
-    {
-        return $"{sourceType}:{packName}:{shipType}:{eventName}".ToLowerInvariant();
     }
 }
 

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -163,6 +163,15 @@ class Program
                 services.AddSingleton<PatternFileService>();
                 services.AddSingleton<PatternSelectionService>();
                 services.AddSingleton<ShipPatternService>();
+
+                // Journal event pipeline: one ordered path for history, ship state,
+                // pattern selection and audio, shared by live monitoring and replay.
+                services.AddSingleton<IJournalEventStore, JournalEventStore>();
+                services.AddSingleton<IJournalEventAudioSink>(sp => sp.GetRequiredService<EventMappingService>());
+                services.AddSingleton<IShipPatternProvider>(sp => sp.GetRequiredService<ShipPatternService>());
+                services.AddSingleton<IPatternCatalog>(sp => sp.GetRequiredService<PatternFileService>());
+                services.AddSingleton<PatternSourceCatalogReconciler>();
+                services.AddSingleton<IJournalEventPipeline, JournalEventPipeline>();
                 // IntensityCurveProcessor is a static class, no need to register
                 // AdvancedWaveformGenerator and MultiLayerPatternGenerator are created as needed
                 

--- a/src/EDButtkicker/Services/EventMappingService.cs
+++ b/src/EDButtkicker/Services/EventMappingService.cs
@@ -6,7 +6,7 @@ using EDButtkicker.Models;
 
 namespace EDButtkicker.Services;
 
-public class EventMappingService
+public class EventMappingService : IJournalEventAudioSink
 {
     private readonly ILogger<EventMappingService> _logger;
     private readonly AudioEngineService _audioEngine;
@@ -36,7 +36,13 @@ public class EventMappingService
             _eventMappings.EventMappings.Count);
     }
 
-    public async Task ProcessEvent(JournalEvent journalEvent)
+    public Task ProcessEvent(JournalEvent journalEvent) => ProcessEvent(journalEvent, null);
+
+    /// <summary>
+    /// Processes one event. <paramref name="preferredPattern"/> - typically the active
+    /// ship-specific pattern - is used as the base pattern instead of the default mapping.
+    /// </summary>
+    public async Task ProcessEvent(JournalEvent journalEvent, HapticPattern? preferredPattern)
     {
         try
         {
@@ -44,19 +50,20 @@ public class EventMappingService
                 return;
 
             var eventType = journalEvent.Event;
-            
+
             // Process for contextual intelligence first (even for unmapped events)
             _contextualIntelligence.ProcessEvent(journalEvent);
-            
+
             // Check if we have a mapping for this event
-            if (!_eventMappings.EventMappings.TryGetValue(eventType, out var mapping))
+            var hasMapping = _eventMappings.EventMappings.TryGetValue(eventType, out var mapping);
+            if (!hasMapping && preferredPattern == null)
             {
                 // Log unmapped events occasionally to avoid spam
                 LogUnmappedEvent(eventType);
                 return;
             }
 
-            if (!mapping.Enabled)
+            if (hasMapping && !mapping!.Enabled)
             {
                 _logger.LogDebug("Event mapping disabled for: {EventType}", eventType);
                 return;
@@ -76,7 +83,8 @@ public class EventMappingService
             _eventCounts.AddOrUpdate(eventType, 1, (key, value) => value + 1);
 
             // Apply any event-specific modifications to the pattern
-            var basePattern = CreatePatternForEvent(mapping.Pattern, journalEvent);
+            var sourcePattern = preferredPattern ?? mapping!.Pattern;
+            var basePattern = CreatePatternForEvent(sourcePattern, journalEvent);
             
             // Apply contextual intelligence adjustments
             var pattern = _contextualIntelligence.GetContextuallyAdjustedPattern(basePattern, journalEvent);

--- a/src/EDButtkicker/Services/JournalEventPipeline.cs
+++ b/src/EDButtkicker/Services/JournalEventPipeline.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Logging;
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// The single ordered path every journal event takes: history, ship state, ship pattern
+/// selection, then contextual intelligence + audio. Live monitoring and replay both go
+/// through here so they can never drift apart.
+/// </summary>
+public interface IJournalEventPipeline
+{
+    Task ProcessAsync(JournalEvent journalEvent, bool skipHistory = false);
+}
+
+/// <summary>
+/// The audio/context end of the pipeline. Implemented by <see cref="EventMappingService"/>;
+/// the seam keeps the audio stack out of pipeline tests.
+/// </summary>
+public interface IJournalEventAudioSink
+{
+    Task ProcessEvent(JournalEvent journalEvent, HapticPattern? preferredPattern);
+}
+
+/// <summary>
+/// The ship-specific pattern library. Implemented by <see cref="ShipPatternService"/>.
+/// </summary>
+public interface IShipPatternProvider
+{
+    void SetCurrentShip(CurrentShip ship);
+
+    HapticPattern? GetPatternForEvent(string eventName);
+}
+
+public class JournalEventPipeline : IJournalEventPipeline
+{
+    private readonly ILogger<JournalEventPipeline> _logger;
+    private readonly IJournalEventStore _store;
+    private readonly ShipTrackingService _shipTracking;
+    private readonly IShipPatternProvider _shipPatterns;
+    private readonly IJournalEventAudioSink _audioSink;
+
+    public JournalEventPipeline(
+        ILogger<JournalEventPipeline> logger,
+        IJournalEventStore store,
+        ShipTrackingService shipTracking,
+        IShipPatternProvider shipPatterns,
+        IJournalEventAudioSink audioSink)
+    {
+        _logger = logger;
+        _store = store;
+        _shipTracking = shipTracking;
+        _shipPatterns = shipPatterns;
+        _audioSink = audioSink;
+    }
+
+    public async Task ProcessAsync(JournalEvent journalEvent, bool skipHistory = false)
+    {
+        if (journalEvent == null || string.IsNullOrEmpty(journalEvent.Event))
+            return;
+
+        // 1. History - skipped for replay, where the events already came from the store.
+        if (!skipHistory)
+        {
+            _store.Add(journalEvent);
+        }
+
+        // 2. Ship state.
+        _shipTracking.ProcessJournalEvent(journalEvent);
+
+        // 3. Keep the active pattern library pointed at the ship we are actually flying.
+        var currentShip = _shipTracking.GetCurrentShip();
+        if (currentShip != null)
+        {
+            _shipPatterns.SetCurrentShip(currentShip);
+        }
+
+        // 4. Contextual intelligence + audio, preferring a ship-specific pattern when one exists.
+        var shipPattern = _shipPatterns.GetPatternForEvent(journalEvent.Event);
+        await _audioSink.ProcessEvent(journalEvent, shipPattern);
+
+        _logger.LogDebug("Pipeline processed {Event} (ship: {Ship}, ship pattern: {HasPattern})",
+            journalEvent.Event, currentShip?.ShipType ?? "unknown", shipPattern != null);
+    }
+}

--- a/src/EDButtkicker/Services/JournalEventStore.cs
+++ b/src/EDButtkicker/Services/JournalEventStore.cs
@@ -1,0 +1,94 @@
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Bounded, thread-safe history of the journal events the app has seen this session.
+/// The web API reads from here, so it has to be a real singleton rather than static state
+/// hidden inside a controller.
+/// </summary>
+public interface IJournalEventStore
+{
+    void Add(JournalEvent journalEvent);
+
+    /// <summary>Most recent events first, capped at <paramref name="limit"/>.</summary>
+    IReadOnlyList<JournalEvent> GetRecent(int limit);
+
+    /// <summary>Events at or after <paramref name="cutoff"/>, oldest first (replay order).</summary>
+    IReadOnlyList<JournalEvent> GetSince(DateTime cutoff);
+
+    int Count { get; }
+
+    DateTime? LastTimestamp { get; }
+}
+
+public class JournalEventStore : IJournalEventStore
+{
+    public const int MaxEvents = 1000;
+
+    private readonly List<JournalEvent> _events = new();
+    private readonly object _lock = new object();
+
+    public void Add(JournalEvent journalEvent)
+    {
+        if (journalEvent == null)
+            return;
+
+        lock (_lock)
+        {
+            _events.Insert(0, journalEvent);
+
+            if (_events.Count > MaxEvents)
+            {
+                _events.RemoveRange(MaxEvents, _events.Count - MaxEvents);
+            }
+        }
+    }
+
+    public IReadOnlyList<JournalEvent> GetRecent(int limit)
+    {
+        if (limit <= 0)
+            return Array.Empty<JournalEvent>();
+
+        lock (_lock)
+        {
+            return _events
+                .OrderByDescending(e => e.Timestamp)
+                .Take(limit)
+                .ToList();
+        }
+    }
+
+    public IReadOnlyList<JournalEvent> GetSince(DateTime cutoff)
+    {
+        lock (_lock)
+        {
+            return _events
+                .Where(e => e.Timestamp >= cutoff)
+                .OrderBy(e => e.Timestamp)
+                .ToList();
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _events.Count;
+            }
+        }
+    }
+
+    public DateTime? LastTimestamp
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _events.FirstOrDefault()?.Timestamp;
+            }
+        }
+    }
+}

--- a/src/EDButtkicker/Services/JournalMonitorService.cs
+++ b/src/EDButtkicker/Services/JournalMonitorService.cs
@@ -12,29 +12,46 @@ public class JournalMonitorService : BackgroundService
 
     private readonly ILogger<JournalMonitorService> _logger;
     private readonly AppSettings _settings;
-    private readonly EventMappingService _eventMappingService;
+    private readonly IJournalEventPipeline _pipeline;
     private readonly ShipTrackingService _shipTrackingService;
+    private readonly ShipPatternService _shipPatternService;
+    private readonly PatternSelectionService _patternSelectionService;
+    private readonly PatternFileService _patternFileService;
+    private readonly PatternSourceCatalogReconciler _catalogReconciler;
     private FileSystemWatcher? _fileWatcher;
     private JournalSignalPump? _pump;
     private JournalTailReader? _reader;
+    private bool _subscribed;
 
     public event Action<JournalEvent>? JournalEventReceived;
 
     public JournalMonitorService(
         ILogger<JournalMonitorService> logger,
         AppSettings settings,
-        EventMappingService eventMappingService,
-        ShipTrackingService shipTrackingService)
+        IJournalEventPipeline pipeline,
+        ShipTrackingService shipTrackingService,
+        ShipPatternService shipPatternService,
+        PatternSelectionService patternSelectionService,
+        PatternFileService patternFileService,
+        PatternSourceCatalogReconciler catalogReconciler)
     {
         _logger = logger;
         _settings = settings;
-        _eventMappingService = eventMappingService;
+        _pipeline = pipeline;
         _shipTrackingService = shipTrackingService;
+        _shipPatternService = shipPatternService;
+        _patternSelectionService = patternSelectionService;
+        _patternFileService = patternFileService;
+        _catalogReconciler = catalogReconciler;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Starting Journal Monitor Service");
+
+        // Saved ship libraries and pattern selections must be in memory before the first
+        // journal event is processed, otherwise early events use default patterns only.
+        await LoadPatternStateAsync();
 
         var journalPath = _settings.EliteDangerous.JournalPath;
         if (!Directory.Exists(journalPath))
@@ -44,6 +61,56 @@ public class JournalMonitorService : BackgroundService
         }
 
         await StartMonitoring(journalPath, stoppingToken);
+    }
+
+    private async Task LoadPatternStateAsync()
+    {
+        try
+        {
+            await _shipPatternService.LoadShipPatternsAsync();
+            await _patternSelectionService.LoadSelectionsAsync();
+            await _catalogReconciler.ReconcileAsync();
+
+            if (!_subscribed)
+            {
+                // Ship swaps keep the active library current even if a pipeline step is skipped,
+                // and new/edited pattern files re-enter the selection catalog automatically.
+                _shipTrackingService.ShipChanged += OnShipChanged;
+                _patternFileService.PatternFilesChanged += OnPatternFilesChanged;
+                _subscribed = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading ship patterns and selections; continuing with defaults");
+        }
+    }
+
+    private void OnShipChanged(CurrentShip ship)
+    {
+        try
+        {
+            _shipPatternService.SetCurrentShip(ship);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error applying ship change to pattern library");
+        }
+    }
+
+    private void OnPatternFilesChanged(PatternFileChangeEventArgs args)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _catalogReconciler.ReconcileAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reconciling pattern sources after catalog change");
+            }
+        });
     }
 
     private async Task StartMonitoring(string journalPath, CancellationToken stoppingToken)
@@ -149,8 +216,8 @@ public class JournalMonitorService : BackgroundService
             // Raise event for subscribers
             JournalEventReceived?.Invoke(journalEvent);
 
-            // Process through event mapping service
-            await _eventMappingService.ProcessEvent(journalEvent);
+            // History -> ship state -> ship pattern selection -> context + audio
+            await _pipeline.ProcessAsync(journalEvent);
         }
         catch (JsonException ex)
         {
@@ -165,6 +232,13 @@ public class JournalMonitorService : BackgroundService
 
     public override void Dispose()
     {
+        if (_subscribed)
+        {
+            _shipTrackingService.ShipChanged -= OnShipChanged;
+            _patternFileService.PatternFilesChanged -= OnPatternFilesChanged;
+            _subscribed = false;
+        }
+
         _fileWatcher?.Dispose();
         _pump?.Dispose();
         base.Dispose();

--- a/src/EDButtkicker/Services/PatternFileService.cs
+++ b/src/EDButtkicker/Services/PatternFileService.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace EDButtkicker.Services;
 
-public class PatternFileService
+public class PatternFileService : IPatternCatalog
 {
     private readonly ILogger<PatternFileService> _logger;
     private readonly string _patternsPath;

--- a/src/EDButtkicker/Services/PatternSourceCatalogReconciler.cs
+++ b/src/EDButtkicker/Services/PatternSourceCatalogReconciler.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// The file-system pattern catalog, as far as the reconciler is concerned.
+/// Implemented by <see cref="PatternFileService"/>.
+/// </summary>
+public interface IPatternCatalog
+{
+    List<string> GetAllShipTypes();
+
+    List<ShipPatternDefinition> GetPatternsForShip(string shipType);
+}
+
+public class PatternSourceRegistration
+{
+    public string ShipType { get; init; } = string.Empty;
+    public string EventName { get; init; } = string.Empty;
+    public PatternSourceInfo SourceInfo { get; init; } = new();
+}
+
+/// <summary>
+/// Registers every pattern the catalog knows about as a selectable source and drops
+/// selections whose source has gone away. Runs at startup, whenever pattern files change,
+/// and from the refresh-sources API.
+/// </summary>
+public class PatternSourceCatalogReconciler
+{
+    private readonly ILogger<PatternSourceCatalogReconciler> _logger;
+    private readonly IPatternCatalog _catalog;
+    private readonly PatternSelectionService _patternSelectionService;
+    private readonly SemaphoreSlim _reconcileLock = new(1, 1);
+
+    public PatternSourceCatalogReconciler(
+        ILogger<PatternSourceCatalogReconciler> logger,
+        IPatternCatalog catalog,
+        PatternSelectionService patternSelectionService)
+    {
+        _logger = logger;
+        _catalog = catalog;
+        _patternSelectionService = patternSelectionService;
+    }
+
+    /// <summary>
+    /// Every ship/event pattern the catalog currently exposes. Driven by
+    /// <see cref="IPatternCatalog.GetAllShipTypes"/> - never a hardcoded ship list.
+    /// </summary>
+    public static List<PatternSourceRegistration> BuildSources(IPatternCatalog catalog)
+    {
+        var registrations = new List<PatternSourceRegistration>();
+
+        foreach (var shipType in catalog.GetAllShipTypes())
+        {
+            foreach (var shipPattern in catalog.GetPatternsForShip(shipType))
+            {
+                foreach (var eventEntry in shipPattern.Events)
+                {
+                    var eventName = eventEntry.Key;
+                    var pattern = eventEntry.Value;
+
+                    registrations.Add(new PatternSourceRegistration
+                    {
+                        ShipType = shipType,
+                        EventName = eventName,
+                        SourceInfo = new PatternSourceInfo
+                        {
+                            SourceId = GenerateSourceId(PatternSourceType.FileSystem, shipPattern.PackName, shipType, eventName),
+                            SourceName = $"{shipPattern.PackName} - {shipPattern.DisplayName}",
+                            SourceType = PatternSourceType.FileSystem,
+                            PackName = shipPattern.PackName,
+                            Author = shipPattern.Author,
+                            Version = shipPattern.Version,
+                            LastModified = DateTime.UtcNow,
+                            Description = "",
+                            Tags = shipPattern.Tags,
+                            PatternType = pattern.Pattern.ToString(),
+                            Frequency = pattern.Frequency,
+                            Intensity = pattern.Intensity,
+                            Duration = pattern.Duration
+                        }
+                    });
+                }
+            }
+        }
+
+        return registrations;
+    }
+
+    /// <summary>
+    /// Registers all catalog sources, cleans up selections whose source disappeared and
+    /// persists the result. Returns the number of registered sources.
+    /// </summary>
+    public async Task<int> ReconcileAsync()
+    {
+        await _reconcileLock.WaitAsync();
+
+        try
+        {
+            var registrations = BuildSources(_catalog);
+            var sourceIds = new HashSet<string>();
+
+            foreach (var registration in registrations)
+            {
+                sourceIds.Add(registration.SourceInfo.SourceId);
+                _patternSelectionService.RegisterPatternSource(registration.ShipType, registration.EventName, registration.SourceInfo);
+            }
+
+            _patternSelectionService.CleanupMissingSources(sourceIds);
+            await _patternSelectionService.SaveSelectionsAsync();
+
+            _logger.LogInformation("Reconciled {SourceCount} pattern sources from the pattern catalog", sourceIds.Count);
+
+            return sourceIds.Count;
+        }
+        finally
+        {
+            _reconcileLock.Release();
+        }
+    }
+
+    public static string GenerateSourceId(PatternSourceType sourceType, string packName, string shipType, string eventName)
+    {
+        return $"{sourceType}:{packName}:{shipType}:{eventName}".ToLowerInvariant();
+    }
+}

--- a/src/EDButtkicker/Services/ShipPatternService.cs
+++ b/src/EDButtkicker/Services/ShipPatternService.cs
@@ -4,7 +4,7 @@ using EDButtkicker.Models;
 
 namespace EDButtkicker.Services;
 
-public class ShipPatternService
+public class ShipPatternService : IShipPatternProvider
 {
     private readonly ILogger<ShipPatternService> _logger;
     private readonly EventMappingService _eventMappingService;

--- a/src/EDButtkicker/Services/ShipTrackingService.cs
+++ b/src/EDButtkicker/Services/ShipTrackingService.cs
@@ -72,7 +72,9 @@ public class ShipTrackingService
     {
         try
         {
-            var shipType = ExtractStringProperty(journalEvent, "Ship");
+            // "Ship" binds to the typed property when the line is deserialized, so it is not
+            // in AdditionalData - check both.
+            var shipType = journalEvent.Ship ?? ExtractStringProperty(journalEvent, "Ship");
             var shipName = ExtractStringProperty(journalEvent, "ShipName");
             var shipIdent = ExtractStringProperty(journalEvent, "ShipIdent");
             var shipId = journalEvent.ShipID ?? ExtractLongProperty(journalEvent, "ShipID");
@@ -137,7 +139,7 @@ public class ShipTrackingService
     {
         try
         {
-            var shipType = ExtractStringProperty(journalEvent, "Ship");
+            var shipType = journalEvent.Ship ?? ExtractStringProperty(journalEvent, "Ship");
             var shipName = ExtractStringProperty(journalEvent, "ShipName");
             var shipIdent = ExtractStringProperty(journalEvent, "ShipIdent");
             var shipId = journalEvent.ShipID ?? ExtractLongProperty(journalEvent, "ShipID");

--- a/src/EDButtkicker/Services/WebConfigurationService.cs
+++ b/src/EDButtkicker/Services/WebConfigurationService.cs
@@ -20,6 +20,10 @@ public class WebConfigurationService : BackgroundService
     private readonly EventMappingService _eventMapping;
     private readonly PatternSequencer _patternSequencer;
     private readonly ContextualIntelligenceService _contextualIntelligence;
+    private readonly IJournalEventStore _journalEventStore;
+    private readonly IJournalEventPipeline _journalEventPipeline;
+    private readonly PatternSelectionService _patternSelectionService;
+    private readonly PatternSourceCatalogReconciler _catalogReconciler;
     private IWebHost? _webHost;
     private readonly int _port = 47811; // Elite Dangerous Buttkicker - uncommon port
 
@@ -29,7 +33,11 @@ public class WebConfigurationService : BackgroundService
         AudioEngineService audioEngine,
         EventMappingService eventMapping,
         PatternSequencer patternSequencer,
-        ContextualIntelligenceService contextualIntelligence)
+        ContextualIntelligenceService contextualIntelligence,
+        IJournalEventStore journalEventStore,
+        IJournalEventPipeline journalEventPipeline,
+        PatternSelectionService patternSelectionService,
+        PatternSourceCatalogReconciler catalogReconciler)
     {
         _logger = logger;
         _settings = settings;
@@ -37,6 +45,10 @@ public class WebConfigurationService : BackgroundService
         _eventMapping = eventMapping;
         _patternSequencer = patternSequencer;
         _contextualIntelligence = contextualIntelligence;
+        _journalEventStore = journalEventStore;
+        _journalEventPipeline = journalEventPipeline;
+        _patternSelectionService = patternSelectionService;
+        _catalogReconciler = catalogReconciler;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -56,6 +68,12 @@ public class WebConfigurationService : BackgroundService
                     services.AddSingleton(_audioEngine);
                     services.AddSingleton(_eventMapping);
                     services.AddSingleton(_patternSequencer);
+                    // Same instances as the root container - the API must see live journal
+                    // history and share the pipeline with journal monitoring.
+                    services.AddSingleton(_journalEventStore);
+                    services.AddSingleton(_journalEventPipeline);
+                    services.AddSingleton(_patternSelectionService);
+                    services.AddSingleton(_catalogReconciler);
                     services.AddSingleton<PatternFileService>();
                     services.AddSingleton<ConfigurationApiController>();
                     services.AddSingleton<PatternApiController>();

--- a/tests/EDButtkicker.Tests/JournalEventPipelineTests.cs
+++ b/tests/EDButtkicker.Tests/JournalEventPipelineTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Every journal event has to travel one ordered path: history, ship state, ship pattern
+/// selection, then context + audio. These tests drive that pipeline through test doubles for
+/// the audio and pattern-library ends - no audio device, no FileSystemWatcher, no AppData.
+/// </summary>
+public class JournalEventPipelineTests
+{
+    private static readonly DateTime Start = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Store_KeepsOnlyTheNewestThousandEvents()
+    {
+        var store = new JournalEventStore();
+
+        for (var i = 0; i < 1500; i++)
+        {
+            store.Add(new JournalEvent { Event = $"E{i}", Timestamp = Start.AddSeconds(i) });
+        }
+
+        Assert.Equal(1000, store.Count);
+
+        var recent = store.GetRecent(1000);
+        Assert.Equal("E1499", recent[0].Event);
+        Assert.Equal("E500", recent[^1].Event);
+        Assert.Equal(Start.AddSeconds(1499), store.LastTimestamp);
+    }
+
+    [Fact]
+    public void Store_GetRecent_IsNewestFirstAndRespectsLimit()
+    {
+        var store = new JournalEventStore();
+        store.Add(new JournalEvent { Event = "First", Timestamp = Start });
+        store.Add(new JournalEvent { Event = "Second", Timestamp = Start.AddSeconds(1) });
+        store.Add(new JournalEvent { Event = "Third", Timestamp = Start.AddSeconds(2) });
+
+        var recent = store.GetRecent(2);
+
+        Assert.Equal(new[] { "Third", "Second" }, recent.Select(e => e.Event));
+        Assert.Empty(store.GetRecent(0));
+    }
+
+    [Fact]
+    public void Store_GetSince_ReturnsEventsAfterCutoffOldestFirst()
+    {
+        var store = new JournalEventStore();
+        store.Add(new JournalEvent { Event = "Old", Timestamp = Start });
+        store.Add(new JournalEvent { Event = "Recent", Timestamp = Start.AddMinutes(10) });
+        store.Add(new JournalEvent { Event = "Newest", Timestamp = Start.AddMinutes(20) });
+
+        var since = store.GetSince(Start.AddMinutes(5));
+
+        Assert.Equal(new[] { "Recent", "Newest" }, since.Select(e => e.Event));
+    }
+
+    [Fact]
+    public async Task Pipeline_RecordsHistory_TracksShip_AndFeedsAudio()
+    {
+        var harness = new PipelineHarness();
+
+        await harness.Pipeline.ProcessAsync(Parse("{\"timestamp\":\"2026-08-27T12:00:00Z\",\"event\":\"LoadGame\",\"Ship\":\"python\",\"ShipName\":\"Nyx\",\"ShipID\":42}"));
+        await harness.Pipeline.ProcessAsync(Parse("{\"timestamp\":\"2026-08-27T12:00:05Z\",\"event\":\"FSDJump\",\"StarSystem\":\"Shinrarta Dezhra\"}"));
+
+        // History has both events, newest first.
+        Assert.Equal(2, harness.Store.Count);
+        Assert.Equal(new[] { "FSDJump", "LoadGame" }, harness.Store.GetRecent(10).Select(e => e.Event));
+
+        // Ship state was updated, and the active pattern library follows it.
+        Assert.Equal("python", harness.ShipTracking.GetCurrentShip()?.ShipType);
+        Assert.Contains(harness.ShipPatterns.ShipsSet, s => s.ShipType == "python");
+
+        // Audio ran for every event, and only after history and ship state were updated.
+        Assert.Equal(new[] { "LoadGame", "FSDJump" }, harness.AudioSink.Calls.Select(c => c.Event.Event));
+        Assert.Equal(new[] { 1, 2 }, harness.AudioSink.Calls.Select(c => c.StoreCountAtCall));
+        Assert.Equal(new[] { "python", "python" }, harness.AudioSink.Calls.Select(c => c.ShipAtCall?.ShipType));
+    }
+
+    [Fact]
+    public async Task Pipeline_PassesShipSpecificPatternToAudio()
+    {
+        var harness = new PipelineHarness();
+        var shipPattern = new HapticPattern
+        {
+            Name = "Python FSD Jump",
+            Pattern = PatternType.BuildupRumble,
+            Frequency = 35,
+            Intensity = 70,
+            Duration = 3000
+        };
+        harness.ShipPatterns.Patterns["FSDJump"] = shipPattern;
+
+        await harness.Pipeline.ProcessAsync(Parse("{\"timestamp\":\"2026-08-27T12:00:05Z\",\"event\":\"FSDJump\",\"StarSystem\":\"Sol\"}"));
+        await harness.Pipeline.ProcessAsync(Parse("{\"timestamp\":\"2026-08-27T12:00:06Z\",\"event\":\"Docked\",\"StationName\":\"Jameson Memorial\"}"));
+
+        Assert.Same(shipPattern, harness.AudioSink.Calls[0].Pattern);
+        Assert.Null(harness.AudioSink.Calls[1].Pattern);
+    }
+
+    [Fact]
+    public async Task Pipeline_SkipHistory_StillPlaysButDoesNotGrowTheStore()
+    {
+        var harness = new PipelineHarness();
+        var replayed = Parse("{\"timestamp\":\"2026-08-27T12:00:05Z\",\"event\":\"FSDJump\",\"StarSystem\":\"Sol\"}");
+
+        await harness.Pipeline.ProcessAsync(replayed, skipHistory: true);
+
+        Assert.Equal(0, harness.Store.Count);
+        Assert.Single(harness.AudioSink.Calls);
+    }
+
+    [Fact]
+    public async Task Pipeline_IgnoresEventsWithoutAnEventName()
+    {
+        var harness = new PipelineHarness();
+
+        await harness.Pipeline.ProcessAsync(new JournalEvent { Timestamp = Start });
+
+        Assert.Equal(0, harness.Store.Count);
+        Assert.Empty(harness.AudioSink.Calls);
+    }
+
+    [Fact]
+    public void Reconciler_BuildsSourcesForEveryShipTypeInTheCatalog()
+    {
+        // Ship types deliberately outside the old hardcoded "known ship types" list.
+        var catalog = new StubPatternCatalog();
+        catalog.Add("diamondbackexplorer", "Explorer Pack", "FSDJump", "Touchdown");
+        catalog.Add("mamba", "Combat Pack", "HullDamage");
+
+        var sources = PatternSourceCatalogReconciler.BuildSources(catalog);
+
+        Assert.Equal(new[] { "diamondbackexplorer", "mamba" }, catalog.ShipTypesQueried);
+        Assert.Equal(3, sources.Count);
+        Assert.Contains(sources, s => s.ShipType == "diamondbackexplorer" && s.EventName == "Touchdown");
+        Assert.Contains(sources, s => s.ShipType == "mamba" && s.EventName == "HullDamage");
+        Assert.All(sources, s => Assert.Equal(PatternSourceType.FileSystem, s.SourceInfo.SourceType));
+
+        // Source ids are stable and unique per pack/ship/event.
+        Assert.Equal(sources.Count, sources.Select(s => s.SourceInfo.SourceId).Distinct().Count());
+        Assert.Contains(sources, s => s.SourceInfo.SourceId == "filesystem:combat pack:mamba:hulldamage");
+    }
+
+    [Fact]
+    public void Reconciler_BuildsNothingForAnEmptyCatalog()
+    {
+        Assert.Empty(PatternSourceCatalogReconciler.BuildSources(new StubPatternCatalog()));
+    }
+
+    private static JournalEvent Parse(string line)
+    {
+        return JsonSerializer.Deserialize<JournalEvent>(line, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        })!;
+    }
+
+    private sealed class PipelineHarness
+    {
+        public JournalEventStore Store { get; } = new();
+        public ShipTrackingService ShipTracking { get; } = new(NullLogger<ShipTrackingService>.Instance);
+        public FakeShipPatternProvider ShipPatterns { get; } = new();
+        public RecordingAudioSink AudioSink { get; }
+        public JournalEventPipeline Pipeline { get; }
+
+        public PipelineHarness()
+        {
+            AudioSink = new RecordingAudioSink(Store, ShipTracking);
+            Pipeline = new JournalEventPipeline(
+                NullLogger<JournalEventPipeline>.Instance,
+                Store,
+                ShipTracking,
+                ShipPatterns,
+                AudioSink);
+        }
+    }
+
+    private sealed record AudioCall(JournalEvent Event, HapticPattern? Pattern, int StoreCountAtCall, CurrentShip? ShipAtCall);
+
+    private sealed class RecordingAudioSink : IJournalEventAudioSink
+    {
+        private readonly IJournalEventStore _store;
+        private readonly ShipTrackingService _shipTracking;
+
+        public List<AudioCall> Calls { get; } = new();
+
+        public RecordingAudioSink(IJournalEventStore store, ShipTrackingService shipTracking)
+        {
+            _store = store;
+            _shipTracking = shipTracking;
+        }
+
+        public Task ProcessEvent(JournalEvent journalEvent, HapticPattern? preferredPattern)
+        {
+            Calls.Add(new AudioCall(journalEvent, preferredPattern, _store.Count, _shipTracking.GetCurrentShip()));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeShipPatternProvider : IShipPatternProvider
+    {
+        public List<CurrentShip> ShipsSet { get; } = new();
+        public Dictionary<string, HapticPattern> Patterns { get; } = new();
+
+        public void SetCurrentShip(CurrentShip ship) => ShipsSet.Add(ship);
+
+        public HapticPattern? GetPatternForEvent(string eventName) =>
+            Patterns.TryGetValue(eventName, out var pattern) ? pattern : null;
+    }
+
+    private sealed class StubPatternCatalog : IPatternCatalog
+    {
+        private readonly Dictionary<string, List<ShipPatternDefinition>> _ships = new();
+
+        public List<string> ShipTypesQueried { get; } = new();
+
+        public void Add(string shipType, string packName, params string[] eventNames)
+        {
+            var definition = new ShipPatternDefinition
+            {
+                ShipType = shipType,
+                DisplayName = shipType,
+                PackName = packName,
+                Author = "Tests",
+                Version = "1.0.0",
+                Events = eventNames.ToDictionary(
+                    name => name,
+                    name => new HapticPattern { Name = $"{shipType} {name}", Pattern = PatternType.Impact })
+            };
+
+            if (!_ships.TryGetValue(shipType, out var definitions))
+            {
+                definitions = new List<ShipPatternDefinition>();
+                _ships[shipType] = definitions;
+            }
+
+            definitions.Add(definition);
+        }
+
+        public List<string> GetAllShipTypes() => _ships.Keys.OrderBy(k => k).ToList();
+
+        public List<ShipPatternDefinition> GetPatternsForShip(string shipType)
+        {
+            ShipTypesQueried.Add(shipType);
+            return _ships.TryGetValue(shipType, out var definitions)
+                ? new List<ShipPatternDefinition>(definitions)
+                : new List<ShipPatternDefinition>();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Journal events now travel one ordered pipeline instead of stopping at `EventMappingService`:

1. History (injected bounded store, cap 1000)
2. Ship tracking
3. Active ship pattern library / selection
4. Contextual intelligence + audio (ship-specific pattern when one exists)

Saved ship libraries and pattern selections load and reconcile **before** monitoring starts, and again whenever the pattern catalog changes. `GetAllShipTypes()` drives reconcile — the old hardcoded ship list is gone.

Replay uses the same pipeline with `skipHistory: true` so historical events are not inserted twice.

## Test plan
- [x] `dotnet test tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj` — 76 passed locally (Linux, no hardware)
- [x] `dotnet build EDButtkicker.sln` — 0 warnings
- [ ] GitHub Actions CI (unit tests + Windows package jobs)

Does not claim Windows/ButtKicker hardware validation.

Closes #46
