### PR TITLE
fix(audio): log device enumeration coordinates

### DIFF
--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -30,7 +30,17 @@ public class AudioApiController
         try
         {
             var devices = GetAvailableAudioDevices();
-            
+
+            // This list prepends a synthetic default entry, so a device's position in the web list is
+            // never its DeviceId. Log both so a mis-selection report can be read against the ids.
+            foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(devices, "web device list"))
+            {
+                _logger.LogInformation("Audio devices - {Device}", line);
+            }
+
+            _logger.LogInformation("Audio devices - {Selection}", AudioDeviceDiagnostics.DescribeConfiguredSelection(
+                devices, _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName));
+
             var response = new
             {
                 devices = devices.Select(d => new

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -315,11 +315,11 @@ class Program
                 // Still show device enumeration in debug mode
                 var devices = GetAvailableAudioDevices(debugMode);
                 Console.WriteLine($"Available devices ({devices.Count} found):");
-                for (int i = 0; i < devices.Count; i++)
+                foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(devices, "WASAPI render"))
                 {
-                    var marker = devices[i].IsDefault ? "✓ " : "  ";
-                    Console.WriteLine($"{marker}{i + 1}. {devices[i].Name}");
+                    Console.WriteLine($"  {line}");
                 }
+                Console.WriteLine($"  {AudioDeviceDiagnostics.DescribeConfiguredSelection(devices, settings.Audio.AudioDeviceId, settings.Audio.AudioDeviceName)}");
                 Console.WriteLine();
             }
             
@@ -388,7 +388,8 @@ class Program
             Console.WriteLine("Available audio devices:");
             for (int i = 0; i < devices.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. {devices[i]}");
+                // Menu numbers are 1-based for input; the DeviceId that gets saved is not.
+                Console.WriteLine($"{i + 1}. {devices[i]} [DeviceId={devices[i].DeviceId}]");
             }
 
             Console.WriteLine($"{devices.Count + 1}. Use default device");

