### PR TITLE
test: add hardware-independent core regression coverage

### DIFF
--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -21,6 +21,10 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton(appSettings);
 
+        // The clock is injected so time-dependent behaviour (event rate limits) is deterministic
+        // in tests; the process always runs on the system clock.
+        services.AddSingleton(TimeProvider.System);
+
         // Add core services
         services.AddSingleton<AudioEngineService>();
         services.AddSingleton<PatternSequencer>();

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -132,7 +132,11 @@ public class AudioEngineService : IDisposable
         }
     }
 
-    public Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
+    /// <summary>
+    /// Plays one pattern. Virtual so tests can observe what would be played without opening a device;
+    /// when no audio device is available this degrades to a no-op instead of throwing.
+    /// </summary>
+    public virtual Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
     {
         if (!EnsureInitialized())
         {

--- a/src/EDButtkicker/Services/EventMappingService.cs
+++ b/src/EDButtkicker/Services/EventMappingService.cs
@@ -13,19 +13,21 @@ public class EventMappingService : IJournalEventAudioSink
     private readonly PatternSequencer _patternSequencer;
     private readonly ContextualIntelligenceService _contextualIntelligence;
     private EventMappingsConfig _eventMappings;
-    private readonly ConcurrentDictionary<string, DateTime> _lastEventTimes = new();
+    private readonly EventRateLimiter _rateLimiter;
     private readonly ConcurrentDictionary<string, int> _eventCounts = new();
 
     public EventMappingService(
         ILogger<EventMappingService> logger,
         AudioEngineService audioEngine,
         PatternSequencer patternSequencer,
-        ContextualIntelligenceService contextualIntelligence)
+        ContextualIntelligenceService contextualIntelligence,
+        TimeProvider timeProvider)
     {
         _logger = logger;
         _audioEngine = audioEngine;
         _patternSequencer = patternSequencer;
         _contextualIntelligence = contextualIntelligence;
+        _rateLimiter = new EventRateLimiter(timeProvider);
         _eventMappings = EventMappingsConfig.GetDefault();
 
         // No audio device work here: the engine opens itself on first playback so that building
@@ -69,17 +71,16 @@ public class EventMappingService : IJournalEventAudioSink
                 return;
             }
 
-            // Check for rate limiting to prevent audio spam
-            if (ShouldRateLimit(eventType))
+            // Check for rate limiting to prevent audio spam. Acquiring also records the acceptance,
+            // so the next occurrence inside the window is refused.
+            if (!_rateLimiter.TryAcquire(eventType))
             {
                 _logger.LogDebug("Rate limiting event: {EventType}", eventType);
                 return;
             }
 
             _logger.LogInformation("Processing mapped event: {EventType}", eventType);
-            
-            // Track event timing (thread-safe)
-            _lastEventTimes[eventType] = DateTime.UtcNow;
+
             _eventCounts.AddOrUpdate(eventType, 1, (key, value) => value + 1);
 
             // Apply any event-specific modifications to the pattern
@@ -124,32 +125,6 @@ public class EventMappingService : IJournalEventAudioSink
     {
         // Deep clone first, then adjust the clone only - the stored mapping keeps its defaults.
         return EventPatternFactory.CreatePatternForEvent(basePattern, journalEvent, _logger);
-    }
-
-    private bool ShouldRateLimit(string eventType)
-    {
-        // Define rate limits for different event types
-        var rateLimits = new Dictionary<string, TimeSpan>
-        {
-            ["HullDamage"] = TimeSpan.FromMilliseconds(500), // Max once per 500ms
-            ["ShipTargeted"] = TimeSpan.FromMilliseconds(1000), // Max once per second
-            ["FuelScoop"] = TimeSpan.FromSeconds(2), // Max once per 2 seconds
-            ["HeatWarning"] = TimeSpan.FromSeconds(1), // Max once per second
-            ["HeatDamage"] = TimeSpan.FromMilliseconds(800), // Max once per 800ms
-            ["UnderAttack"] = TimeSpan.FromMilliseconds(300), // Max once per 300ms
-            ["Touchdown"] = TimeSpan.FromSeconds(3), // Max once per 3 seconds (prevent spam on bouncy landings)
-            ["Liftoff"] = TimeSpan.FromSeconds(3), // Max once per 3 seconds
-            ["ShieldDown"] = TimeSpan.FromSeconds(2), // Max once per 2 seconds
-            ["ShieldsUp"] = TimeSpan.FromSeconds(2) // Max once per 2 seconds
-        };
-
-        if (!rateLimits.TryGetValue(eventType, out var minInterval))
-            return false; // No rate limiting for this event type
-
-        if (!_lastEventTimes.TryGetValue(eventType, out var lastTime))
-            return false; // First occurrence
-
-        return DateTime.UtcNow - lastTime < minInterval;
     }
 
     private void LogUnmappedEvent(string eventType)
@@ -221,7 +196,7 @@ public class EventMappingService : IJournalEventAudioSink
     public void ResetStatistics()
     {
         _eventCounts.Clear();
-        _lastEventTimes.Clear();
+        _rateLimiter.Reset();
         _logger.LogInformation("Event statistics reset");
     }
 

--- a/src/EDButtkicker/Services/EventRateLimiter.cs
+++ b/src/EDButtkicker/Services/EventRateLimiter.cs
@@ -1,0 +1,82 @@
+using System.Collections.Concurrent;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Per-event-type rate limit that keeps bursty journal events (hull damage, being under attack)
+/// from flooding the transducer. Time comes from an injected <see cref="TimeProvider"/> so the
+/// windows are deterministic in tests instead of depending on wall clock timing.
+/// </summary>
+public sealed class EventRateLimiter
+{
+    /// <summary>Minimum spacing between two accepted occurrences of the same event type.</summary>
+    public static readonly IReadOnlyDictionary<string, TimeSpan> DefaultLimits =
+        new Dictionary<string, TimeSpan>
+        {
+            ["HullDamage"] = TimeSpan.FromMilliseconds(500),
+            ["ShipTargeted"] = TimeSpan.FromMilliseconds(1000),
+            ["FuelScoop"] = TimeSpan.FromSeconds(2),
+            ["HeatWarning"] = TimeSpan.FromSeconds(1),
+            ["HeatDamage"] = TimeSpan.FromMilliseconds(800),
+            ["UnderAttack"] = TimeSpan.FromMilliseconds(300),
+            ["Touchdown"] = TimeSpan.FromSeconds(3),
+            ["Liftoff"] = TimeSpan.FromSeconds(3),
+            ["ShieldDown"] = TimeSpan.FromSeconds(2),
+            ["ShieldsUp"] = TimeSpan.FromSeconds(2)
+        };
+
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _lastAccepted = new();
+    private readonly IReadOnlyDictionary<string, TimeSpan> _limits;
+    private readonly TimeProvider _timeProvider;
+
+    public EventRateLimiter(TimeProvider? timeProvider = null, IReadOnlyDictionary<string, TimeSpan>? limits = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _limits = limits ?? DefaultLimits;
+    }
+
+    /// <summary>
+    /// True when <paramref name="eventType"/> may be played now; the acceptance is recorded so the
+    /// next occurrence inside the window is refused. Event types without a limit are always accepted.
+    /// </summary>
+    public bool TryAcquire(string eventType)
+    {
+        if (string.IsNullOrEmpty(eventType))
+            return false;
+
+        var now = _timeProvider.GetUtcNow();
+
+        if (!_limits.TryGetValue(eventType, out var minInterval))
+        {
+            _lastAccepted[eventType] = now;
+            return true;
+        }
+
+        // AddOrUpdate keeps the check-and-record atomic, so two threads racing on the same event
+        // type can never both be accepted inside one window.
+        var accepted = false;
+        _lastAccepted.AddOrUpdate(
+            eventType,
+            _ =>
+            {
+                accepted = true;
+                return now;
+            },
+            (_, last) =>
+            {
+                if (now - last < minInterval)
+                    return last;
+
+                accepted = true;
+                return now;
+            });
+
+        return accepted;
+    }
+
+    /// <summary>Last time an occurrence of <paramref name="eventType"/> was accepted, if any.</summary>
+    public DateTimeOffset? LastAccepted(string eventType) =>
+        _lastAccepted.TryGetValue(eventType, out var last) ? last : null;
+
+    public void Reset() => _lastAccepted.Clear();
+}

--- a/src/EDButtkicker/Services/JournalEventParser.cs
+++ b/src/EDButtkicker/Services/JournalEventParser.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Turns one journal line into a <see cref="JournalEvent"/>. Elite writes one JSON object per line,
+/// but a line can still be blank, truncated by an editor, or something other than an object - none of
+/// which may tear down monitoring, so parsing failures are reported as false rather than thrown.
+/// Free of any file or audio dependency so the parse contract can be exercised directly in tests.
+/// </summary>
+public static class JournalEventParser
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Parses a single journal line. Returns false (and leaves <paramref name="journalEvent"/> null)
+    /// for blank lines, malformed JSON, and JSON that is not an object.
+    /// </summary>
+    public static bool TryParse(string? line, out JournalEvent? journalEvent, ILogger? logger = null)
+    {
+        journalEvent = null;
+
+        if (string.IsNullOrWhiteSpace(line))
+            return false;
+
+        try
+        {
+            journalEvent = JsonSerializer.Deserialize<JournalEvent>(line, Options);
+        }
+        catch (JsonException ex)
+        {
+            logger?.LogWarning("Failed to parse journal line: {Error}", ex.Message);
+            logger?.LogDebug("Problematic line: {Line}", line);
+            return false;
+        }
+
+        return journalEvent != null;
+    }
+}

