### PR TITLE
fix: unify runtime and web dependency injection

### DIFF
--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.DependencyInjection;
+using EDButtkicker.Configuration;
+using EDButtkicker.Controllers;
+using EDButtkicker.Services;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// The single composition root. Program and the integration tests both register through here,
+/// so the runtime services and the web API resolve from one service graph - there is no second
+/// container and no singleton that exists twice.
+/// Hosted services are deliberately NOT registered here: they are a Program concern, so tests can
+/// build the same graph without starting journal watching, status polling or audio hardware.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers every runtime service and every controller dependency in one graph.
+    /// </summary>
+    public static IServiceCollection AddEliteButtkicker(this IServiceCollection services, AppSettings appSettings)
+    {
+        services.AddSingleton(appSettings);
+
+        // Add core services
+        services.AddSingleton<AudioEngineService>();
+        services.AddSingleton<PatternSequencer>();
+        services.AddSingleton<UserSettingsService>();
+        services.AddSingleton<ContextualIntelligenceService>();
+        services.AddSingleton<EventMappingService>();
+        services.AddSingleton<ShipTrackingService>();
+        services.AddSingleton<PatternFileService>();
+        services.AddSingleton<PatternSelectionService>();
+        services.AddSingleton<ShipPatternService>();
+
+        // Journal event pipeline: one ordered path for history, ship state,
+        // pattern selection and audio, shared by live monitoring and replay.
+        services.AddSingleton<IJournalEventStore, JournalEventStore>();
+        services.AddSingleton<IJournalEventAudioSink>(sp => sp.GetRequiredService<EventMappingService>());
+        services.AddSingleton<IShipPatternProvider>(sp => sp.GetRequiredService<ShipPatternService>());
+        services.AddSingleton<IPatternCatalog>(sp => sp.GetRequiredService<PatternFileService>());
+        services.AddSingleton<PatternSourceCatalogReconciler>();
+        services.AddSingleton<IJournalEventPipeline, JournalEventPipeline>();
+        // IntensityCurveProcessor is a static class, no need to register
+        // AdvancedWaveformGenerator and MultiLayerPatternGenerator are created as needed
+
+        return services.AddEliteButtkickerControllers();
+    }
+
+    /// <summary>
+    /// Every controller the process can resolve, registered in the same graph as its dependencies.
+    /// </summary>
+    public static IServiceCollection AddEliteButtkickerControllers(this IServiceCollection services)
+    {
+        // Routed by the web UI middleware in WebUiConfiguration.
+        services.AddSingleton<ConfigurationApiController>();
+        services.AddSingleton<PatternApiController>();
+        services.AddSingleton<AudioApiController>();
+        services.AddSingleton<JournalApiController>();
+        services.AddSingleton<PatternFilesController>();
+        services.AddSingleton<PatternEditorController>();
+        services.AddSingleton<ContextualIntelligenceApiController>();
+
+        // Not routed today, but they belong to the same graph so they stay resolvable.
+        services.AddSingleton<UserSettingsController>();
+        services.AddSingleton<PatternSelectionController>();
+        services.AddSingleton<ShipPatternsController>();
+
+        return services;
+    }
+}