--- a/src/EDButtkicker/Services/AudioDeviceDiagnostics.cs
+++ b/src/EDButtkicker/Services/AudioDeviceDiagnostics.cs
@@ -1,0 +1,102 @@
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Turns an enumerated device list into log lines that name both coordinates of every device:
+/// the 1-based position it occupies in the list a human sees, and the 0-based DeviceId that gets
+/// stored in settings. Those two differ by one for WASAPI render endpoints, and differ by more
+/// than one wherever a synthetic "Default" entry is prepended, which is what makes "the device
+/// names are off by one" reports impossible to confirm from the old logs.
+///
+/// Deliberately free of NAudio types: callers map their enumeration into <see cref="AudioDevice"/>
+/// first, so the formatting is exercisable without an audio device.
+/// </summary>
+public static class AudioDeviceDiagnostics
+{
+    /// <summary>
+    /// One line per device, each stating position, DeviceId and name together. <paramref name="ordinalSpace"/>
+    /// labels which enumeration the positions and ids belong to (WASAPI render endpoints, the web
+    /// device list, ...) because ids from one space do not address devices in another.
+    /// </summary>
+    public static IReadOnlyList<string> DescribeEnumeration(IReadOnlyList<AudioDevice>? devices, string ordinalSpace)
+    {
+        if (devices == null || devices.Count == 0)
+        {
+            return new[] { $"{ordinalSpace}: no devices enumerated" };
+        }
+
+        var lines = new List<string>(devices.Count);
+        for (var i = 0; i < devices.Count; i++)
+        {
+            var device = devices[i];
+            lines.Add(
+                $"{ordinalSpace} position {i + 1} of {devices.Count}: " +
+                $"DeviceId={device.DeviceId} name='{device.Name}' " +
+                $"default={YesNo(device.IsDefault)} available={YesNo(device.IsAvailable)}");
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Describes what the saved settings actually resolve to. AudioEngineService opens the device
+    /// whose friendly name matches <paramref name="configuredDeviceName"/> exactly, so the saved
+    /// DeviceId is only ever a label; when the two disagree this line says so instead of leaving
+    /// the reader to guess which one playback followed.
+    /// </summary>
+    public static string DescribeConfiguredSelection(
+        IReadOnlyList<AudioDevice>? devices,
+        int configuredDeviceId,
+        string? configuredDeviceName)
+    {
+        var enumerated = devices ?? Array.Empty<AudioDevice>();
+
+        if (string.IsNullOrEmpty(configuredDeviceName))
+        {
+            return $"configured: no device name saved, playback uses the system default output " +
+                   $"(saved DeviceId={configuredDeviceId} does not pick the device)";
+        }
+
+        // Ordinal equality, matching how the engine matches MMDevice.FriendlyName.
+        var matches = Enumerable.Range(0, enumerated.Count)
+            .Where(i => string.Equals(enumerated[i].Name, configuredDeviceName, StringComparison.Ordinal))
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            return $"configured: UNRESOLVED - name '{configuredDeviceName}' is not in this enumeration " +
+                   $"({DescribeSavedId(enumerated, configuredDeviceId)}); playback falls back to the system default";
+        }
+
+        if (matches.Count > 1)
+        {
+            var ids = string.Join(", ", matches.Select(i => $"DeviceId={enumerated[i].DeviceId}"));
+            return $"configured: AMBIGUOUS - {matches.Count} devices share name '{configuredDeviceName}' ({ids}); " +
+                   $"playback uses the first, saved DeviceId={configuredDeviceId}";
+        }
+
+        var position = matches[0] + 1;
+        var match = enumerated[matches[0]];
+        var located = $"name '{configuredDeviceName}' resolves to DeviceId={match.DeviceId} " +
+                      $"at position {position} of {enumerated.Count}";
+
+        if (match.DeviceId == configuredDeviceId)
+        {
+            return $"configured: {located}, which matches saved DeviceId={configuredDeviceId}";
+        }
+
+        return $"configured: MISMATCH - {located}, but {DescribeSavedId(enumerated, configuredDeviceId)}; " +
+               $"playback follows the name";
+    }
+
+    private static string DescribeSavedId(IReadOnlyList<AudioDevice> devices, int configuredDeviceId)
+    {
+        var byId = devices.FirstOrDefault(d => d.DeviceId == configuredDeviceId);
+        return byId == null
+            ? $"saved DeviceId={configuredDeviceId} is not in this enumeration"
+            : $"saved DeviceId={configuredDeviceId} is name '{byId.Name}'";
+    }
+
+    private static string YesNo(bool value) => value ? "yes" : "no";
+}

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -1,4 +1,6 @@
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
+using NAudio;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 using NAudio.CoreAudioApi;
@@ -47,8 +49,9 @@ public class AudioEngineService : IDisposable
 					
 					var deviceEnumerator = new MMDeviceEnumerator();
 					var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+					LogWasapiEnumeration(devices);
 					var matchedDevice = devices.FirstOrDefault(d => d.FriendlyName == _settings.Audio.AudioDeviceName);
-					
+
 					if (matchedDevice != null)
 					{
 						_waveOut = new WasapiOut(matchedDevice, AudioClientShareMode.Shared, true, 200);
@@ -421,6 +424,54 @@ public class AudioEngineService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Logs every WASAPI render endpoint with both its list position and its DeviceId, then what the
+    /// saved settings resolve to. This is the record to read when a device selection appears to land
+    /// on the neighbouring device: it shows whether the saved name and the saved DeviceId disagree.
+    /// </summary>
+    private void LogWasapiEnumeration(MMDeviceCollection devices)
+    {
+        try
+        {
+            string? defaultDeviceId = null;
+            try
+            {
+                defaultDeviceId = new MMDeviceEnumerator()
+                    .GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("No default render endpoint available: {Error}", ex.Message);
+            }
+
+            var enumerated = new List<AudioDevice>(devices.Count);
+            for (var i = 0; i < devices.Count; i++)
+            {
+                var device = devices[i];
+                enumerated.Add(new AudioDevice
+                {
+                    DeviceId = i,
+                    Name = device.FriendlyName,
+                    Driver = "WASAPI",
+                    IsDefault = defaultDeviceId != null && device.ID == defaultDeviceId,
+                    IsAvailable = device.State == DeviceState.Active
+                });
+            }
+
+            foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(enumerated, "WASAPI render"))
+            {
+                _logger.LogInformation("Audio devices - {Device}", line);
+            }
+
+            _logger.LogInformation("Audio devices - {Selection}", AudioDeviceDiagnostics.DescribeConfiguredSelection(
+                enumerated, _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to log WASAPI device enumeration");
+        }
+    }
+
     private void LogWaveOutConfiguration()
     {
         if (_waveOut == null)
@@ -433,21 +484,31 @@ public class AudioEngineService : IDisposable
         {
             if (_waveOut is WaveOutEvent waveOutEvent)
             {
-                _logger.LogDebug("WaveOut Configuration - Device Number: {DeviceNumber}, Volume: {Volume}", 
-                    waveOutEvent.DeviceNumber, waveOutEvent.Volume);
-                
-                // Get device capabilities using MMDevice API
+                // WaveOut device numbers are their own ordinal space: they do not index the WASAPI
+                // render endpoint list, so the name is read from the WaveOut capabilities rather
+                // than by using the device number as an index into the MMDevice collection.
+                // WaveOutEvent exposes no capability helpers on this target framework, so the
+                // WinMM entry points are called directly.
                 try
                 {
-                    var deviceEnumerator = new MMDeviceEnumerator();
-                    var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-                    
-                    if (waveOutEvent.DeviceNumber >= 0 && waveOutEvent.DeviceNumber < devices.Count)
+                    var deviceCount = WaveInterop.waveOutGetNumDevs();
+                    var productName = "system default";
+
+                    if (waveOutEvent.DeviceNumber >= 0 && waveOutEvent.DeviceNumber < deviceCount)
                     {
-                        var device = devices[waveOutEvent.DeviceNumber];
-                        _logger.LogDebug("Target Device Capabilities - Name: '{FriendlyName}', ID: {DeviceId}",
-                            device.FriendlyName, device.ID);
+                        var capsResult = WaveInterop.waveOutGetDevCaps(
+                            (IntPtr)waveOutEvent.DeviceNumber,
+                            out var capabilities,
+                            Marshal.SizeOf<WaveOutCapabilities>());
+
+                        productName = capsResult == MmResult.NoError
+                            ? capabilities.ProductName
+                            : $"unknown (waveOutGetDevCaps: {capsResult})";
                     }
+
+                    _logger.LogDebug(
+                        "WaveOut Configuration - WaveOut device number {DeviceNumber} of {DeviceCount} is '{ProductName}', Volume: {Volume}",
+                        waveOutEvent.DeviceNumber, deviceCount, productName, waveOutEvent.Volume);
                 }
                 catch (Exception ex)
                 {

--- a/tests/EDButtkicker.Tests/AudioDeviceDiagnosticsTests.cs
+++ b/tests/EDButtkicker.Tests/AudioDeviceDiagnosticsTests.cs
@@ -1,0 +1,205 @@
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The device diagnostic is the only hardware-independent handle on "the device names look off by
+/// one" reports, so the shape of every line it emits is pinned here: a position must never be
+/// printed without the DeviceId beside it, and a saved name that resolves to a different DeviceId
+/// than the saved one must be called out rather than silently reported as the selected device.
+/// </summary>
+public class AudioDeviceDiagnosticsTests
+{
+    private static AudioDevice Device(int deviceId, string name, bool isDefault = false, bool isAvailable = true) =>
+        new()
+        {
+            DeviceId = deviceId,
+            Name = name,
+            Driver = "WASAPI",
+            Channels = 2,
+            IsDefault = isDefault,
+            IsAvailable = isAvailable
+        };
+
+    private static List<AudioDevice> WasapiEnumeration() => new()
+    {
+        Device(0, "Speakers (Realtek)"),
+        Device(1, "Buttkicker (USB Audio)", isDefault: true),
+        Device(2, "Headphones (USB Audio)")
+    };
+
+    [Fact]
+    public void DescribeEnumeration_PairsEveryPositionWithItsDeviceId()
+    {
+        var lines = AudioDeviceDiagnostics.DescribeEnumeration(WasapiEnumeration(), "WASAPI render");
+
+        Assert.Equal(3, lines.Count);
+        Assert.Equal(
+            "WASAPI render position 1 of 3: DeviceId=0 name='Speakers (Realtek)' default=no available=yes",
+            lines[0]);
+        Assert.Equal(
+            "WASAPI render position 2 of 3: DeviceId=1 name='Buttkicker (USB Audio)' default=yes available=yes",
+            lines[1]);
+        Assert.Equal(
+            "WASAPI render position 3 of 3: DeviceId=2 name='Headphones (USB Audio)' default=no available=yes",
+            lines[2]);
+    }
+
+    [Fact]
+    public void DescribeEnumeration_ReportsPositionsOfAListThatDoesNotStartAtDeviceIdZero()
+    {
+        // The web device list prepends a synthetic default, so position and DeviceId are skewed by
+        // more than one. Both coordinates still have to appear on every line.
+        var webList = new List<AudioDevice>
+        {
+            Device(-1, "Default Audio Device", isDefault: true),
+            Device(0, "Speakers (Realtek)"),
+            Device(1, "Buttkicker (USB Audio)")
+        };
+
+        var lines = AudioDeviceDiagnostics.DescribeEnumeration(webList, "web device list");
+
+        Assert.Equal(
+            "web device list position 1 of 3: DeviceId=-1 name='Default Audio Device' default=yes available=yes",
+            lines[0]);
+        Assert.Equal(
+            "web device list position 3 of 3: DeviceId=1 name='Buttkicker (USB Audio)' default=no available=yes",
+            lines[2]);
+    }
+
+    [Fact]
+    public void DescribeEnumeration_MarksUnavailableDevices()
+    {
+        var lines = AudioDeviceDiagnostics.DescribeEnumeration(
+            new List<AudioDevice> { Device(0, "Unplugged", isAvailable: false) },
+            "WASAPI render");
+
+        Assert.Equal("WASAPI render position 1 of 1: DeviceId=0 name='Unplugged' default=no available=no", lines[0]);
+    }
+
+    [Fact]
+    public void DescribeEnumeration_SaysSoWhenTheListIsEmpty()
+    {
+        var lines = AudioDeviceDiagnostics.DescribeEnumeration(new List<AudioDevice>(), "WASAPI render");
+
+        Assert.Equal(new[] { "WASAPI render: no devices enumerated" }, lines);
+    }
+
+    [Fact]
+    public void DescribeEnumeration_SaysSoWhenEnumerationFailedAndReturnedNothing()
+    {
+        var lines = AudioDeviceDiagnostics.DescribeEnumeration(null, "WASAPI render");
+
+        Assert.Equal(new[] { "WASAPI render: no devices enumerated" }, lines);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_ReportsAgreementBetweenSavedNameAndSavedId()
+    {
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 1, configuredDeviceName: "Buttkicker (USB Audio)");
+
+        Assert.Equal(
+            "configured: name 'Buttkicker (USB Audio)' resolves to DeviceId=1 at position 2 of 3, " +
+            "which matches saved DeviceId=1",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_FlagsOffByOneBetweenSavedNameAndSavedId()
+    {
+        // The exact shape a "names are off by one" report produces: the saved id is the menu
+        // position rather than the DeviceId of the saved name.
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 2, configuredDeviceName: "Buttkicker (USB Audio)");
+
+        Assert.Equal(
+            "configured: MISMATCH - name 'Buttkicker (USB Audio)' resolves to DeviceId=1 at position 2 of 3, " +
+            "but saved DeviceId=2 is name 'Headphones (USB Audio)'; playback follows the name",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_FlagsMismatchWhenSavedIdIsNotEnumerated()
+    {
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 7, configuredDeviceName: "Speakers (Realtek)");
+
+        Assert.Equal(
+            "configured: MISMATCH - name 'Speakers (Realtek)' resolves to DeviceId=0 at position 1 of 3, " +
+            "but saved DeviceId=7 is not in this enumeration; playback follows the name",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_ReportsANameThatIsNoLongerPresent()
+    {
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 1, configuredDeviceName: "Removed Interface");
+
+        Assert.Equal(
+            "configured: UNRESOLVED - name 'Removed Interface' is not in this enumeration " +
+            "(saved DeviceId=1 is name 'Buttkicker (USB Audio)'); playback falls back to the system default",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_ReportsDuplicateNamesAsAmbiguous()
+    {
+        var duplicates = new List<AudioDevice>
+        {
+            Device(0, "USB Audio Device"),
+            Device(1, "Speakers (Realtek)"),
+            Device(2, "USB Audio Device")
+        };
+
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            duplicates, configuredDeviceId: 2, configuredDeviceName: "USB Audio Device");
+
+        Assert.Equal(
+            "configured: AMBIGUOUS - 2 devices share name 'USB Audio Device' (DeviceId=0, DeviceId=2); " +
+            "playback uses the first, saved DeviceId=2",
+            line);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void DescribeConfiguredSelection_SaysTheSavedIdIsUnusedWhenNoNameIsSaved(string? name)
+    {
+        // AudioEngineService only ever selects a device by name, so an id saved without a name
+        // picks nothing; the diagnostic must not imply otherwise.
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 1, configuredDeviceName: name);
+
+        Assert.Equal(
+            "configured: no device name saved, playback uses the system default output " +
+            "(saved DeviceId=1 does not pick the device)",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_HandlesAnEmptyEnumeration()
+    {
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            null, configuredDeviceId: 0, configuredDeviceName: "Buttkicker (USB Audio)");
+
+        Assert.Equal(
+            "configured: UNRESOLVED - name 'Buttkicker (USB Audio)' is not in this enumeration " +
+            "(saved DeviceId=0 is not in this enumeration); playback falls back to the system default",
+            line);
+    }
+
+    [Fact]
+    public void DescribeConfiguredSelection_MatchesNamesCaseSensitively()
+    {
+        // MMDevice.FriendlyName is matched with ordinal equality by the engine; the diagnostic has
+        // to agree with it or it would report a selection the engine never makes.
+        var line = AudioDeviceDiagnostics.DescribeConfiguredSelection(
+            WasapiEnumeration(), configuredDeviceId: 1, configuredDeviceName: "buttkicker (usb audio)");
+
+        Assert.StartsWith("configured: UNRESOLVED", line);
+    }
+}


### PR DESCRIPTION
## Summary
- Log the 1-based list position, persisted DeviceId, friendly name, default state, and availability together for WASAPI and web device lists.
- Flag saved name and DeviceId mismatches without changing selection behavior.
- Correct WaveOut diagnostics so its device number is never treated as a WASAPI endpoint index.

## Validation
- `/home/hermes/.dotnet/dotnet test tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj -v minimal` (329 passed)

Windows playback was not run from this Linux environment. This PR adds diagnostics and hardware-independent tests rather than claiming a hardware fix.