--- a/src/EDButtkicker/Services/JournalMonitorService.cs
+++ b/src/EDButtkicker/Services/JournalMonitorService.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
 using EDButtkicker.Configuration;
 using EDButtkicker.Models;
 
@@ -200,15 +199,8 @@ public class JournalMonitorService : BackgroundService
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(line))
-                return;
-
-            var journalEvent = JsonSerializer.Deserialize<JournalEvent>(line, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
-
-            if (journalEvent == null)
+            // A malformed or truncated line is skipped and logged by the parser; monitoring stays up.
+            if (!JournalEventParser.TryParse(line, out var journalEvent, _logger) || journalEvent == null)
                 return;
 
             _logger.LogDebug("Journal Event: {Event} at {Timestamp}", journalEvent.Event, journalEvent.Timestamp);
@@ -218,11 +210,6 @@ public class JournalMonitorService : BackgroundService
 
             // History -> ship state -> ship pattern selection -> context + audio
             await _pipeline.ProcessAsync(journalEvent);
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogWarning("Failed to parse journal line: {Error}", ex.Message);
-            _logger.LogDebug("Problematic line: {Line}", line);
         }
         catch (Exception ex)
         {

--- a/src/EDButtkicker/Services/UserSettingsService.cs
+++ b/src/EDButtkicker/Services/UserSettingsService.cs
@@ -12,15 +12,29 @@ public class UserSettingsService
     private readonly string _gameContextPath;
     private readonly JsonSerializerOptions _jsonOptions;
 
+    /// <summary>Per-user settings directory used by the running application.</summary>
+    public static string DefaultSettingsDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EDButtkicker");
+
     public UserSettingsService(ILogger<UserSettingsService> logger)
+        : this(logger, DefaultSettingsDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Overload that puts the settings files under an explicit directory, so tests can round trip
+    /// settings through a temporary directory instead of the real per-user profile.
+    /// </summary>
+    public UserSettingsService(ILogger<UserSettingsService> logger, string settingsDirectory)
     {
         _logger = logger;
-        
-        // Create user-specific settings directory
-        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var settingsDir = Path.Combine(appDataPath, "EDButtkicker");
+
+        if (string.IsNullOrWhiteSpace(settingsDirectory))
+            throw new ArgumentException("Settings directory must be provided", nameof(settingsDirectory));
+
+        var settingsDir = settingsDirectory;
         Directory.CreateDirectory(settingsDir);
-        
+
         _userSettingsPath = Path.Combine(settingsDir, "user-settings.json");
         _gameContextPath = Path.Combine(settingsDir, "game-context.json");
         

--- a/tests/EDButtkicker.Tests/EventMappingServiceTests.cs
+++ b/tests/EDButtkicker.Tests/EventMappingServiceTests.cs
@@ -1,0 +1,300 @@
+using EDButtkicker.Configuration;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Event mapping decisions - which journal events reach playback, which are dropped, and how the
+/// per-event rate limit behaves over time. The audio engine is subclassed to record what would be
+/// played, so no device is opened; the clock is hand-advanced, so no test waits on real time.
+/// </summary>
+public class EventMappingServiceTests : IDisposable
+{
+    private const string LimitedEvent = "UnderAttack";   // 300ms window
+    private const string UnlimitedEvent = "Docked";      // no window
+
+    private readonly TempDirectory _settingsDir = new("edbk-mapping");
+    private readonly ManualTimeProvider _clock = new();
+    private readonly RecordingAudioEngine _audio;
+    private readonly ContextualIntelligenceService _contextualIntelligence;
+    private readonly EventMappingService _service;
+
+    public EventMappingServiceTests()
+    {
+        var settings = new AppSettings();
+        _audio = new RecordingAudioEngine(settings);
+        var userSettings = new UserSettingsService(NullLogger<UserSettingsService>.Instance, _settingsDir.Path);
+        _contextualIntelligence = new ContextualIntelligenceService(
+            NullLogger<ContextualIntelligenceService>.Instance, settings, userSettings);
+        var sequencer = new PatternSequencer(NullLogger<PatternSequencer>.Instance, _audio, _contextualIntelligence);
+
+        _service = new EventMappingService(
+            NullLogger<EventMappingService>.Instance, _audio, sequencer, _contextualIntelligence, _clock);
+    }
+
+    [Fact]
+    public async Task MappedEvent_IsPlayedWithItsMappedPattern()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump", intensity: 55)));
+
+        await _service.ProcessEvent(Event(UnlimitedEvent));
+
+        var played = Assert.Single(_audio.Played);
+        Assert.Equal("Docking Thump", played.Pattern.Name);
+    }
+
+    [Fact]
+    public async Task UnmappedEvent_IsNotPlayed()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump")));
+
+        await _service.ProcessEvent(Event("SomethingNobodyMapped"));
+
+        Assert.Empty(_audio.Played);
+    }
+
+    [Fact]
+    public async Task DisabledMapping_IsNotPlayed()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump", enabled: false)));
+
+        await _service.ProcessEvent(Event(UnlimitedEvent));
+
+        Assert.Empty(_audio.Played);
+    }
+
+    [Fact]
+    public async Task EventWithoutAName_IsIgnored()
+    {
+        await _service.ProcessEvent(new JournalEvent { Event = string.Empty });
+
+        Assert.Empty(_audio.Played);
+    }
+
+    [Fact]
+    public async Task RepeatedEventInsideTheRateLimitWindow_IsPlayedOnce()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(LimitedEvent, "Incoming Fire")));
+
+        await _service.ProcessEvent(Event(LimitedEvent));
+
+        _clock.Advance(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessEvent(Event(LimitedEvent));
+        _clock.Advance(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessEvent(Event(LimitedEvent));
+
+        Assert.Single(_audio.Played);
+
+        // 300ms after the accepted event the window has passed.
+        _clock.Advance(TimeSpan.FromMilliseconds(100));
+        await _service.ProcessEvent(Event(LimitedEvent));
+
+        Assert.Equal(2, _audio.Played.Count);
+    }
+
+    [Fact]
+    public async Task UnlimitedEventType_IsPlayedEveryTime()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump")));
+
+        for (var i = 0; i < 5; i++)
+        {
+            await _service.ProcessEvent(Event(UnlimitedEvent));
+        }
+
+        Assert.Equal(5, _audio.Played.Count);
+    }
+
+    [Fact]
+    public async Task RateLimit_DoesNotDelayADifferentEventType()
+    {
+        _service.UpdateEventMappings(Mappings(
+            Mapping(LimitedEvent, "Incoming Fire"),
+            Mapping(UnlimitedEvent, "Docking Thump")));
+
+        await _service.ProcessEvent(Event(LimitedEvent));
+        await _service.ProcessEvent(Event(LimitedEvent));   // refused
+        await _service.ProcessEvent(Event(UnlimitedEvent)); // unaffected
+
+        Assert.Equal(new[] { "Incoming Fire", "Docking Thump" }, _audio.Played.Select(p => p.Pattern.Name));
+    }
+
+    [Fact]
+    public async Task Statistics_CountOnlyThePlayedEvents()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(LimitedEvent, "Incoming Fire")));
+
+        await _service.ProcessEvent(Event(LimitedEvent));
+        await _service.ProcessEvent(Event(LimitedEvent)); // rate limited
+
+        _clock.Advance(TimeSpan.FromSeconds(1));
+        await _service.ProcessEvent(Event(LimitedEvent));
+
+        var statistics = _service.GetEventStatistics();
+        Assert.Equal(2, statistics[LimitedEvent]);
+    }
+
+    [Fact]
+    public async Task ResetStatistics_ClearsCountsAndRateLimitWindows()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(LimitedEvent, "Incoming Fire")));
+
+        await _service.ProcessEvent(Event(LimitedEvent));
+        _service.ResetStatistics();
+
+        // Same instant as the previous event: only a cleared window lets this one through.
+        await _service.ProcessEvent(Event(LimitedEvent));
+
+        Assert.Equal(2, _audio.Played.Count);
+        Assert.Equal(1, _service.GetEventStatistics()[LimitedEvent]);
+    }
+
+    [Fact]
+    public async Task PreferredPattern_OverridesTheMappingButKeepsRateLimiting()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(LimitedEvent, "Default Fire")));
+        var shipPattern = Pattern("Anaconda Fire", intensity: 90);
+
+        await _service.ProcessEvent(Event(LimitedEvent), shipPattern);
+        await _service.ProcessEvent(Event(LimitedEvent), shipPattern); // inside the window
+
+        var played = Assert.Single(_audio.Played);
+        Assert.Equal("Anaconda Fire", played.Pattern.Name);
+    }
+
+    [Fact]
+    public async Task PreferredPattern_IsPlayedEvenWithoutAMapping()
+    {
+        _service.UpdateEventMappings(Mappings()); // nothing mapped at all
+
+        await _service.ProcessEvent(Event(UnlimitedEvent), Pattern("Ship Specific", intensity: 70));
+
+        var played = Assert.Single(_audio.Played);
+        Assert.Equal("Ship Specific", played.Pattern.Name);
+    }
+
+    [Fact]
+    public async Task PlayedPattern_IsACopy_SoTheStoredMappingKeepsItsDefaults()
+    {
+        var mappings = Mappings(Mapping("UnderAttack", "Incoming Fire", intensity: 50));
+        _service.UpdateEventMappings(mappings);
+
+        await _service.ProcessEvent(Event("UnderAttack"));
+
+        var played = Assert.Single(_audio.Played);
+        // UnderAttack adds +10 to the event copy; the stored mapping must be untouched.
+        Assert.Equal(60, played.Pattern.Intensity);
+        Assert.Equal(50, mappings.EventMappings["UnderAttack"].Pattern.Intensity);
+        Assert.Equal(50, _service.GetDefaultPatternForEvent("UnderAttack")!.Intensity);
+    }
+
+    [Fact]
+    public void DefaultMappings_AreLoadedAtConstruction()
+    {
+        // The service starts from the built-in catalogue, before any file is loaded.
+        Assert.NotEmpty(_service.GetAllDefaultPatterns());
+        Assert.NotNull(_service.GetDefaultPatternForEvent("HullDamage"));
+        Assert.Null(_service.GetDefaultPatternForEvent("NoSuchEvent"));
+    }
+
+    [Fact]
+    public void EventMappings_RoundTripThroughAFile()
+    {
+        var configPath = _settingsDir.File("event-mappings.json");
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump", intensity: 63)));
+
+        _service.SaveEventMappings(configPath);
+        Assert.True(File.Exists(configPath));
+
+        // Overwrite in memory, then load the file back over it.
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Replaced", intensity: 1)));
+        _service.LoadEventMappings(configPath);
+
+        var restored = _service.GetDefaultPatternForEvent(UnlimitedEvent);
+        Assert.NotNull(restored);
+        Assert.Equal("Docking Thump", restored!.Name);
+        Assert.Equal(63, restored.Intensity);
+    }
+
+    [Fact]
+    public void LoadEventMappings_FromAMissingFile_KeepsTheCurrentMappings()
+    {
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump")));
+
+        _service.LoadEventMappings(_settingsDir.File("does-not-exist.json"));
+
+        Assert.Equal("Docking Thump", _service.GetDefaultPatternForEvent(UnlimitedEvent)!.Name);
+    }
+
+    [Fact]
+    public void LoadEventMappings_FromACorruptFile_KeepsTheCurrentMappings()
+    {
+        var configPath = _settingsDir.File("corrupt.json");
+        File.WriteAllText(configPath, "{ this is not valid json");
+        _service.UpdateEventMappings(Mappings(Mapping(UnlimitedEvent, "Docking Thump")));
+
+        _service.LoadEventMappings(configPath);
+
+        Assert.Equal("Docking Thump", _service.GetDefaultPatternForEvent(UnlimitedEvent)!.Name);
+    }
+
+    public void Dispose()
+    {
+        _contextualIntelligence.Dispose();
+        _audio.Dispose();
+        _settingsDir.Dispose();
+    }
+
+    private static JournalEvent Event(string name) => new()
+    {
+        Event = name,
+        Timestamp = new DateTime(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static HapticPattern Pattern(string name, int intensity = 50) => new()
+    {
+        Name = name,
+        Pattern = PatternType.SharpPulse,
+        Frequency = 40,
+        Duration = 200,
+        Intensity = intensity,
+        MaxIntensity = 100
+    };
+
+    private static EventMapping Mapping(string eventType, string patternName, int intensity = 50, bool enabled = true) =>
+        new()
+        {
+            EventType = eventType,
+            Pattern = Pattern(patternName, intensity),
+            Enabled = enabled
+        };
+
+    private static EventMappingsConfig Mappings(params EventMapping[] mappings) => new()
+    {
+        EventMappings = mappings.ToDictionary(m => m.EventType)
+    };
+
+    /// <summary>Audio engine that records what it was asked to play instead of opening a device.</summary>
+    private sealed class RecordingAudioEngine : AudioEngineService
+    {
+        public RecordingAudioEngine(AppSettings settings)
+            : base(NullLogger<AudioEngineService>.Instance, settings)
+        {
+        }
+
+        public List<(HapticPattern Pattern, JournalEvent? Event)> Played { get; } = new();
+
+        public override Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
+        {
+            lock (Played)
+            {
+                Played.Add((pattern, journalEvent));
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/EDButtkicker.Tests/EventRateLimiterTests.cs
+++ b/tests/EDButtkicker.Tests/EventRateLimiterTests.cs
@@ -1,0 +1,165 @@
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The per-event-type rate limit that stops bursty journal events from flooding the transducer.
+/// Every window here is driven by a hand-advanced clock, so nothing waits on the wall clock.
+/// </summary>
+public class EventRateLimiterTests
+{
+    [Fact]
+    public void FirstOccurrence_IsAlwaysAccepted()
+    {
+        var limiter = new EventRateLimiter(new ManualTimeProvider());
+
+        Assert.True(limiter.TryAcquire("UnderAttack"));
+    }
+
+    [Fact]
+    public void SecondOccurrenceInsideTheWindow_IsRefused()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        Assert.True(limiter.TryAcquire("UnderAttack"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(299)); // window is 300ms
+        Assert.False(limiter.TryAcquire("UnderAttack"));
+    }
+
+    [Fact]
+    public void OccurrenceExactlyAtTheWindowBoundary_IsAccepted()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        Assert.True(limiter.TryAcquire("UnderAttack"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(300));
+        Assert.True(limiter.TryAcquire("UnderAttack"));
+    }
+
+    [Fact]
+    public void RefusedOccurrences_DoNotExtendTheWindow()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        Assert.True(limiter.TryAcquire("HullDamage")); // 500ms window
+
+        // A burst of refused events must not push the next acceptance further out.
+        clock.Advance(TimeSpan.FromMilliseconds(200));
+        Assert.False(limiter.TryAcquire("HullDamage"));
+        clock.Advance(TimeSpan.FromMilliseconds(200));
+        Assert.False(limiter.TryAcquire("HullDamage"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(100)); // 500ms after the accepted one
+        Assert.True(limiter.TryAcquire("HullDamage"));
+    }
+
+    [Fact]
+    public void WindowsAreTrackedPerEventType()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        Assert.True(limiter.TryAcquire("HullDamage"));
+        Assert.True(limiter.TryAcquire("ShieldDown"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        Assert.False(limiter.TryAcquire("HullDamage"));
+        Assert.False(limiter.TryAcquire("ShieldDown"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(500)); // clears HullDamage (500ms), not ShieldDown (2s)
+        Assert.True(limiter.TryAcquire("HullDamage"));
+        Assert.False(limiter.TryAcquire("ShieldDown"));
+    }
+
+    [Fact]
+    public void EventTypesWithoutALimit_AreNeverRefused()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.True(limiter.TryAcquire("Docked"));
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void MissingEventName_IsRefused(string? eventType)
+    {
+        var limiter = new EventRateLimiter(new ManualTimeProvider());
+
+        Assert.False(limiter.TryAcquire(eventType!));
+    }
+
+    [Fact]
+    public void Reset_ClearsEveryWindow()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+
+        Assert.True(limiter.TryAcquire("Touchdown")); // 3s window
+        Assert.False(limiter.TryAcquire("Touchdown"));
+
+        limiter.Reset();
+
+        Assert.Null(limiter.LastAccepted("Touchdown"));
+        Assert.True(limiter.TryAcquire("Touchdown"));
+    }
+
+    [Fact]
+    public void CustomLimits_ReplaceTheDefaults()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock, new Dictionary<string, TimeSpan>
+        {
+            ["Docked"] = TimeSpan.FromSeconds(10)
+        });
+
+        Assert.True(limiter.TryAcquire("Docked"));
+        clock.Advance(TimeSpan.FromSeconds(9));
+        Assert.False(limiter.TryAcquire("Docked"));
+
+        // A type limited by default is unlimited under this configuration.
+        Assert.True(limiter.TryAcquire("HullDamage"));
+        Assert.True(limiter.TryAcquire("HullDamage"));
+    }
+
+    [Fact]
+    public void LastAccepted_TracksTheAcceptedOccurrenceOnly()
+    {
+        var clock = new ManualTimeProvider();
+        var limiter = new EventRateLimiter(clock);
+        var accepted = clock.GetUtcNow();
+
+        Assert.True(limiter.TryAcquire("HeatDamage"));
+
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        Assert.False(limiter.TryAcquire("HeatDamage"));
+
+        Assert.Equal(accepted, limiter.LastAccepted("HeatDamage"));
+    }
+
+    [Fact]
+    public void ConcurrentBurst_AcceptsExactlyOneEventPerWindow()
+    {
+        var limiter = new EventRateLimiter(new ManualTimeProvider());
+        var accepted = 0;
+
+        // Overlapping journal reads can process the same burst from several threads.
+        Parallel.For(0, 64, _ =>
+        {
+            if (limiter.TryAcquire("UnderAttack"))
+                Interlocked.Increment(ref accepted);
+        });
+
+        Assert.Equal(1, accepted);
+    }
+}

--- a/tests/EDButtkicker.Tests/IntensityBoundsTests.cs
+++ b/tests/EDButtkicker.Tests/IntensityBoundsTests.cs
@@ -1,0 +1,221 @@
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NAudio.Wave;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Intensity must stay inside its declared range at every stage: the curve processor never returns
+/// a value outside 0..1, and a pattern whose per-event modifiers push it past 100% still reaches the
+/// output bounded by the configured app maximum. Pure sample math - no device is opened.
+/// </summary>
+public class IntensityBoundsTests
+{
+    private const int SampleRate = 44100;
+    private const float Tolerance = 1e-5f;
+
+    public static TheoryData<IntensityCurve> AllCurves => new()
+    {
+        IntensityCurve.Linear,
+        IntensityCurve.Exponential,
+        IntensityCurve.Logarithmic,
+        IntensityCurve.Sine,
+        IntensityCurve.Bounce,
+        IntensityCurve.Custom
+    };
+
+    [Theory]
+    [MemberData(nameof(AllCurves))]
+    public void CalculateIntensity_StaysWithinZeroToOneAcrossTheWholeCurve(IntensityCurve curve)
+    {
+        for (var step = 0; step <= 200; step++)
+        {
+            var time = step / 200f;
+            var intensity = IntensityCurveProcessor.CalculateIntensity(curve, time, 1.0f);
+
+            Assert.InRange(intensity, 0f, 1f);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCurves))]
+    public void CalculateIntensity_ClampsTimeOutsideZeroToOne(IntensityCurve curve)
+    {
+        var below = IntensityCurveProcessor.CalculateIntensity(curve, -5f, 1.0f);
+        var above = IntensityCurveProcessor.CalculateIntensity(curve, 5f, 1.0f);
+
+        Assert.InRange(below, 0f, 1f);
+        Assert.InRange(above, 0f, 1f);
+        Assert.Equal(IntensityCurveProcessor.CalculateIntensity(curve, 0f, 1.0f), below, Tolerance);
+        Assert.Equal(IntensityCurveProcessor.CalculateIntensity(curve, 1f, 1.0f), above, Tolerance);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCurves))]
+    public void CalculateIntensity_ClampsABaseIntensityAboveOne(IntensityCurve curve)
+    {
+        for (var step = 0; step <= 20; step++)
+        {
+            var intensity = IntensityCurveProcessor.CalculateIntensity(curve, step / 20f, 10.0f);
+
+            Assert.InRange(intensity, 0f, 1f);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCurves))]
+    public void CalculateIntensity_WithNoBaseIntensity_IsSilent(IntensityCurve curve)
+    {
+        Assert.Equal(0f, IntensityCurveProcessor.CalculateIntensity(curve, 0.5f, 0f), Tolerance);
+    }
+
+    [Fact]
+    public void BounceCurve_OvershootIsClampedRatherThanLeakingThrough()
+    {
+        // The bounce easing overshoots 1.0 near the end; the processor must bound it.
+        var values = Enumerable.Range(0, 101)
+            .Select(i => IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Bounce, i / 100f, 1.0f))
+            .ToList();
+
+        Assert.All(values, v => Assert.InRange(v, 0f, 1f));
+        Assert.Contains(values, v => v >= 1f - Tolerance);
+    }
+
+    [Fact]
+    public void LinearCurve_TracksTimeExactly()
+    {
+        Assert.Equal(0f, IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Linear, 0f, 1f), Tolerance);
+        Assert.Equal(0.25f, IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Linear, 0.5f, 0.5f), Tolerance);
+        Assert.Equal(1f, IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Linear, 1f, 1f), Tolerance);
+    }
+
+    [Fact]
+    public void CustomCurve_InterpolatesBetweenPointsAndStaysBounded()
+    {
+        var points = new List<CurvePoint>
+        {
+            new() { Time = 0.0f, Intensity = 0.0f },
+            new() { Time = 0.5f, Intensity = 1.0f },
+            new() { Time = 1.0f, Intensity = 0.0f }
+        };
+
+        Assert.Equal(0.5f, IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Custom, 0.25f, 1f, points), Tolerance);
+        Assert.Equal(1.0f, IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Custom, 0.5f, 1f, points), Tolerance);
+
+        for (var step = 0; step <= 100; step++)
+        {
+            Assert.InRange(IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Custom, step / 100f, 1f, points), 0f, 1f);
+        }
+    }
+
+    [Fact]
+    public void CustomCurve_WithOutOfRangePoints_IsStillBounded()
+    {
+        var points = new List<CurvePoint>
+        {
+            new() { Time = 0.0f, Intensity = -3.0f },
+            new() { Time = 0.5f, Intensity = 8.0f },
+            new() { Time = 1.0f, Intensity = 4.0f }
+        };
+
+        for (var step = 0; step <= 100; step++)
+        {
+            Assert.InRange(IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Custom, step / 100f, 1f, points), 0f, 1f);
+        }
+    }
+
+    [Fact]
+    public void CustomCurve_WithNoPoints_FallsBackToLinear()
+    {
+        var custom = IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Custom, 0.4f, 1f, new List<CurvePoint>());
+        var linear = IntensityCurveProcessor.CalculateIntensity(IntensityCurve.Linear, 0.4f, 1f);
+
+        Assert.Equal(linear, custom, Tolerance);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCurves))]
+    public void CurvePreview_IsFullyBounded(IntensityCurve curve)
+    {
+        var preview = IntensityCurveProcessor.GenerateCurvePreview(curve);
+
+        Assert.Equal(100, preview.Count);
+        Assert.All(preview, value => Assert.InRange(value, 0f, 1f));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(25)]
+    [InlineData(80)]
+    [InlineData(100)]
+    public void EventBoostedPattern_IsStillBoundedByTheAppMaximum(int appMaxIntensity)
+    {
+        // "Interdicted" adds 20 on top of an already maximal pattern, so the per-event copy asks for
+        // more than 100%. The app-level cap is what has to hold.
+        var stored = new HapticPattern
+        {
+            Name = "Interdiction",
+            Pattern = PatternType.BuildupRumble,
+            Frequency = 40,
+            Duration = 200,
+            Intensity = 100,
+            MaxIntensity = 100
+        };
+
+        var journalEvent = new JournalEvent { Event = "Interdicted" };
+        var perEvent = EventPatternFactory.CreatePatternForEvent(stored, journalEvent, NullLogger.Instance);
+
+        Assert.Equal(100, stored.Intensity); // the stored mapping keeps its own value
+        var provider = HapticSampleFactory.Create(
+            perEvent, perEvent.Intensity, perEvent.Frequency, SampleRate, appMaxIntensity);
+
+        var ceiling = appMaxIntensity / 100f;
+        foreach (var sample in ReadAll(provider))
+        {
+            Assert.False(float.IsNaN(sample));
+            Assert.InRange(sample, -ceiling - Tolerance, ceiling + Tolerance);
+        }
+    }
+
+    [Fact]
+    public void HullDamagePattern_ScaledByHealth_StaysWithinItsDeclaredIntensityRange()
+    {
+        var stored = new HapticPattern
+        {
+            Name = "Hull Damage",
+            Pattern = PatternType.SharpPulse,
+            Frequency = 50,
+            Duration = 200,
+            Intensity = 80,
+            IntensityFromDamage = true,
+            MinIntensity = 30,
+            MaxIntensity = 100
+        };
+
+        foreach (var health in new[] { 0.0, 0.25, 0.5, 0.99, 1.0 })
+        {
+            var perEvent = EventPatternFactory.CreatePatternForEvent(
+                stored, new JournalEvent { Event = "HullDamage", Health = health }, NullLogger.Instance);
+
+            Assert.InRange(perEvent.Intensity, perEvent.MinIntensity, perEvent.MaxIntensity);
+            Assert.InRange(perEvent.Frequency, 1, stored.Frequency);
+        }
+    }
+
+    private static float[] ReadAll(ISampleProvider provider)
+    {
+        var samples = new List<float>();
+        var buffer = new float[4096];
+
+        int read;
+        while ((read = provider.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            samples.AddRange(buffer.Take(read));
+            if (samples.Count > SampleRate * 5) break; // safety net against an endless provider
+        }
+
+        return samples.ToArray();
+    }
+}