--- a/src/EDButtkicker/Hosting/WebUiConfiguration.cs
+++ b/src/EDButtkicker/Hosting/WebUiConfiguration.cs
@@ -1,0 +1,439 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using EDButtkicker.Controllers;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// The web pipeline - static files plus the middleware router - as a reusable Configure callback.
+/// Program attaches it to the generic host so requests resolve controllers out of the primary
+/// service provider; the integration tests attach the exact same callback to a TestServer.
+/// </summary>
+public static class WebUiConfiguration
+{
+    /// <summary>Elite Dangerous Buttkicker - uncommon port, loopback only.</summary>
+    public const int Port = 47811;
+
+    /// <summary>
+    /// Wires static file serving and the API routes onto <paramref name="app"/>.
+    /// Everything is resolved from <c>context.RequestServices</c>, i.e. the host's provider.
+    /// </summary>
+    public static void Configure(IApplicationBuilder app)
+    {
+        var logger = app.ApplicationServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(WebUiConfiguration).FullName!);
+
+        var webRootPath = ResolveWebRootPath(logger);
+
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(webRootPath),
+            RequestPath = ""
+        });
+
+        // Simple middleware-based routing
+        app.Use(async (context, next) =>
+        {
+            var path = context.Request.Path.ToString();
+            var method = context.Request.Method;
+
+            try
+            {
+                // Configuration API
+                if (path == "/api/config" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<ConfigurationApiController>();
+                    await controller!.GetConfiguration(context);
+                    return;
+                }
+                else if (path == "/api/config" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<ConfigurationApiController>();
+                    await controller!.UpdateConfiguration(context);
+                    return;
+                }
+                else if (path == "/api/config/export" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<ConfigurationApiController>();
+                    await controller!.ExportConfiguration(context);
+                    return;
+                }
+                else if (path == "/api/config/import" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<ConfigurationApiController>();
+                    await controller!.ImportConfiguration(context);
+                    return;
+                }
+                // Pattern API
+                else if (path == "/api/patterns" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.GetPatterns(context);
+                    return;
+                }
+                else if (path == "/api/patterns" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.CreatePattern(context);
+                    return;
+                }
+                else if (path.StartsWith("/api/patterns/") && path.EndsWith("/test") && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.TestPattern(context);
+                    return;
+                }
+                else if (path.StartsWith("/api/patterns/") && method == "PUT")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.UpdatePattern(context);
+                    return;
+                }
+                else if (path.StartsWith("/api/patterns/") && method == "DELETE")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.DeletePattern(context);
+                    return;
+                }
+                else if (path == "/api/patterns/test/custom" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternApiController>();
+                    await controller!.TestCustomPattern(context);
+                    return;
+                }
+                // Audio API
+                else if (path == "/api/audio/devices" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<AudioApiController>();
+                    await controller!.GetAudioDevices(context);
+                    return;
+                }
+                else if (path == "/api/audio/device" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<AudioApiController>();
+                    await controller!.SetAudioDevice(context);
+                    return;
+                }
+                else if (path == "/api/audio/test" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<AudioApiController>();
+                    await controller!.TestAudio(context);
+                    return;
+                }
+                // Journal API
+                else if (path == "/api/journal/status" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.GetJournalStatus(context);
+                    return;
+                }
+                else if (path == "/api/journal/path" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.SetJournalPath(context);
+                    return;
+                }
+                else if (path == "/api/journal/events/recent" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.GetRecentEvents(context);
+                    return;
+                }
+                else if (path == "/api/journal/replay/start" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.StartJournalReplay(context);
+                    return;
+                }
+                else if (path == "/api/journal/replay/stop" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.StopJournalReplay(context);
+                    return;
+                }
+                else if (path == "/api/journal/replay/status" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<JournalApiController>();
+                    await controller!.GetJournalReplayStatus(context);
+                    return;
+                }
+                // Pattern Files API
+                else if (path == "/api/PatternFiles/reload" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternFilesController>();
+                    await controller!.ReloadPatternFilesHttpContext(context);
+                    return;
+                }
+                else if (path == "/api/PatternFiles/export" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternFilesController>();
+                    await controller!.ExportPatternPack(context);
+                    return;
+                }
+                else if (path == "/api/PatternFiles/import" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternFilesController>();
+                    await controller!.ImportPatternFile(context);
+                    return;
+                }
+                else if (path == "/api/PatternFiles/packs" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<PatternFilesController>();
+                    await controller!.GetPatternPacks(context);
+                    return;
+                }
+                // Pattern Editor API
+                else if (path == "/api/PatternEditor/templates" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.GetPatternTemplatesHttpContext(context);
+                    return;
+                }
+                else if (path == "/api/PatternEditor/create" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.CreateNewPatternHttpContext(context);
+                    return;
+                }
+                else if (path == "/api/PatternEditor/save" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.SavePatternHttpContext(context);
+                    return;
+                }
+                else if (path == "/api/PatternEditor/validate" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.ValidatePatternHttpContext(context);
+                    return;
+                }
+                else if (path == "/api/PatternEditor/test" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.TestPatternHttpContext(context);
+                    return;
+                }
+                else if (path.StartsWith("/api/PatternEditor/load/") && method == "GET")
+                {
+                    var fileName = path.Substring("/api/PatternEditor/load/".Length);
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.LoadPatternForEditingHttpContext(context, fileName);
+                    return;
+                }
+                else if (path.StartsWith("/api/PatternEditor/user-files/") && method == "GET")
+                {
+                    var author = path.Substring("/api/PatternEditor/user-files/".Length);
+                    var controller = context.RequestServices.GetService<PatternEditorController>();
+                    await controller!.GetUserFilesHttpContext(context, author);
+                    return;
+                }
+                // Contextual Intelligence API
+                else if (path == "/api/context/status" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
+                    await controller!.GetContextualIntelligenceStatus(context);
+                    return;
+                }
+                else if (path == "/api/context/config" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
+                    await controller!.UpdateContextualIntelligenceConfig(context);
+                    return;
+                }
+                else if (path == "/api/context/predictions" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
+                    await controller!.GetGameContextPredictions(context);
+                    return;
+                }
+                // Default route - serve the main UI
+                else if (path == "/" || path == "/index.html" || !path.StartsWith("/api/"))
+                {
+                    context.Response.ContentType = "text/html";
+                    var html = await GetMainHtmlPage(webRootPath);
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(html);
+                    await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error handling request: {Path}", path);
+                context.Response.StatusCode = 500;
+                var errorBytes = System.Text.Encoding.UTF8.GetBytes("Internal server error");
+                await context.Response.Body.WriteAsync(errorBytes, 0, errorBytes.Length);
+                return;
+            }
+
+            await next();
+        });
+    }
+
+    public static string ResolveWebRootPath(ILogger logger)
+    {
+        // Try multiple possible locations for wwwroot
+        var possiblePaths = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "wwwroot"),
+            Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"),
+            Path.Combine(Directory.GetCurrentDirectory(), "src", "EDButtkicker", "wwwroot"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "EDButtkicker", "wwwroot")
+        };
+
+        foreach (var path in possiblePaths)
+        {
+            if (Directory.Exists(path))
+            {
+                logger.LogInformation("Found wwwroot at: {Path}", path);
+                return Path.GetFullPath(path);
+            }
+        }
+
+        // If no wwwroot found, use the base directory (will serve embedded content)
+        logger.LogWarning("wwwroot directory not found, using base directory: {Path}", AppContext.BaseDirectory);
+        return AppContext.BaseDirectory;
+    }
+
+    private static async Task<string> GetMainHtmlPage(string webRootPath)
+    {
+        var htmlPath = Path.Combine(webRootPath, "index.html");
+
+        if (File.Exists(htmlPath))
+        {
+            return await File.ReadAllTextAsync(htmlPath);
+        }
+
+        // Return embedded HTML if file doesn't exist
+        return GetEmbeddedHtml();
+    }
+
+    private static string GetEmbeddedHtml()
+    {
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Elite Dangerous Buttkicker Configuration</title>
+            <style>
+                * { margin: 0; padding: 0; box-sizing: border-box; }
+                body {
+                    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                    background: linear-gradient(135deg, #0a0a0a, #1a1a2e);
+                    color: #ffffff;
+                    min-height: 100vh;
+                }
+                .header {
+                    background: linear-gradient(90deg, #ff6b35, #f7931e);
+                    padding: 20px;
+                    text-align: center;
+                    box-shadow: 0 4px 20px rgba(255, 107, 53, 0.3);
+                }
+                .header h1 {
+                    font-size: 2.5rem;
+                    font-weight: 700;
+                    text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
+                }
+                .subtitle {
+                    margin-top: 10px;
+                    font-size: 1.1rem;
+                    opacity: 0.9;
+                }
+                .loading {
+                    text-align: center;
+                    padding: 50px;
+                    font-size: 1.2rem;
+                    color: #ff6b35;
+                }
+                .container {
+                    max-width: 1200px;
+                    margin: 0 auto;
+                    padding: 30px 20px;
+                }
+                .status-bar {
+                    background: rgba(255, 255, 255, 0.1);
+                    border-radius: 10px;
+                    padding: 20px;
+                    margin-bottom: 30px;
+                    backdrop-filter: blur(10px);
+                    border: 1px solid rgba(255, 255, 255, 0.1);
+                }
+                .status-item {
+                    display: inline-block;
+                    margin-right: 30px;
+                    font-size: 0.95rem;
+                }
+                .status-indicator {
+                    display: inline-block;
+                    width: 10px;
+                    height: 10px;
+                    border-radius: 50%;
+                    margin-right: 8px;
+                }
+                .status-online { background: #4CAF50; }
+                .status-offline { background: #f44336; }
+                .status-warning { background: #ff9800; }
+            </style>
+        </head>
+        <body>
+            <div class="header">
+                <h1>Elite Dangerous Buttkicker Extension</h1>
+                <div class="subtitle">Advanced Haptic Feedback Configuration Interface</div>
+            </div>
+
+            <div class="container">
+                <div class="status-bar">
+                    <div class="status-item">
+                        <span class="status-indicator status-online"></span>
+                        Web Interface: Online
+                    </div>
+                    <div class="status-item">
+                        <span class="status-indicator status-warning"></span>
+                        Audio Engine: Initializing
+                    </div>
+                    <div class="status-item">
+                        <span class="status-indicator status-offline"></span>
+                        Journal Monitor: Disconnected
+                    </div>
+                </div>
+
+                <div class="loading">
+                    🚀 Loading configuration interface...
+                    <br><br>
+                    <small>Please wait while the advanced pattern system initializes</small>
+                </div>
+            </div>
+
+            <script>
+                console.log('Elite Dangerous Buttkicker Configuration Interface');
+                console.log('Web server running on localhost:8080');
+
+                // Basic status check
+                setTimeout(() => {
+                    document.querySelector('.loading').innerHTML = `
+                        <h3>📡 Configuration Interface Ready</h3>
+                        <p>API endpoints are available for pattern configuration</p>
+                        <br>
+                        <p><strong>Available endpoints:</strong></p>
+                        <ul style="text-align: left; max-width: 600px; margin: 0 auto;">
+                            <li>GET /api/config - Current configuration</li>
+                            <li>GET /api/patterns - All haptic patterns</li>
+                            <li>GET /api/audio/devices - Available audio devices</li>
+                            <li>GET /api/journal/status - Journal monitoring status</li>
+                            <li>POST /api/patterns/{eventType}/test - Test patterns</li>
+                        </ul>
+                        <br>
+                        <p><em>Advanced web UI will load here automatically...</em></p>
+                    `;
+                }, 2000);
+            </script>
+        </body>
+        </html>
+        """;
+    }
+}

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -6,6 +7,7 @@ using NAudio.Wave;
 using NAudio.CoreAudioApi;
 using NAudio.Wasapi;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using EDButtkicker.Controllers;
@@ -146,42 +148,33 @@ class Program
                       .AddEnvironmentVariables()
                       .AddCommandLine(args);
             })
+            .UseDefaultServiceProvider(options =>
+            {
+                // One graph, and it has to be resolvable: a missing controller dependency is a
+                // startup failure instead of a 500 on the first request that needs it.
+                options.ValidateScopes = true;
+                options.ValidateOnBuild = true;
+            })
             .ConfigureServices((hostContext, services) =>
             {
                 // Bind configuration
                 var appSettings = new AppSettings();
                 hostContext.Configuration.Bind(appSettings);
-                services.AddSingleton(appSettings);
 
-                // Add core services
-                services.AddSingleton<AudioEngineService>();
-                services.AddSingleton<PatternSequencer>();
-                services.AddSingleton<ContextualIntelligenceService>();
-                services.AddSingleton<EventMappingService>();
-                services.AddSingleton<UserSettingsService>();
-                services.AddSingleton<ShipTrackingService>();
-                services.AddSingleton<PatternFileService>();
-                services.AddSingleton<PatternSelectionService>();
-                services.AddSingleton<ShipPatternService>();
+                // Runtime services, web controllers and their dependencies - one registration
+                // method, shared with the integration tests.
+                services.AddEliteButtkicker(appSettings);
 
-                // Journal event pipeline: one ordered path for history, ship state,
-                // pattern selection and audio, shared by live monitoring and replay.
-                services.AddSingleton<IJournalEventStore, JournalEventStore>();
-                services.AddSingleton<IJournalEventAudioSink>(sp => sp.GetRequiredService<EventMappingService>());
-                services.AddSingleton<IShipPatternProvider>(sp => sp.GetRequiredService<ShipPatternService>());
-                services.AddSingleton<IPatternCatalog>(sp => sp.GetRequiredService<PatternFileService>());
-                services.AddSingleton<PatternSourceCatalogReconciler>();
-                services.AddSingleton<IJournalEventPipeline, JournalEventPipeline>();
-                // IntensityCurveProcessor is a static class, no need to register
-                // AdvancedWaveformGenerator and MultiLayerPatternGenerator are created as needed
-                
-                // Add API controllers
-                services.AddTransient<ContextualIntelligenceApiController>();
-                
                 // Add hosted services
                 services.AddHostedService<JournalMonitorService>();
                 services.AddHostedService<WebConfigurationService>();
 				services.AddHostedService<StatusMonitorService>();
+            })
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                // The web app lives in the primary service provider - there is no second container.
+                webBuilder.UseKestrel(options => options.ListenLocalhost(WebUiConfiguration.Port));
+                webBuilder.Configure(WebUiConfiguration.Configure);
             })
             .ConfigureLogging(logging =>
             {

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -16,6 +16,7 @@ public class AudioEngineService : IDisposable
     private MixingSampleProvider? _mixer;
     private readonly object _lock = new object();
     private bool _isInitialized = false;
+    private bool _initializationFailed = false;
     private readonly Dictionary<string, SignalGenerator> _activeGenerators = new();
     private readonly Dictionary<string, CancellationTokenSource> _activeCancellations = new();
 
@@ -103,11 +104,39 @@ public class AudioEngineService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Opens the audio device on first use. Playback is the trigger, so nothing that merely
+    /// constructs or resolves this service touches audio hardware. Unlike <see cref="Initialize"/>
+    /// this never throws: a machine with no usable output device just gets no haptics, and one
+    /// failed attempt is remembered so every later pattern does not retry the device enumeration.
+    /// </summary>
+    public bool EnsureInitialized()
+    {
+        lock (_lock)
+        {
+            if (_isInitialized) return true;
+            if (_initializationFailed) return false;
+
+            try
+            {
+                Initialize();
+            }
+            catch (Exception ex)
+            {
+                _initializationFailed = true;
+                _logger.LogError(ex, "Audio engine unavailable, haptics are disabled for this session");
+                return false;
+            }
+
+            return _isInitialized;
+        }
+    }
+
     public Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
     {
-        if (!_isInitialized)
+        if (!EnsureInitialized())
         {
-            _logger.LogWarning("⚠ Audio engine not initialized, skipping playbook for pattern: {PatternName}", pattern.Name);
+            _logger.LogWarning("⚠ Audio engine not initialized, skipping playback for pattern: {PatternName}", pattern.Name);
             return Task.CompletedTask;
         }
 
@@ -294,6 +323,8 @@ public class AudioEngineService : IDisposable
             
             _mixer = null;
             _isInitialized = false;
+            // A new device deserves a fresh attempt even if the previous one could not be opened.
+            _initializationFailed = false;
             
             // Clear active cancellations
             foreach (var cancellation in _activeCancellations.Values)

--- a/src/EDButtkicker/Services/EventMappingService.cs
+++ b/src/EDButtkicker/Services/EventMappingService.cs
@@ -27,9 +27,9 @@ public class EventMappingService : IJournalEventAudioSink
         _patternSequencer = patternSequencer;
         _contextualIntelligence = contextualIntelligence;
         _eventMappings = EventMappingsConfig.GetDefault();
-        
-        // Initialize services
-        _audioEngine.Initialize();
+
+        // No audio device work here: the engine opens itself on first playback so that building
+        // the service graph never touches hardware.
         _patternSequencer.LoadPatterns(_eventMappings);
         
         _logger.LogInformation("Event Mapping Service initialized with {Count} default patterns", 

--- a/src/EDButtkicker/Services/WebConfigurationService.cs
+++ b/src/EDButtkicker/Services/WebConfigurationService.cs
@@ -1,530 +1,72 @@
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.Extensions.FileProviders;
-using EDButtkicker.Configuration;
-using EDButtkicker.Controllers;
+using EDButtkicker.Hosting;
 using System.Diagnostics;
 
 namespace EDButtkicker.Services;
 
+/// <summary>
+/// The web app is hosted by the generic host (see Program.CreateHostBuilder), so it resolves
+/// controllers from the primary service provider. This service no longer builds a second
+/// WebHost - it only announces the interface and opens the browser once the server is up.
+/// </summary>
 public class WebConfigurationService : BackgroundService
 {
     private readonly ILogger<WebConfigurationService> _logger;
-    private readonly AppSettings _settings;
-    private readonly AudioEngineService _audioEngine;
-    private readonly EventMappingService _eventMapping;
-    private readonly PatternSequencer _patternSequencer;
-    private readonly ContextualIntelligenceService _contextualIntelligence;
-    private readonly IJournalEventStore _journalEventStore;
-    private readonly IJournalEventPipeline _journalEventPipeline;
-    private readonly PatternSelectionService _patternSelectionService;
-    private readonly PatternSourceCatalogReconciler _catalogReconciler;
-    private IWebHost? _webHost;
-    private readonly int _port = 47811; // Elite Dangerous Buttkicker - uncommon port
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly int _port = WebUiConfiguration.Port;
 
     public WebConfigurationService(
         ILogger<WebConfigurationService> logger,
-        AppSettings settings,
-        AudioEngineService audioEngine,
-        EventMappingService eventMapping,
-        PatternSequencer patternSequencer,
-        ContextualIntelligenceService contextualIntelligence,
-        IJournalEventStore journalEventStore,
-        IJournalEventPipeline journalEventPipeline,
-        PatternSelectionService patternSelectionService,
-        PatternSourceCatalogReconciler catalogReconciler)
+        IHostApplicationLifetime lifetime)
     {
         _logger = logger;
-        _settings = settings;
-        _audioEngine = audioEngine;
-        _eventMapping = eventMapping;
-        _patternSequencer = patternSequencer;
-        _contextualIntelligence = contextualIntelligence;
-        _journalEventStore = journalEventStore;
-        _journalEventPipeline = journalEventPipeline;
-        _patternSelectionService = patternSelectionService;
-        _catalogReconciler = catalogReconciler;
+        _lifetime = lifetime;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("Starting Web Configuration Server on localhost:{Port}", _port);
+        _logger.LogInformation("Web Configuration Server listening on localhost:{Port}", _port);
 
         try
         {
-            _webHost = new WebHostBuilder()
-                .UseKestrel(options =>
-                {
-                    options.ListenLocalhost(_port);
-                })
-                .ConfigureServices(services =>
-                {
-                    services.AddSingleton(_settings);
-                    services.AddSingleton(_audioEngine);
-                    services.AddSingleton(_eventMapping);
-                    services.AddSingleton(_patternSequencer);
-                    // Same instances as the root container - the API must see live journal
-                    // history and share the pipeline with journal monitoring.
-                    services.AddSingleton(_journalEventStore);
-                    services.AddSingleton(_journalEventPipeline);
-                    services.AddSingleton(_patternSelectionService);
-                    services.AddSingleton(_catalogReconciler);
-                    services.AddSingleton<PatternFileService>();
-                    services.AddSingleton<ConfigurationApiController>();
-                    services.AddSingleton<PatternApiController>();
-                    services.AddSingleton<PatternFilesController>();
-                    services.AddSingleton<PatternEditorController>();
-                    services.AddSingleton<AudioApiController>();
-                    services.AddSingleton<JournalApiController>();
-                    services.AddSingleton<ContextualIntelligenceApiController>();
-                })
-                .Configure(app =>
-                {
-                    var webRootPath = GetWebRootPath();
-                    app.UseStaticFiles(new StaticFileOptions
-                    {
-                        FileProvider = new PhysicalFileProvider(webRootPath),
-                        RequestPath = ""
-                    });
-                    
-                    // Simple middleware-based routing
-                    app.Use(async (context, next) =>
-                    {
-                        var path = context.Request.Path.ToString();
-                        var method = context.Request.Method;
-                        
-                        try
-                        {
-                            // Configuration API
-                            if (path == "/api/config" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<ConfigurationApiController>();
-                                await controller!.GetConfiguration(context);
-                                return;
-                            }
-                            else if (path == "/api/config" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<ConfigurationApiController>();
-                                await controller!.UpdateConfiguration(context);
-                                return;
-                            }
-                            else if (path == "/api/config/export" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<ConfigurationApiController>();
-                                await controller!.ExportConfiguration(context);
-                                return;
-                            }
-                            else if (path == "/api/config/import" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<ConfigurationApiController>();
-                                await controller!.ImportConfiguration(context);
-                                return;
-                            }
-                            // Pattern API
-                            else if (path == "/api/patterns" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.GetPatterns(context);
-                                return;
-                            }
-                            else if (path == "/api/patterns" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.CreatePattern(context);
-                                return;
-                            }
-                            else if (path.StartsWith("/api/patterns/") && path.EndsWith("/test") && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.TestPattern(context);
-                                return;
-                            }
-                            else if (path.StartsWith("/api/patterns/") && method == "PUT")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.UpdatePattern(context);
-                                return;
-                            }
-                            else if (path.StartsWith("/api/patterns/") && method == "DELETE")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.DeletePattern(context);
-                                return;
-                            }
-                            else if (path == "/api/patterns/test/custom" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternApiController>();
-                                await controller!.TestCustomPattern(context);
-                                return;
-                            }
-                            // Audio API
-                            else if (path == "/api/audio/devices" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<AudioApiController>();
-                                await controller!.GetAudioDevices(context);
-                                return;
-                            }
-                            else if (path == "/api/audio/device" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<AudioApiController>();
-                                await controller!.SetAudioDevice(context);
-                                return;
-                            }
-                            else if (path == "/api/audio/test" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<AudioApiController>();
-                                await controller!.TestAudio(context);
-                                return;
-                            }
-                            // Journal API
-                            else if (path == "/api/journal/status" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.GetJournalStatus(context);
-                                return;
-                            }
-                            else if (path == "/api/journal/path" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.SetJournalPath(context);
-                                return;
-                            }
-                            else if (path == "/api/journal/events/recent" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.GetRecentEvents(context);
-                                return;
-                            }
-                            else if (path == "/api/journal/replay/start" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.StartJournalReplay(context);
-                                return;
-                            }
-                            else if (path == "/api/journal/replay/stop" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.StopJournalReplay(context);
-                                return;
-                            }
-                            else if (path == "/api/journal/replay/status" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<JournalApiController>();
-                                await controller!.GetJournalReplayStatus(context);
-                                return;
-                            }
-                            // Pattern Files API
-                            else if (path == "/api/PatternFiles/reload" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternFilesController>();
-                                await controller!.ReloadPatternFilesHttpContext(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternFiles/export" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternFilesController>();
-                                await controller!.ExportPatternPack(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternFiles/import" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternFilesController>();
-                                await controller!.ImportPatternFile(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternFiles/packs" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<PatternFilesController>();
-                                await controller!.GetPatternPacks(context);
-                                return;
-                            }
-                            // Pattern Editor API
-                            else if (path == "/api/PatternEditor/templates" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.GetPatternTemplatesHttpContext(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternEditor/create" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.CreateNewPatternHttpContext(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternEditor/save" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.SavePatternHttpContext(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternEditor/validate" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.ValidatePatternHttpContext(context);
-                                return;
-                            }
-                            else if (path == "/api/PatternEditor/test" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.TestPatternHttpContext(context);
-                                return;
-                            }
-                            else if (path.StartsWith("/api/PatternEditor/load/") && method == "GET")
-                            {
-                                var fileName = path.Substring("/api/PatternEditor/load/".Length);
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.LoadPatternForEditingHttpContext(context, fileName);
-                                return;
-                            }
-                            else if (path.StartsWith("/api/PatternEditor/user-files/") && method == "GET")
-                            {
-                                var author = path.Substring("/api/PatternEditor/user-files/".Length);
-                                var controller = context.RequestServices.GetService<PatternEditorController>();
-                                await controller!.GetUserFilesHttpContext(context, author);
-                                return;
-                            }
-                            // Contextual Intelligence API
-                            else if (path == "/api/context/status" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
-                                await controller!.GetContextualIntelligenceStatus(context);
-                                return;
-                            }
-                            else if (path == "/api/context/config" && method == "POST")
-                            {
-                                var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
-                                await controller!.UpdateContextualIntelligenceConfig(context);
-                                return;
-                            }
-                            else if (path == "/api/context/predictions" && method == "GET")
-                            {
-                                var controller = context.RequestServices.GetService<ContextualIntelligenceApiController>();
-                                await controller!.GetGameContextPredictions(context);
-                                return;
-                            }
-                            // Default route - serve the main UI
-                            else if (path == "/" || path == "/index.html" || !path.StartsWith("/api/"))
-                            {
-                                context.Response.ContentType = "text/html";
-                                var html = await GetMainHtmlPage();
-                                var bytes = System.Text.Encoding.UTF8.GetBytes(html);
-                                await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
-                                return;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "Error handling request: {Path}", path);
-                            context.Response.StatusCode = 500;
-                            var errorBytes = System.Text.Encoding.UTF8.GetBytes("Internal server error");
-                            await context.Response.Body.WriteAsync(errorBytes, 0, errorBytes.Length);
-                            return;
-                        }
-                        
-                        await next();
-                    });
-                })
-                .UseContentRoot(GetWebRootPath())
-                .Build();
-
-            await _webHost.StartAsync(stoppingToken);
+            await WaitForApplicationStartedAsync(stoppingToken);
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
 
             _logger.LogInformation("✅ Web Configuration Interface started!");
             _logger.LogInformation("🌐 Opening browser at: http://localhost:{Port}", _port);
             _logger.LogInformation("📱 Configure patterns, audio devices, and monitor Elite Dangerous events");
-            
+
             // Automatically open the web browser
             OpenBrowser($"http://localhost:{_port}");
-            
-            await _webHost.WaitForShutdownAsync(stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutting down before the host finished starting - nothing to announce.
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to start web configuration server");
+            _logger.LogError(ex, "Failed to announce the web configuration server");
         }
     }
 
-    private async Task<string> GetMainHtmlPage()
+    private async Task WaitForApplicationStartedAsync(CancellationToken stoppingToken)
     {
-        var webRootPath = GetWebRootPath();
-        var htmlPath = Path.Combine(webRootPath, "index.html");
-        
-        if (File.Exists(htmlPath))
-        {
-            return await File.ReadAllTextAsync(htmlPath);
-        }
-        
-        // Return embedded HTML if file doesn't exist
-        return GetEmbeddedHtml();
-    }
-    
-    private string GetEmbeddedHtml()
-    {
-        return """
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Elite Dangerous Buttkicker Configuration</title>
-            <style>
-                * { margin: 0; padding: 0; box-sizing: border-box; }
-                body { 
-                    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-                    background: linear-gradient(135deg, #0a0a0a, #1a1a2e);
-                    color: #ffffff; 
-                    min-height: 100vh;
-                }
-                .header { 
-                    background: linear-gradient(90deg, #ff6b35, #f7931e);
-                    padding: 20px; 
-                    text-align: center; 
-                    box-shadow: 0 4px 20px rgba(255, 107, 53, 0.3);
-                }
-                .header h1 { 
-                    font-size: 2.5rem; 
-                    font-weight: 700;
-                    text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
-                }
-                .subtitle { 
-                    margin-top: 10px; 
-                    font-size: 1.1rem; 
-                    opacity: 0.9; 
-                }
-                .loading { 
-                    text-align: center; 
-                    padding: 50px; 
-                    font-size: 1.2rem;
-                    color: #ff6b35;
-                }
-                .container { 
-                    max-width: 1200px; 
-                    margin: 0 auto; 
-                    padding: 30px 20px; 
-                }
-                .status-bar {
-                    background: rgba(255, 255, 255, 0.1);
-                    border-radius: 10px;
-                    padding: 20px;
-                    margin-bottom: 30px;
-                    backdrop-filter: blur(10px);
-                    border: 1px solid rgba(255, 255, 255, 0.1);
-                }
-                .status-item {
-                    display: inline-block;
-                    margin-right: 30px;
-                    font-size: 0.95rem;
-                }
-                .status-indicator {
-                    display: inline-block;
-                    width: 10px;
-                    height: 10px;
-                    border-radius: 50%;
-                    margin-right: 8px;
-                }
-                .status-online { background: #4CAF50; }
-                .status-offline { background: #f44336; }
-                .status-warning { background: #ff9800; }
-            </style>
-        </head>
-        <body>
-            <div class="header">
-                <h1>Elite Dangerous Buttkicker Extension</h1>
-                <div class="subtitle">Advanced Haptic Feedback Configuration Interface</div>
-            </div>
-            
-            <div class="container">
-                <div class="status-bar">
-                    <div class="status-item">
-                        <span class="status-indicator status-online"></span>
-                        Web Interface: Online
-                    </div>
-                    <div class="status-item">
-                        <span class="status-indicator status-warning"></span>
-                        Audio Engine: Initializing
-                    </div>
-                    <div class="status-item">
-                        <span class="status-indicator status-offline"></span>
-                        Journal Monitor: Disconnected
-                    </div>
-                </div>
-                
-                <div class="loading">
-                    🚀 Loading configuration interface...
-                    <br><br>
-                    <small>Please wait while the advanced pattern system initializes</small>
-                </div>
-            </div>
-            
-            <script>
-                console.log('Elite Dangerous Buttkicker Configuration Interface');
-                console.log('Web server running on localhost:8080');
-                
-                // Basic status check
-                setTimeout(() => {
-                    document.querySelector('.loading').innerHTML = `
-                        <h3>📡 Configuration Interface Ready</h3>
-                        <p>API endpoints are available for pattern configuration</p>
-                        <br>
-                        <p><strong>Available endpoints:</strong></p>
-                        <ul style="text-align: left; max-width: 600px; margin: 0 auto;">
-                            <li>GET /api/config - Current configuration</li>
-                            <li>GET /api/patterns - All haptic patterns</li>
-                            <li>GET /api/audio/devices - Available audio devices</li>
-                            <li>GET /api/journal/status - Journal monitoring status</li>
-                            <li>POST /api/patterns/{eventType}/test - Test patterns</li>
-                        </ul>
-                        <br>
-                        <p><em>Advanced web UI will load here automatically...</em></p>
-                    `;
-                }, 2000);
-            </script>
-        </body>
-        </html>
-        """;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var startedRegistration = _lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+        using var stoppingRegistration = stoppingToken.Register(() => started.TrySetResult());
+
+        await started.Task;
     }
 
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Stopping Web Configuration Server");
-        
-        if (_webHost != null)
-        {
-            await _webHost.StopAsync(cancellationToken);
-            _webHost.Dispose();
-        }
-        
         await base.StopAsync(cancellationToken);
-    }
-
-    private string GetWebRootPath()
-    {
-        // Try multiple possible locations for wwwroot
-        var possiblePaths = new[]
-        {
-            Path.Combine(AppContext.BaseDirectory, "wwwroot"),
-            Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"),
-            Path.Combine(Directory.GetCurrentDirectory(), "src", "EDButtkicker", "wwwroot"),
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "EDButtkicker", "wwwroot")
-        };
-
-        foreach (var path in possiblePaths)
-        {
-            if (Directory.Exists(path))
-            {
-                _logger.LogInformation("Found wwwroot at: {Path}", path);
-                return path;
-            }
-        }
-
-        // If no wwwroot found, use the base directory (will serve embedded content)
-        _logger.LogWarning("wwwroot directory not found, using base directory: {Path}", AppContext.BaseDirectory);
-        return AppContext.BaseDirectory;
     }
 
     private void OpenBrowser(string url)
@@ -548,7 +90,7 @@ public class WebConfigurationService : BackgroundService
             {
                 Process.Start("open", url);
             }
-            
+
             _logger.LogInformation("Browser launched successfully");
         }
         catch (Exception ex)

--- a/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
+++ b/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using EDButtkicker.Configuration;
+using EDButtkicker.Controllers;
+using EDButtkicker.Hosting;
+using EDButtkicker.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Guards the single composition root: the runtime services and the web controllers must resolve
+/// from one graph, and every route the web UI maps must actually be servable from it.
+/// Nothing here touches audio hardware, binds a port, or starts a hosted service.
+/// </summary>
+public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixture>
+{
+    private readonly WebUiTestServerFixture _fixture;
+
+    public DependencyInjectionGraphTests(WebUiTestServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void AddEliteButtkicker_BuildsAValidatedServiceGraph()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEliteButtkicker(new AppSettings());
+
+        // ValidateOnBuild turns a missing controller dependency into a build failure instead of a
+        // 500 on the first request that needs it; ValidateScopes catches captive dependencies.
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void ContextualIntelligenceApiController_Resolves()
+    {
+        var controller = _fixture.Services.GetRequiredService<ContextualIntelligenceApiController>();
+
+        Assert.NotNull(controller);
+    }
+
+    [Fact]
+    public void PatternFileService_IsTheSameInstanceForControllersAndRuntime()
+    {
+        var runtimeSingleton = _fixture.Services.GetRequiredService<PatternFileService>();
+
+        var patternFilesController = _fixture.Services.GetRequiredService<PatternFilesController>();
+        var patternEditorController = _fixture.Services.GetRequiredService<PatternEditorController>();
+
+        Assert.True(ReferenceEquals(
+            runtimeSingleton,
+            GetPrivateDependency<PatternFileService>(patternFilesController)));
+        Assert.True(ReferenceEquals(
+            runtimeSingleton,
+            GetPrivateDependency<PatternFileService>(patternEditorController)));
+
+        // The catalog interface the journal pipeline consumes has to be that same object too,
+        // otherwise pattern reloads through the API would never reach playback.
+        Assert.True(ReferenceEquals(runtimeSingleton, _fixture.Services.GetRequiredService<IPatternCatalog>()));
+    }
+
+    [Fact]
+    public void ContextualIntelligenceService_UsedByController_IsTheRuntimeSingleton()
+    {
+        var runtimeSingleton = _fixture.Services.GetRequiredService<ContextualIntelligenceService>();
+        var controller = _fixture.Services.GetRequiredService<ContextualIntelligenceApiController>();
+
+        Assert.True(ReferenceEquals(
+            runtimeSingleton,
+            GetPrivateDependency<ContextualIntelligenceService>(controller)));
+    }
+
+    [Fact]
+    public async Task GetContextStatus_IsSuccessful()
+    {
+        // Smoking gun for the old split container: ContextualIntelligenceService was missing from
+        // the web container, so this route used to fail outright.
+        var response = await _fixture.Client.GetAsync("/api/context/status");
+
+        Assert.True(
+            response.IsSuccessStatusCode,
+            $"GET /api/context/status returned {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
+
+    [Theory]
+    [MemberData(nameof(MappedRoutes))]
+    public async Task EveryMappedRoute_IsHandledWithoutServerError(string method, string path)
+    {
+        var response = await SendAsync(method, path);
+        var body = await response.Content.ReadAsStringAsync();
+        var status = (int)response.StatusCode;
+
+        // 4xx is fine - these requests carry deliberately minimal bodies. 5xx means the route could
+        // not be served at all, which is what a broken service graph looks like from the outside.
+        // The one documented exception is the import endpoint, which answers 501 by design.
+        var allowNotImplemented = path == "/api/PatternFiles/import";
+
+        Assert.True(
+            status < 500 || (allowNotImplemented && status == (int)HttpStatusCode.NotImplemented),
+            $"{method} {path} returned {status}: {body}");
+    }
+
+    [Theory]
+    [MemberData(nameof(ReadOnlyRoutes))]
+    public async Task ReadOnlyGetRoutes_AreSuccessful(string path)
+    {
+        var response = await _fixture.Client.GetAsync(path);
+
+        Assert.True(
+            response.IsSuccessStatusCode,
+            $"GET {path} returned {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
+
+    /// <summary>Every route wired up in <see cref="WebUiConfiguration.Configure"/>.</summary>
+    public static TheoryData<string, string> MappedRoutes() => new()
+    {
+        { "GET", "/api/config" },
+        { "POST", "/api/config" },
+        { "GET", "/api/config/export" },
+        { "POST", "/api/config/import" },
+        { "GET", "/api/patterns" },
+        { "POST", "/api/patterns" },
+        { "POST", "/api/patterns/FSDJump/test" },
+        { "PUT", "/api/patterns/FSDJump" },
+        { "DELETE", "/api/patterns/FSDJump" },
+        { "POST", "/api/patterns/test/custom" },
+        { "GET", "/api/audio/devices" },
+        { "POST", "/api/audio/device" },
+        { "POST", "/api/audio/test" },
+        { "GET", "/api/journal/status" },
+        { "POST", "/api/journal/path" },
+        { "GET", "/api/journal/events/recent" },
+        { "POST", "/api/journal/replay/start" },
+        { "POST", "/api/journal/replay/stop" },
+        { "GET", "/api/journal/replay/status" },
+        { "POST", "/api/PatternFiles/reload" },
+        { "POST", "/api/PatternFiles/export" },
+        { "POST", "/api/PatternFiles/import" },
+        { "GET", "/api/PatternFiles/packs" },
+        { "GET", "/api/PatternEditor/templates" },
+        { "POST", "/api/PatternEditor/create" },
+        { "POST", "/api/PatternEditor/save" },
+        { "POST", "/api/PatternEditor/validate" },
+        { "POST", "/api/PatternEditor/test" },
+        { "GET", "/api/PatternEditor/load/dummy.json" },
+        { "GET", "/api/PatternEditor/user-files/test-author" },
+        { "GET", "/api/context/status" },
+        { "POST", "/api/context/config" },
+        { "GET", "/api/context/predictions" },
+        { "GET", "/" }
+    };
+
+    /// <summary>GETs that need no request body, so anything but success is a real failure.</summary>
+    public static TheoryData<string> ReadOnlyRoutes() => new()
+    {
+        "/api/config",
+        "/api/patterns",
+        "/api/journal/status",
+        "/api/audio/devices",
+        "/api/PatternFiles/packs",
+        "/api/PatternEditor/templates",
+        "/api/context/predictions",
+        "/"
+    };
+
+    private Task<HttpResponseMessage> SendAsync(string method, string path)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), path);
+
+        // Send a minimal JSON body on writes so we are testing DI and routing rather than
+        // whatever a handler does with an empty stream.
+        if (method is "POST" or "PUT")
+        {
+            request.Content = new StringContent(MinimalBodyFor(path), Encoding.UTF8, "application/json");
+        }
+
+        return _fixture.Client.SendAsync(request);
+    }
+
+    private static string MinimalBodyFor(string path) => path switch
+    {
+        "/api/patterns" => """{"eventType":"FSDJump","pattern":{"name":"Test","pattern":"SharpPulse","frequency":40,"intensity":50,"duration":500}}""",
+        "/api/patterns/FSDJump" => """{"eventType":"FSDJump","pattern":{"name":"Test","pattern":"SharpPulse","frequency":40,"intensity":50,"duration":500}}""",
+        _ => "{}"
+    };
+
+    private static T GetPrivateDependency<T>(object instance) where T : class
+    {
+        var field = instance.GetType()
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+            .SingleOrDefault(f => f.FieldType == typeof(T));
+
+        Assert.True(field != null, $"{instance.GetType().Name} has no {typeof(T).Name} field to compare");
+
+        return (T)field!.GetValue(instance)!;
+    }
+}
+
+/// <summary>
+/// Hosts the real web pipeline on a TestServer: same registrations and same Configure callback as
+/// Program, minus Kestrel, minus the hosted services (journal watching, status polling, browser
+/// launch) and minus any audio device initialisation.
+/// </summary>
+public sealed class WebUiTestServerFixture : IDisposable
+{
+    private readonly IWebHost _host;
+
+    public WebUiTestServerFixture()
+    {
+        var settings = new AppSettings();
+
+        _host = new WebHostBuilder()
+            .UseContentRoot(AppContext.BaseDirectory)
+            .UseTestServer()
+            .ConfigureServices(services =>
+            {
+                services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+
+                // The one composition root, exactly as Program registers it.
+                services.AddEliteButtkicker(settings);
+
+                // Deliberately no AddHostedService: no JournalMonitorService, no StatusMonitorService,
+                // no WebConfigurationService, and AudioEngineService is never Initialize()d.
+                Assert.DoesNotContain(services, d => d.ServiceType == typeof(IHostedService));
+            })
+            .Configure(WebUiConfiguration.Configure)
+            .Build();
+
+        _host.Start();
+        Client = _host.GetTestClient();
+    }
+
+    public HttpClient Client { get; }
+
+    public IServiceProvider Services => _host.Services;
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        _host.Dispose();
+    }
+}

--- a/tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj
+++ b/tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- WebHostBuilder / IApplicationBuilder come from the shared framework, same as the app. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
## Summary
The web UI no longer builds a second container.

- `Program` hosts Kestrel on loopback (`ListenLocalhost(47811)`) through `ConfigureWebHostDefaults`.
- `AddEliteButtkicker` is the single composition root for runtime services and every controller.
- `WebConfigurationService` only announces the UI and opens the browser; it does not `Build()` a nested WebHost.
- `ContextualIntelligenceApiController` resolves `ContextualIntelligenceService` from the same graph.
- `PatternFileService` is one singleton for runtime and web.
- `EventMappingService` no longer opens WASAPI in its constructor. The audio engine initializes on first playback so graph construction never touches hardware.

## Test plan
- [x] `dotnet test EDButtkicker.sln --configuration Release` — 123 passed locally (Linux, no hardware)
- [ ] GitHub Actions CI (unit tests + Windows package jobs)

Does not claim Windows/ButtKicker hardware validation.

Closes #23
