### PR TITLE
fix: block path traversal in pattern file routes

### DIFF
--- a/src/EDButtkicker/Controllers/PatternEditorApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternEditorApiController.cs
@@ -191,23 +191,38 @@ public class PatternEditorController : ControllerBase
             }
 
             // Generate safe filename if not provided
-            var fileName = request.FileName;
-            if (string.IsNullOrEmpty(fileName))
+            var requestedFileName = request.FileName;
+            if (string.IsNullOrEmpty(requestedFileName))
             {
-                fileName = GenerateSafeFileName(
-                    request.PatternFile.Metadata.Name, 
+                requestedFileName = GenerateSafeFileName(
+                    request.PatternFile.Metadata.Name,
                     request.PatternFile.Metadata.Author);
+            }
+
+            var fileName = PatternPathGuard.SanitizeFileName(requestedFileName);
+            if (fileName == null)
+            {
+                return BadRequest(new { error = "Invalid file name" });
             }
 
             // Ensure .json extension
             if (!fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
             {
-                fileName += ".json";
+                fileName = PatternPathGuard.SanitizeFileName(fileName + ".json");
+                if (fileName == null)
+                {
+                    return BadRequest(new { error = "Invalid file name" });
+                }
             }
 
             // Determine save location
             var saveDirectory = request.SaveToCustom ? "Custom" : "patterns";
-            var fullPath = Path.Combine(Directory.GetCurrentDirectory(), "patterns", saveDirectory, fileName);
+            var fullPath = PatternPathGuard.ResolveUnderRoot(
+                Path.Combine(Directory.GetCurrentDirectory(), "patterns"), fileName, saveDirectory);
+            if (fullPath == null)
+            {
+                return BadRequest(new { error = "Invalid file name" });
+            }
 
             // Create directory if it doesn't exist
             var directory = Path.GetDirectoryName(fullPath);
@@ -254,22 +269,23 @@ public class PatternEditorController : ControllerBase
     {
         try
         {
-            // Try to find the file in various locations
-            var searchPaths = new[]
+            var safeFileName = PatternPathGuard.SanitizeFileName(fileName);
+            if (safeFileName == null)
             {
-                Path.Combine("patterns", "Custom", fileName),
-                Path.Combine("patterns", "Community", fileName),
-                Path.Combine("patterns", "Small_Ships", fileName),
-                Path.Combine("patterns", "Large_Ships", fileName),
-                Path.Combine("patterns", fileName)
-            };
+                return BadRequest(new { error = "Invalid file name" });
+            }
 
-            foreach (var searchPath in searchPaths)
+            // Try to find the file in the known pattern locations
+            var patternsRoot = Path.Combine(Directory.GetCurrentDirectory(), "patterns");
+            var searchPaths = new string?[] { "Custom", "Community", "Small_Ships", "Large_Ships", null }
+                .Select(subdirectory => PatternPathGuard.ResolveUnderRoot(patternsRoot, safeFileName, subdirectory))
+                .Where(path => path != null);
+
+            foreach (var fullPath in searchPaths)
             {
-                var fullPath = Path.Combine(Directory.GetCurrentDirectory(), searchPath);
                 if (System.IO.File.Exists(fullPath))
                 {
-                    var json = await System.IO.File.ReadAllTextAsync(fullPath);
+                    var json = await System.IO.File.ReadAllTextAsync(fullPath!);
                     var patternFile = JsonSerializer.Deserialize<PatternFileDefinition>(json, new JsonSerializerOptions
                     {
                         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -280,7 +296,7 @@ public class PatternEditorController : ControllerBase
                 }
             }
 
-            return NotFound(new { error = $"Pattern file '{fileName}' not found" });
+            return NotFound(new { error = $"Pattern file '{safeFileName}' not found" });
         }
         catch (Exception ex)
         {

--- a/src/EDButtkicker/Controllers/PatternFilesApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternFilesApiController.cs
@@ -10,8 +10,13 @@ namespace EDButtkicker.Controllers;
 [Route("api/[controller]")]
 public class PatternFilesController : ControllerBase
 {
+    private static readonly string[] DeletableSubdirectories = { "imports", "exports", "Custom" };
+    private static readonly string?[] SystemSubdirectories = { "Community", "Small_Ships", "Large_Ships", null };
+
     private readonly ILogger<PatternFilesController> _logger;
     private readonly PatternFileService _patternFileService;
+
+    private static string PatternsRoot => Path.Combine(Directory.GetCurrentDirectory(), "patterns");
 
     public PatternFilesController(
         ILogger<PatternFilesController> logger,
@@ -254,6 +259,12 @@ public class PatternFilesController : ControllerBase
                 return BadRequest(new { error = "Only JSON files are supported" });
             }
 
+            var safeFileName = PatternPathGuard.SanitizeFileName(file.FileName, requireJsonExtension: true);
+            if (safeFileName == null)
+            {
+                return BadRequest(new { error = "Invalid file name" });
+            }
+
             // Save to temporary location first
             var tempPath = Path.GetTempFileName();
             using (var stream = new FileStream(tempPath, FileMode.Create))
@@ -262,16 +273,16 @@ public class PatternFilesController : ControllerBase
             }
 
             // Import the file
-            var success = await _patternFileService.ImportPatternFileAsync(tempPath, file.FileName);
-            
+            var success = await _patternFileService.ImportPatternFileAsync(tempPath, safeFileName);
+
             // Clean up temp file
             System.IO.File.Delete(tempPath);
 
             if (success)
             {
-                return Ok(new { 
-                    message = $"Pattern file '{file.FileName}' imported successfully",
-                    fileName = file.FileName,
+                return Ok(new {
+                    message = $"Pattern file '{safeFileName}' imported successfully",
+                    fileName = safeFileName,
                     fileSize = file.Length
                 });
             }
@@ -292,15 +303,20 @@ public class PatternFilesController : ControllerBase
     {
         try
         {
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "patterns", "exports", fileName);
-            
+            var safeFileName = PatternPathGuard.SanitizeFileName(fileName);
+            var filePath = PatternPathGuard.ResolveUnderRoot(PatternsRoot, safeFileName, "exports");
+            if (safeFileName == null || filePath == null)
+            {
+                return BadRequest(new { error = "Invalid file name" });
+            }
+
             if (!System.IO.File.Exists(filePath))
             {
-                return NotFound(new { error = $"File not found: {fileName}" });
+                return NotFound(new { error = $"File not found: {safeFileName}" });
             }
 
             var fileBytes = System.IO.File.ReadAllBytes(filePath);
-            return base.File(fileBytes, "application/json", fileName);
+            return base.File(fileBytes, "application/json", safeFileName);
         }
         catch (Exception ex)
         {
@@ -314,25 +330,33 @@ public class PatternFilesController : ControllerBase
     {
         try
         {
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "patterns", fileName);
-            
-            if (!System.IO.File.Exists(filePath))
+            var safeFileName = PatternPathGuard.SanitizeFileName(fileName);
+            if (safeFileName == null)
             {
-                return NotFound(new { error = $"File not found: {fileName}" });
+                return BadRequest(new { error = "Invalid file name" });
             }
 
-            // Only allow deletion of files in certain directories for safety
-            var relativePath = Path.GetRelativePath(Path.Combine(Directory.GetCurrentDirectory(), "patterns"), filePath);
-            if (relativePath.StartsWith("..") || 
-                (!relativePath.StartsWith("imports") && 
-                 !relativePath.StartsWith("exports") && 
-                 !relativePath.StartsWith("custom", StringComparison.OrdinalIgnoreCase)))
+            // Only files in these directories may be deleted; the caller never picks the directory.
+            foreach (var subdirectory in DeletableSubdirectories)
             {
-                return BadRequest(new { error = "Cannot delete system pattern files" });
+                var candidate = PatternPathGuard.ResolveUnderRoot(PatternsRoot, safeFileName, subdirectory);
+                if (candidate != null && System.IO.File.Exists(candidate))
+                {
+                    System.IO.File.Delete(candidate);
+                    return Ok(new { message = $"Pattern file '{safeFileName}' deleted successfully" });
+                }
             }
 
-            System.IO.File.Delete(filePath);
-            return Ok(new { message = $"Pattern file '{fileName}' deleted successfully" });
+            foreach (var subdirectory in SystemSubdirectories)
+            {
+                var candidate = PatternPathGuard.ResolveUnderRoot(PatternsRoot, safeFileName, subdirectory);
+                if (candidate != null && System.IO.File.Exists(candidate))
+                {
+                    return BadRequest(new { error = "Cannot delete system pattern files" });
+                }
+            }
+
+            return NotFound(new { error = $"File not found: {safeFileName}" });
         }
         catch (Exception ex)
         {

--- a/src/EDButtkicker/Services/PatternFileService.cs
+++ b/src/EDButtkicker/Services/PatternFileService.cs
@@ -331,8 +331,13 @@ public class PatternFileService : IPatternCatalog
             }
 
             var fileName = targetFileName ?? Path.GetFileName(sourceFilePath);
-            var targetPath = Path.Combine(_patternsPath, "imports", fileName);
-            
+            var targetPath = PatternPathGuard.ResolveUnderRoot(_patternsPath, fileName, "imports");
+            if (targetPath == null)
+            {
+                _logger.LogWarning("Rejected pattern import: unsafe target file name");
+                return false;
+            }
+
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
             File.Copy(sourceFilePath, targetPath, overwrite: true);
             

--- a/src/EDButtkicker/Services/PatternPathGuard.cs
+++ b/src/EDButtkicker/Services/PatternPathGuard.cs
@@ -1,0 +1,148 @@
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Single place where caller-supplied pattern file names are turned into filesystem paths.
+/// A name is only ever a single file name; the directory always comes from the server.
+/// </summary>
+public static class PatternPathGuard
+{
+    private const int MaxDecodePasses = 4;
+
+    /// <summary>Subdirectories the pattern APIs are allowed to address. Never caller-controlled.</summary>
+    private static readonly HashSet<string> AllowedSubdirectories = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Custom",
+        "Community",
+        "Small_Ships",
+        "Large_Ships",
+        "patterns",
+        "imports",
+        "exports"
+    };
+
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Returns the sanitized single file name, or null when the value carries any directory
+    /// component, drive/stream qualifier, or percent-encoded variant of one.
+    /// </summary>
+    public static string? SanitizeFileName(string? name, bool requireJsonExtension = false)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        var decoded = name;
+        for (var pass = 0; pass < MaxDecodePasses; pass++)
+        {
+            string next;
+            try
+            {
+                next = Uri.UnescapeDataString(decoded);
+            }
+            catch (UriFormatException)
+            {
+                return null;
+            }
+
+            if (string.Equals(next, decoded, StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            decoded = next;
+        }
+
+        if (string.IsNullOrWhiteSpace(decoded))
+        {
+            return null;
+        }
+
+        // '/' and '\' are both rejected on every platform: a Windows-shaped path must not become a
+        // legal Linux file name just because the alt separator differs there.
+        if (decoded.IndexOf('/') >= 0 ||
+            decoded.IndexOf('\\') >= 0 ||
+            decoded.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            decoded.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+        {
+            return null;
+        }
+
+        if (decoded.IndexOf(':') >= 0)
+        {
+            return null;
+        }
+
+        if (decoded == "." || decoded == "..")
+        {
+            return null;
+        }
+
+        if (decoded.Any(char.IsControl))
+        {
+            return null;
+        }
+
+        if (Path.IsPathRooted(decoded))
+        {
+            return null;
+        }
+
+        var fileName = Path.GetFileName(decoded);
+        if (!string.Equals(fileName, decoded, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (requireJsonExtension && !fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return fileName;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="fileName"/> inside <paramref name="rootDirectory"/> (optionally one
+    /// allow-listed subdirectory deep). Returns null when the name is rejected or the canonical path
+    /// would land outside the root.
+    /// </summary>
+    public static string? ResolveUnderRoot(
+        string rootDirectory,
+        string? fileName,
+        string? relativeSubdirectory = null,
+        bool requireJsonExtension = false)
+    {
+        if (string.IsNullOrWhiteSpace(rootDirectory))
+        {
+            return null;
+        }
+
+        var safeName = SanitizeFileName(fileName, requireJsonExtension);
+        if (safeName == null)
+        {
+            return null;
+        }
+
+        if (relativeSubdirectory != null && !AllowedSubdirectories.Contains(relativeSubdirectory))
+        {
+            return null;
+        }
+
+        var rootFull = Path.GetFullPath(rootDirectory);
+        var combined = relativeSubdirectory == null
+            ? Path.Combine(rootFull, safeName)
+            : Path.Combine(rootFull, relativeSubdirectory, safeName);
+
+        var candidate = Path.GetFullPath(combined);
+
+        var rootPrefix = rootFull.EndsWith(Path.DirectorySeparatorChar)
+            ? rootFull
+            : rootFull + Path.DirectorySeparatorChar;
+
+        // The trailing separator is what keeps "/patterns" from matching "/patterns-evil".
+        return candidate.StartsWith(rootPrefix, PathComparison) ? candidate : null;
+    }
+}

--- a/tests/EDButtkicker.Tests/PatternPathGuardTests.cs
+++ b/tests/EDButtkicker.Tests/PatternPathGuardTests.cs
@@ -1,0 +1,171 @@
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The path guard is the only thing standing between a caller-supplied pattern file name and a
+/// filesystem path, so every traversal shape the HTTP surface can carry is pinned here.
+/// </summary>
+public class PatternPathGuardTests
+{
+    [Theory]
+    [InlineData("../secret.json")]
+    [InlineData("..\\secret.json")]
+    [InlineData("foo/../../secret.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("C:/Windows/win.ini")]
+    [InlineData("\\\\server\\share\\file.json")]
+    [InlineData("foo.json/../../x")]
+    [InlineData("%2e%2e/%2e%2e/secret.json")]
+    [InlineData("%2e%2e%2fsecret.json")]
+    [InlineData("%2e%2e%5csecret.json")]
+    [InlineData("%2fetc%2fpasswd")]
+    [InlineData("%252e%252e%252fsecret.json")]
+    [InlineData("..%252f..%252fsecret.json")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("....//....")]
+    [InlineData("C:pack.json")]
+    [InlineData("pack.json:stream")]
+    [InlineData("patterns\\Custom\\pack.json")]
+    [InlineData(null)]
+    public void SanitizeFileName_RejectsTraversalShapes(string? name)
+    {
+        Assert.Null(PatternPathGuard.SanitizeFileName(name));
+    }
+
+    [Theory]
+    [InlineData("my-pack.json")]
+    [InlineData("Author_Pack_20260101_010101.json")]
+    [InlineData("pack.with.dots.json")]
+    public void SanitizeFileName_AcceptsPlainFileNames(string name)
+    {
+        Assert.Equal(name, PatternPathGuard.SanitizeFileName(name));
+    }
+
+    [Fact]
+    public void SanitizeFileName_DecodesBeforeReturning()
+    {
+        Assert.Equal("my pack.json", PatternPathGuard.SanitizeFileName("my%20pack.json"));
+    }
+
+    [Fact]
+    public void SanitizeFileName_CanRequireJsonExtension()
+    {
+        Assert.Null(PatternPathGuard.SanitizeFileName("pack.exe", requireJsonExtension: true));
+        Assert.Equal("pack.JSON", PatternPathGuard.SanitizeFileName("pack.JSON", requireJsonExtension: true));
+    }
+
+    [Theory]
+    [InlineData("../secret.json")]
+    [InlineData("..\\secret.json")]
+    [InlineData("foo/../../secret.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("C:/Windows/win.ini")]
+    [InlineData("\\\\server\\share\\file.json")]
+    [InlineData("foo.json/../../x")]
+    [InlineData("%2e%2e/%2e%2e/secret.json")]
+    [InlineData("%2e%2e%2fsecret.json")]
+    [InlineData("%2e%2e%5csecret.json")]
+    [InlineData("%2fetc%2fpasswd")]
+    [InlineData("%252e%252e%252fsecret.json")]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("....//....")]
+    [InlineData(null)]
+    public void ResolveUnderRoot_RejectsTraversalShapes(string? name)
+    {
+        using var root = new TempDirectory();
+
+        Assert.Null(PatternPathGuard.ResolveUnderRoot(root.Path, name));
+        Assert.Null(PatternPathGuard.ResolveUnderRoot(root.Path, name, "Custom"));
+    }
+
+    [Theory]
+    [InlineData("my-pack.json")]
+    [InlineData("Author_Pack_20260101_010101.json")]
+    public void ResolveUnderRoot_PlacesAcceptedNamesUnderTheRoot(string name)
+    {
+        using var root = new TempDirectory();
+
+        var resolved = PatternPathGuard.ResolveUnderRoot(root.Path, name);
+
+        Assert.Equal(Path.Combine(Path.GetFullPath(root.Path), name), resolved);
+    }
+
+    [Fact]
+    public void ResolveUnderRoot_PlacesAcceptedNamesUnderTheAllowedSubdirectory()
+    {
+        using var root = new TempDirectory();
+
+        var resolved = PatternPathGuard.ResolveUnderRoot(root.Path, "my-pack.json", "imports");
+
+        Assert.Equal(Path.Combine(Path.GetFullPath(root.Path), "imports", "my-pack.json"), resolved);
+    }
+
+    [Theory]
+    [InlineData("../evil")]
+    [InlineData("Custom/../..")]
+    [InlineData("unknown")]
+    [InlineData("")]
+    public void ResolveUnderRoot_RejectsSubdirectoriesOutsideTheAllowList(string subdirectory)
+    {
+        using var root = new TempDirectory();
+
+        Assert.Null(PatternPathGuard.ResolveUnderRoot(root.Path, "my-pack.json", subdirectory));
+    }
+
+    [Fact]
+    public void ResolveUnderRoot_DoesNotTreatASiblingPrefixDirectoryAsInside()
+    {
+        using var parent = new TempDirectory();
+        var root = Path.Combine(parent.Path, "patterns");
+        var sibling = Path.Combine(parent.Path, "patterns-evil");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(sibling);
+
+        var resolved = PatternPathGuard.ResolveUnderRoot(root, "my-pack.json");
+
+        Assert.NotNull(resolved);
+        Assert.StartsWith(Path.GetFullPath(root) + Path.DirectorySeparatorChar, resolved);
+        Assert.False(resolved!.StartsWith(Path.GetFullPath(sibling), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ResolveUnderRoot_RejectsAnEmptyRoot()
+    {
+        Assert.Null(PatternPathGuard.ResolveUnderRoot("", "my-pack.json"));
+    }
+}
+
+/// <summary>A scratch directory that removes itself, so no test writes into the repo tree.</summary>
+internal sealed class TempDirectory : IDisposable
+{
+    public TempDirectory()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "edbk-guard-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+}

--- a/tests/EDButtkicker.Tests/PatternPathTraversalApiTests.cs
+++ b/tests/EDButtkicker.Tests/PatternPathTraversalApiTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using EDButtkicker.Controllers;
+using EDButtkicker.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The pattern file APIs take a caller-supplied name straight from a request. These pin that a
+/// traversal name is refused before it ever reaches the filesystem, on the same pipeline Program
+/// runs. Nothing here touches audio hardware or binds a port.
+/// </summary>
+public class PatternPathTraversalApiTests : IClassFixture<WebUiTestServerFixture>
+{
+    private const string ValidPatternJson = """
+    {
+      "metadata": { "name": "Guard Test", "version": "1.0.0", "author": "Tester", "description": "d", "tags": [], "created": "2026-01-01T00:00:00Z", "compatibility": "1.0.0" },
+      "ships": { "sidewinder": { "displayName": "Sidewinder", "class": "small", "role": "combat", "events": {} } }
+    }
+    """;
+
+    private readonly WebUiTestServerFixture _fixture;
+
+    public PatternPathTraversalApiTests(WebUiTestServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("../escape.json")]
+    [InlineData("..%2fescape.json")]
+    [InlineData("%2e%2e%2fescape.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("..\\escape.json")]
+    [InlineData("C:\\Windows\\win.ini")]
+    public async Task SavePattern_WithTraversalFileName_IsRejected(string fileName)
+    {
+        var body = SaveRequestBody(fileName);
+
+        var response = await _fixture.Client.PostAsync(
+            "/api/PatternEditor/save", new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.False(File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "patterns", "escape.json")));
+        Assert.False(File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "escape.json")));
+    }
+
+    [Theory]
+    [InlineData("..%2f..%2fetc%2fpasswd")]
+    [InlineData("%2e%2e%2fsecret.json")]
+    [InlineData("%2e%2e%5csecret.json")]
+    [InlineData("%252e%252e%252fsecret.json")]
+    public async Task LoadPatternForEditing_WithTraversalFileName_IsRejected(string fileName)
+    {
+        var response = await _fixture.Client.GetAsync($"/api/PatternEditor/load/{fileName}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveThenLoad_WithASanitizedName_RoundTrips()
+    {
+        var fileName = "edbk-guard-roundtrip.json";
+        var savedPath = Path.Combine(Directory.GetCurrentDirectory(), "patterns", "Custom", fileName);
+        var body = SaveRequestBody(fileName);
+
+        try
+        {
+            var save = await _fixture.Client.PostAsync(
+                "/api/PatternEditor/save", new StringContent(body, Encoding.UTF8, "application/json"));
+
+            Assert.True(save.IsSuccessStatusCode, $"save returned {(int)save.StatusCode}: {await save.Content.ReadAsStringAsync()}");
+            Assert.True(File.Exists(savedPath));
+
+            var load = await _fixture.Client.GetAsync($"/api/PatternEditor/load/{fileName}");
+
+            Assert.True(load.IsSuccessStatusCode, $"load returned {(int)load.StatusCode}: {await load.Content.ReadAsStringAsync()}");
+            Assert.Contains("Guard Test", await load.Content.ReadAsStringAsync());
+        }
+        finally
+        {
+            if (File.Exists(savedPath))
+            {
+                File.Delete(savedPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("../x.json")]
+    [InlineData("..\\x.json")]
+    [InlineData("%2e%2e%2fx.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("exports/../../x.json")]
+    public void DownloadPatternFile_WithTraversalFileName_IsRejected(string fileName)
+    {
+        var controller = _fixture.Services.GetRequiredService<PatternFilesController>();
+
+        var result = controller.DownloadPatternFile(fileName);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Theory]
+    [InlineData("../x.json")]
+    [InlineData("..\\x.json")]
+    [InlineData("%2e%2e%2fx.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("imports/../../x.json")]
+    public void DeletePatternFile_WithTraversalFileName_IsRejected(string fileName)
+    {
+        var controller = _fixture.Services.GetRequiredService<PatternFilesController>();
+
+        var result = controller.DeletePatternFile(fileName);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void DeletePatternFile_RemovesAnImportedFileButNotASystemFile()
+    {
+        var controller = _fixture.Services.GetRequiredService<PatternFilesController>();
+        var patternsRoot = Path.Combine(Directory.GetCurrentDirectory(), "patterns");
+        var importPath = Path.Combine(patternsRoot, "imports", "edbk-guard-delete.json");
+        var systemPath = Path.Combine(patternsRoot, "Community", "edbk-guard-system.json");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(importPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(systemPath)!);
+        File.WriteAllText(importPath, ValidPatternJson);
+        File.WriteAllText(systemPath, ValidPatternJson);
+
+        try
+        {
+            Assert.IsType<OkObjectResult>(controller.DeletePatternFile("edbk-guard-delete.json"));
+            Assert.False(File.Exists(importPath));
+
+            Assert.IsType<BadRequestObjectResult>(controller.DeletePatternFile("edbk-guard-system.json"));
+            Assert.True(File.Exists(systemPath));
+
+            Assert.IsType<NotFoundObjectResult>(controller.DeletePatternFile("edbk-guard-missing.json"));
+        }
+        finally
+        {
+            foreach (var path in new[] { importPath, systemPath })
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ImportPatternFileAsync_RejectsATraversalTargetName()
+    {
+        var service = _fixture.Services.GetRequiredService<PatternFileService>();
+        var patternsPath = PatternsPathOf(service);
+        var sourcePath = Path.Combine(Path.GetTempPath(), $"edbk-guard-source-{Guid.NewGuid():N}.json");
+        var escapedPath = Path.GetFullPath(Path.Combine(patternsPath, "imports", "..", "..", "edbk-guard-escaped.json"));
+        var importedPath = Path.Combine(patternsPath, "imports", "edbk-guard-import.json");
+
+        await File.WriteAllTextAsync(sourcePath, ValidPatternJson);
+
+        try
+        {
+            Assert.False(await service.ImportPatternFileAsync(sourcePath, "../../edbk-guard-escaped.json"));
+            Assert.False(await service.ImportPatternFileAsync(sourcePath, "%2e%2e%2fedbk-guard-escaped.json"));
+            Assert.False(File.Exists(escapedPath));
+
+            // The same source under a plain name still imports, so the rejection is about the name.
+            Assert.True(await service.ImportPatternFileAsync(sourcePath, "edbk-guard-import.json"));
+            Assert.True(File.Exists(importedPath));
+        }
+        finally
+        {
+            foreach (var path in new[] { sourcePath, importedPath, escapedPath })
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+
+    private static string SaveRequestBody(string fileName) =>
+        "{\"patternFile\":{\"metadata\":{\"name\":\"Guard Test\",\"author\":\"Tester\"}},\"fileName\":\"" +
+        fileName.Replace("\\", "\\\\") +
+        "\",\"saveToCustom\":true}";
+
+    private static string PatternsPathOf(PatternFileService service)
+    {
+        var field = typeof(PatternFileService)
+            .GetField("_patternsPath", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+
+        return (string)field!.GetValue(service)!;
+    }
+}


### PR DESCRIPTION
## Summary
Pattern save, load, import, download, and delete no longer combine a caller-controlled name into a filesystem path.

- `PatternPathGuard` accepts only a single sanitized file name (URL-decoded, no separators, no drive/stream qualifier).
- Resolved paths are canonicalized with `Path.GetFullPath` and must stay under the patterns root plus a directory separator, so `/patterns` does not match `/patterns-evil`.
- Allowed subdirectories (`Custom`, `imports`, `exports`, ship packs) are server-chosen, never taken from the request.
- Traversal tests cover `..`, rooted paths, alternate separators, drive paths, and URL-encoded / double-encoded variants.

## Test plan
- [x] `dotnet test EDButtkicker.sln --configuration Release` — 202 passed locally (Linux, no hardware)
- [ ] GitHub Actions CI (unit tests + Windows package jobs)

Does not claim Windows/ButtKicker hardware validation.

Closes #14