--- a/tests/EDButtkicker.Tests/JournalEventParserTests.cs
+++ b/tests/EDButtkicker.Tests/JournalEventParserTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The parse step between a tailed line and the event pipeline. Elite writes one JSON object per
+/// line, but a line can be blank, truncated, or something other than an object - none of which may
+/// stop monitoring. No file watching and no audio stack is involved here.
+/// </summary>
+public class JournalEventParserTests
+{
+    [Fact]
+    public void TryParse_ReadsTheEventNameAndTimestampAsUtc()
+    {
+        var line = """{"timestamp":"2026-08-27T11:42:50Z","event":"FSDJump","StarSystem":"Sol"}""";
+
+        Assert.True(JournalEventParser.TryParse(line, out var journalEvent));
+
+        Assert.NotNull(journalEvent);
+        Assert.Equal("FSDJump", journalEvent!.Event);
+        Assert.Equal("Sol", journalEvent.StarSystem);
+        Assert.Equal(new DateTime(2026, 8, 27, 11, 42, 50, DateTimeKind.Utc), journalEvent.Timestamp.ToUniversalTime());
+    }
+
+    [Fact]
+    public void TryParse_ReadsTypedDamageFields()
+    {
+        var line = """{"timestamp":"2026-08-27T11:42:50Z","event":"HullDamage","Health":0.42,"PlayerPilot":true}""";
+
+        Assert.True(JournalEventParser.TryParse(line, out var journalEvent));
+
+        Assert.Equal("HullDamage", journalEvent!.Event);
+        Assert.Equal(0.42, journalEvent.Health!.Value, 5);
+    }
+
+    [Fact]
+    public void TryParse_KeepsUnmodelledFieldsAsExtensionData()
+    {
+        var line = """{"timestamp":"2026-08-27T11:42:50Z","event":"FuelScoop","Rate":8.5,"Scooped":12.0}""";
+
+        Assert.True(JournalEventParser.TryParse(line, out var journalEvent));
+
+        Assert.NotNull(journalEvent!.AdditionalData);
+        Assert.True(journalEvent.AdditionalData!.ContainsKey("Rate"));
+        Assert.True(journalEvent.AdditionalData.ContainsKey("Scooped"));
+
+        // Extension data arrives as JsonElement, so the value survives parsing but is only readable
+        // through the JsonElement API - not through Convert.ToDouble.
+        var rate = Assert.IsType<JsonElement>(journalEvent.AdditionalData["Rate"]);
+        Assert.Equal(JsonValueKind.Number, rate.ValueKind);
+        Assert.Equal(8.5, rate.GetDouble(), 5);
+    }
+
+    [Fact]
+    public void TryParse_IsCaseInsensitiveOnTheEventName()
+    {
+        Assert.True(JournalEventParser.TryParse("""{"Event":"Docked"}""", out var journalEvent));
+
+        Assert.Equal("Docked", journalEvent!.Event);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void TryParse_SkipsBlankLines(string? line)
+    {
+        Assert.False(JournalEventParser.TryParse(line, out var journalEvent));
+        Assert.Null(journalEvent);
+    }
+
+    [Theory]
+    [InlineData("""{"event":"FSDJump" """)]      // truncated object, as seen mid-write
+    [InlineData("not json at all")]
+    [InlineData("[1,2,3]")]                       // an array is not an event
+    [InlineData("42")]
+    [InlineData("null")]
+    public void TryParse_RejectsMalformedOrNonObjectLines(string line)
+    {
+        Assert.False(JournalEventParser.TryParse(line, out var journalEvent));
+        Assert.Null(journalEvent);
+    }
+
+    [Fact]
+    public void TryParse_AcceptsAnObjectWithoutAnEventName()
+    {
+        // Downstream treats an empty event name as "nothing to play"; parsing itself must not throw.
+        Assert.True(JournalEventParser.TryParse("{}", out var journalEvent));
+        Assert.Equal(string.Empty, journalEvent!.Event);
+    }
+
+    [Fact]
+    public void TryParse_OneBadLineDoesNotAffectTheNext()
+    {
+        var lines = new[]
+        {
+            """{"event":"LoadGame"}""",
+            "{ this line is broken",
+            """{"event":"Docked","StationName":"Jameson Memorial"}"""
+        };
+
+        var parsed = new List<string>();
+        foreach (var line in lines)
+        {
+            if (JournalEventParser.TryParse(line, out var journalEvent))
+                parsed.Add(journalEvent!.Event);
+        }
+
+        Assert.Equal(new[] { "LoadGame", "Docked" }, parsed);
+    }
+}

--- a/tests/EDButtkicker.Tests/PatternPathGuardTests.cs
+++ b/tests/EDButtkicker.Tests/PatternPathGuardTests.cs
@@ -143,29 +143,3 @@ public class PatternPathGuardTests
         Assert.Null(PatternPathGuard.ResolveUnderRoot("", "my-pack.json"));
     }
 }
-
-/// <summary>A scratch directory that removes itself, so no test writes into the repo tree.</summary>
-internal sealed class TempDirectory : IDisposable
-{
-    public TempDirectory()
-    {
-        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "edbk-guard-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path);
-    }
-
-    public string Path { get; }
-
-    public void Dispose()
-    {
-        try
-        {
-            if (Directory.Exists(Path))
-            {
-                Directory.Delete(Path, recursive: true);
-            }
-        }
-        catch (IOException)
-        {
-        }
-    }
-}

--- a/tests/EDButtkicker.Tests/PatternValidationTests.cs
+++ b/tests/EDButtkicker.Tests/PatternValidationTests.cs
@@ -1,0 +1,203 @@
+using EDButtkicker.Controllers;
+using EDButtkicker.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Pattern pack validation: what makes a pack rejected (errors) versus merely questionable
+/// (warnings). The controller is resolved from the real service graph, but validation itself never
+/// plays anything, so no audio device is involved.
+/// </summary>
+public class PatternValidationTests : IClassFixture<WebUiTestServerFixture>
+{
+    private readonly PatternEditorController _controller;
+
+    public PatternValidationTests(WebUiTestServerFixture fixture)
+    {
+        _controller = fixture.Services.GetRequiredService<PatternEditorController>();
+    }
+
+    [Fact]
+    public void CompletePack_IsValidWithoutWarnings()
+    {
+        var result = Validate(Pack());
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void MissingPackNameAndAuthor_AreErrors()
+    {
+        var file = Pack();
+        file.Metadata.Name = string.Empty;
+        file.Metadata.Author = string.Empty;
+
+        var result = Validate(file);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("Pack name is required", result.Errors);
+        Assert.Contains("Author is required", result.Errors);
+    }
+
+    [Fact]
+    public void MissingVersion_IsOnlyAWarning()
+    {
+        var file = Pack();
+        file.Metadata.Version = string.Empty;
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Warnings, w => w.Contains("Version not specified"));
+    }
+
+    [Fact]
+    public void PackWithoutShips_IsValidButWarned()
+    {
+        var file = Pack();
+        file.Ships.Clear();
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.Contains("No ships defined in pattern file", result.Warnings);
+    }
+
+    [Fact]
+    public void ShipWithoutDisplayNameOrEvents_IsWarned()
+    {
+        var file = Pack();
+        file.Ships["anaconda"].DisplayName = string.Empty;
+        file.Ships["anaconda"].Events.Clear();
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Warnings, w => w.Contains("has no display name"));
+        Assert.Contains(result.Warnings, w => w.Contains("has no events defined"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(101)]
+    public void IntensityOutsideOneToOneHundred_IsAnError(int intensity)
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Intensity = intensity;
+
+        var result = Validate(file);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("Intensity must be between 1-100%"));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void IntensityOnTheBoundary_IsAccepted(int intensity)
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Intensity = intensity;
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.DoesNotContain(result.Errors, e => e.Contains("Intensity"));
+    }
+
+    [Theory]
+    [InlineData(9)]
+    [InlineData(101)]
+    public void FrequencyOutsideTenToOneHundredHertz_IsAWarningNotAnError(int frequency)
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Frequency = frequency;
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Warnings, w => w.Contains("Frequency should be between 10-100Hz"));
+    }
+
+    [Theory]
+    [InlineData(49)]
+    [InlineData(10001)]
+    public void DurationOutsideFiftyToTenThousandMs_IsAWarningNotAnError(int duration)
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Duration = duration;
+
+        var result = Validate(file);
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Warnings, w => w.Contains("Duration should be between 50-10000ms"));
+    }
+
+    [Fact]
+    public void EveryOffendingEvent_IsReportedIndividually()
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Intensity = 0;
+        file.Ships["anaconda"].Events["ShieldDown"] = new HapticPattern
+        {
+            Name = "Shields Down",
+            Frequency = 40,
+            Duration = 500,
+            Intensity = 250
+        };
+
+        var result = Validate(file);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.Errors.Count(e => e.Contains("Intensity must be between 1-100%")));
+        Assert.Contains(result.Errors, e => e.Contains("'HullDamage'"));
+        Assert.Contains(result.Errors, e => e.Contains("'ShieldDown'"));
+    }
+
+    private ValidationResponse Validate(PatternFileDefinition file)
+    {
+        var action = _controller.ValidatePattern(file);
+        var ok = Assert.IsType<OkObjectResult>(action.Result);
+        return Assert.IsType<ValidationResponse>(ok.Value);
+    }
+
+    private static PatternFileDefinition Pack() => new()
+    {
+        Metadata = new PatternFileMetadata
+        {
+            Name = "Test Pack",
+            Version = "1.0.0",
+            Author = "Test Author",
+            Description = "Fixture pack",
+            Created = "2026-08-28T12:00:00Z",
+            Compatibility = "1.0.0"
+        },
+        Ships = new Dictionary<string, ShipPatternDefinition>
+        {
+            ["anaconda"] = new()
+            {
+                DisplayName = "Anaconda",
+                Class = "Large",
+                Role = "Multipurpose",
+                Events = new Dictionary<string, HapticPattern>
+                {
+                    ["HullDamage"] = new()
+                    {
+                        Name = "Hull Damage",
+                        Pattern = PatternType.SharpPulse,
+                        Frequency = 45,
+                        Duration = 300,
+                        Intensity = 80
+                    }
+                }
+            }
+        }
+    };
+}

--- a/tests/EDButtkicker.Tests/TestSupport.cs
+++ b/tests/EDButtkicker.Tests/TestSupport.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// A throwaway directory under the system temp path. Every test that touches the filesystem owns
+/// one of these, so nothing is read from - or written to - the developer's real profile.
+/// </summary>
+public sealed class TempDirectory : IDisposable
+{
+    public TempDirectory(string prefix = "edbk-test")
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public string File(string name) => System.IO.Path.Combine(Path, name);
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+        catch (IOException) { /* best effort cleanup */ }
+        catch (UnauthorizedAccessException) { /* best effort cleanup */ }
+    }
+}
+
+/// <summary>
+/// Clock the test drives by hand. Nothing that depends on elapsed time may wait on the wall clock,
+/// otherwise the rate limit tests would be slow on a good day and flaky on a bad one.
+/// </summary>
+public sealed class ManualTimeProvider : TimeProvider
+{
+    private DateTimeOffset _utcNow;
+
+    public ManualTimeProvider(DateTimeOffset? start = null)
+    {
+        _utcNow = start ?? new DateTimeOffset(2026, 8, 28, 12, 0, 0, TimeSpan.Zero);
+    }
+
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+
+    public void Advance(TimeSpan delta) => _utcNow += delta;
+}
+
+internal static class TestLoggers
+{
+    public static ILogger<T> For<T>() => NullLogger<T>.Instance;
+}

--- a/tests/EDButtkicker.Tests/UserSettingsRoundTripTests.cs
+++ b/tests/EDButtkicker.Tests/UserSettingsRoundTripTests.cs
@@ -1,0 +1,240 @@
+using EDButtkicker.Configuration;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Saved settings must survive a restart: what is written has to come back identical, a missing or
+/// damaged file has to fall back to defaults rather than throw, and preferences have to map onto
+/// AppSettings both ways. Everything runs against a temporary directory, never the real profile.
+/// </summary>
+public class UserSettingsRoundTripTests : IDisposable
+{
+    private readonly TempDirectory _dir = new("edbk-settings");
+    private readonly UserSettingsService _service;
+
+    public UserSettingsRoundTripTests()
+    {
+        _service = new UserSettingsService(NullLogger<UserSettingsService>.Instance, _dir.Path);
+    }
+
+    [Fact]
+    public void SettingsPath_IsInsideTheGivenDirectory()
+    {
+        Assert.Equal(Path.Combine(_dir.Path, "user-settings.json"), _service.GetUserSettingsPath());
+        Assert.False(_service.UserSettingsExist());
+    }
+
+    [Fact]
+    public async Task Preferences_RoundTripThroughDisk()
+    {
+        var saved = new UserPreferences
+        {
+            AudioDeviceId = 3,
+            AudioDeviceName = "ButtKicker Gamer Pro",
+            MaxIntensity = 65,
+            DefaultFrequency = 42,
+            JournalPath = _dir.File("journals"),
+            MonitorLatestOnly = false,
+            ContextualIntelligence = new UserContextualIntelligencePreferences
+            {
+                Enabled = true,
+                EnableAdaptiveIntensity = false,
+                EnablePredictivePatterns = true,
+                EnableContextualVoice = false
+            },
+            LastSaved = new DateTime(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc),
+            Version = "1.0.0"
+        };
+
+        await _service.SaveUserPreferencesAsync(saved);
+        Assert.True(_service.UserSettingsExist());
+
+        var loaded = await _service.LoadUserPreferencesAsync();
+
+        Assert.Equal(saved.AudioDeviceId, loaded.AudioDeviceId);
+        Assert.Equal(saved.AudioDeviceName, loaded.AudioDeviceName);
+        Assert.Equal(saved.MaxIntensity, loaded.MaxIntensity);
+        Assert.Equal(saved.DefaultFrequency, loaded.DefaultFrequency);
+        Assert.Equal(saved.JournalPath, loaded.JournalPath);
+        Assert.Equal(saved.MonitorLatestOnly, loaded.MonitorLatestOnly);
+        Assert.Equal(saved.Version, loaded.Version);
+        Assert.Equal(saved.LastSaved, loaded.LastSaved);
+
+        Assert.NotNull(loaded.ContextualIntelligence);
+        Assert.True(loaded.ContextualIntelligence!.Enabled);
+        Assert.False(loaded.ContextualIntelligence.EnableAdaptiveIntensity);
+        Assert.True(loaded.ContextualIntelligence.EnablePredictivePatterns);
+        Assert.False(loaded.ContextualIntelligence.EnableContextualVoice);
+    }
+
+    [Fact]
+    public async Task Preferences_AreRewrittenOnEverySave()
+    {
+        await _service.SaveUserPreferencesAsync(new UserPreferences { MaxIntensity = 90 });
+        await _service.SaveUserPreferencesAsync(new UserPreferences { MaxIntensity = 30 });
+
+        var loaded = await _service.LoadUserPreferencesAsync();
+
+        Assert.Equal(30, loaded.MaxIntensity);
+    }
+
+    [Fact]
+    public async Task MissingFile_YieldsDefaults()
+    {
+        var loaded = await _service.LoadUserPreferencesAsync();
+
+        Assert.Null(loaded.AudioDeviceId);
+        Assert.Null(loaded.MaxIntensity);
+        Assert.Null(loaded.JournalPath);
+    }
+
+    [Fact]
+    public async Task CorruptFile_YieldsDefaultsInsteadOfThrowing()
+    {
+        await File.WriteAllTextAsync(_service.GetUserSettingsPath(), "{ not valid json");
+
+        var loaded = await _service.LoadUserPreferencesAsync();
+
+        Assert.Null(loaded.AudioDeviceId);
+        Assert.Null(loaded.AudioDeviceName);
+    }
+
+    [Fact]
+    public async Task FileContainingJsonNull_YieldsDefaults()
+    {
+        await File.WriteAllTextAsync(_service.GetUserSettingsPath(), "null");
+
+        var loaded = await _service.LoadUserPreferencesAsync();
+
+        Assert.Null(loaded.MaxIntensity);
+    }
+
+    [Fact]
+    public async Task AppSettings_RoundTripThroughPreferences()
+    {
+        var original = new AppSettings
+        {
+            Audio =
+            {
+                AudioDeviceId = 7,
+                AudioDeviceName = "Test Device",
+                MaxIntensity = 55,
+                DefaultFrequency = 38
+            },
+            EliteDangerous =
+            {
+                JournalPath = _dir.File("journals"),
+                MonitorLatestOnly = false
+            },
+            ContextualIntelligence = new ContextualIntelligenceConfiguration
+            {
+                Enabled = true,
+                EnableAdaptiveIntensity = false,
+                EnablePredictivePatterns = false,
+                EnableContextualVoice = true
+            }
+        };
+
+        await _service.SaveUserPreferencesAsync(_service.CreatePreferencesFromAppSettings(original));
+
+        var restored = new AppSettings();
+        _service.ApplyUserPreferencesToAppSettings(await _service.LoadUserPreferencesAsync(), restored);
+
+        Assert.Equal(original.Audio.AudioDeviceId, restored.Audio.AudioDeviceId);
+        Assert.Equal(original.Audio.AudioDeviceName, restored.Audio.AudioDeviceName);
+        Assert.Equal(original.Audio.MaxIntensity, restored.Audio.MaxIntensity);
+        Assert.Equal(original.Audio.DefaultFrequency, restored.Audio.DefaultFrequency);
+        Assert.Equal(original.EliteDangerous.JournalPath, restored.EliteDangerous.JournalPath);
+        Assert.Equal(original.EliteDangerous.MonitorLatestOnly, restored.EliteDangerous.MonitorLatestOnly);
+        Assert.True(restored.ContextualIntelligence!.Enabled);
+        Assert.False(restored.ContextualIntelligence.EnableAdaptiveIntensity);
+        Assert.False(restored.ContextualIntelligence.EnablePredictivePatterns);
+        Assert.True(restored.ContextualIntelligence.EnableContextualVoice);
+    }
+
+    [Fact]
+    public void UnsetPreferences_LeaveAppSettingsUntouched()
+    {
+        var settings = new AppSettings();
+        var defaults = new AppSettings();
+
+        _service.ApplyUserPreferencesToAppSettings(new UserPreferences(), settings);
+
+        Assert.Equal(defaults.Audio.MaxIntensity, settings.Audio.MaxIntensity);
+        Assert.Equal(defaults.Audio.DefaultFrequency, settings.Audio.DefaultFrequency);
+        Assert.Equal(defaults.Audio.AudioDeviceId, settings.Audio.AudioDeviceId);
+        Assert.Equal(defaults.EliteDangerous.JournalPath, settings.EliteDangerous.JournalPath);
+        Assert.Equal(defaults.EliteDangerous.MonitorLatestOnly, settings.EliteDangerous.MonitorLatestOnly);
+    }
+
+    [Fact]
+    public async Task GameContext_RoundTripsThroughDisk()
+    {
+        var snapshot = new GameContextSnapshot
+        {
+            PlayerAggressiveness = 0.62,
+            PlayerCautiousness = 0.31,
+            SystemsVisited = 17,
+            BodiesScanned = 42,
+            LastHullIntegrity = 0.75,
+            LastKnownSystem = "Shinrarta Dezhra",
+            RecentEventFrequency = { ["HullDamage"] = 4, ["FSDJump"] = 9 },
+            StateTimeSpent = { ["Combat"] = TimeSpan.FromMinutes(3) },
+            SavedAt = new DateTime(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        await _service.SaveGameContextAsync(snapshot);
+        var loaded = await _service.LoadGameContextAsync();
+
+        Assert.NotNull(loaded);
+        Assert.Equal(snapshot.PlayerAggressiveness, loaded!.PlayerAggressiveness, 6);
+        Assert.Equal(snapshot.PlayerCautiousness, loaded.PlayerCautiousness, 6);
+        Assert.Equal(snapshot.SystemsVisited, loaded.SystemsVisited);
+        Assert.Equal(snapshot.BodiesScanned, loaded.BodiesScanned);
+        Assert.Equal(snapshot.LastHullIntegrity, loaded.LastHullIntegrity, 6);
+        Assert.Equal(snapshot.LastKnownSystem, loaded.LastKnownSystem);
+        Assert.Equal(4, loaded.RecentEventFrequency["HullDamage"]);
+        Assert.Equal(TimeSpan.FromMinutes(3), loaded.StateTimeSpent["Combat"]);
+        Assert.Equal(snapshot.SavedAt, loaded.SavedAt);
+    }
+
+    [Fact]
+    public async Task MissingGameContext_LoadsAsNull()
+    {
+        Assert.Null(await _service.LoadGameContextAsync());
+    }
+
+    [Fact]
+    public async Task CorruptGameContext_LoadsAsNullInsteadOfThrowing()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_dir.Path, "game-context.json"), "}{");
+
+        Assert.Null(await _service.LoadGameContextAsync());
+    }
+
+    [Fact]
+    public void SettingsDirectory_IsCreatedIfMissing()
+    {
+        var nested = Path.Combine(_dir.Path, "nested", "settings");
+
+        var service = new UserSettingsService(NullLogger<UserSettingsService>.Instance, nested);
+
+        Assert.True(Directory.Exists(nested));
+        Assert.Equal(Path.Combine(nested, "user-settings.json"), service.GetUserSettingsPath());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptySettingsDirectory_IsRejected(string directory)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new UserSettingsService(NullLogger<UserSettingsService>.Instance, directory));
+    }
+
+    public void Dispose() => _dir.Dispose();
+}


### PR DESCRIPTION
## Summary
- add deterministic seams for journal parsing and per-event rate limits
- add regression coverage for journal parsing/rotation, event mapping/rate limits, settings round trips, path and pattern validation, and intensity bounds
- keep the suite hardware-independent and runnable in CI

## Verification
- `/home/hermes/.dotnet/dotnet test EDButtkicker.sln --no-restore --verbosity minimal` (315 passed)
- `/home/hermes/.dotnet/dotnet test EDButtkicker.sln --configuration Release --no-restore --verbosity minimal` (315 passed)

Closes #32