### PR TITLE
feat: guide first run and report real subsystem health

### DIFF
--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -14,15 +14,18 @@ public class AudioApiController
     private readonly ILogger<AudioApiController> _logger;
     private readonly AppSettings _settings;
     private readonly AudioEngineService _audioEngine;
+    private readonly IAudioDeviceCatalog _deviceCatalog;
 
     public AudioApiController(
-        ILogger<AudioApiController> logger, 
+        ILogger<AudioApiController> logger,
         AppSettings settings,
-        AudioEngineService audioEngine)
+        AudioEngineService audioEngine,
+        IAudioDeviceCatalog deviceCatalog)
     {
         _logger = logger;
         _settings = settings;
         _audioEngine = audioEngine;
+        _deviceCatalog = deviceCatalog;
     }
 
     public async Task GetAudioDevices(HttpContext context)
@@ -208,60 +211,9 @@ public class AudioApiController
         }
     }
 
-    private List<AudioDevice> GetAvailableAudioDevices()
-    {
-        var devices = new List<AudioDevice>();
-
-        try
-        {
-            // Add default device option
-            devices.Add(new AudioDevice
-            {
-                DeviceId = -1,
-                Name = "Default Audio Device",
-                Driver = "WaveOut",
-                Channels = 2,
-                IsDefault = true,
-                IsAvailable = true
-            });
-
-            // For now, use a simple mapping of MMDevice names to WaveOut-compatible IDs
-            // This is a temporary workaround for the device ID mismatch issue
-            var deviceEnumerator = new MMDeviceEnumerator();
-            var devicesCollection = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-            
-            for (int i = 0; i < devicesCollection.Count; i++)
-            {
-                var device = devicesCollection[i];
-                devices.Add(new AudioDevice
-                {
-                    DeviceId = i,
-                    Name = device.FriendlyName,
-                    Driver = "WASAPI",
-                    Channels = 2, // Default assumption
-                    IsDefault = device.ID == deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID,
-                    IsAvailable = true
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Error enumerating audio devices, using fallback");
-            
-            // Fallback - add a default device entry
-            devices.Add(new AudioDevice
-            {
-                DeviceId = -1,
-                Name = "Default Audio Device",
-                Driver = "Default",
-                Channels = 2,
-                IsDefault = true,
-                IsAvailable = true
-            });
-        }
-
-        return devices;
-    }
+    // One enumeration for the whole app: the setup wizard, the health checks and this API all read
+    // the same catalog, so they can never disagree about which devices exist.
+    private List<AudioDevice> GetAvailableAudioDevices() => _deviceCatalog.GetDevices().ToList();
 
     private int ConvertToWaveOutDeviceId(int mmDeviceId, string deviceName)
     {

--- a/src/EDButtkicker/Controllers/HealthApiController.cs
+++ b/src/EDButtkicker/Controllers/HealthApiController.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Controllers;
+
+/// <summary>
+/// Serves the dashboard's health list and the per-subsystem retry behind each indicator.
+/// </summary>
+public class HealthApiController
+{
+    private readonly ILogger<HealthApiController> _logger;
+    private readonly SystemHealthService _health;
+
+    public HealthApiController(ILogger<HealthApiController> logger, SystemHealthService health)
+    {
+        _logger = logger;
+        _health = health;
+    }
+
+    public async Task GetHealth(HttpContext context)
+    {
+        try
+        {
+            await WriteJsonAsync(context, Serialize(_health.GetReport()));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error building the health report");
+            context.Response.StatusCode = 500;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+        }
+    }
+
+    /// <summary>Runs the retry for one subsystem and answers with the state it produced.</summary>
+    public async Task RetryComponent(HttpContext context, string componentId)
+    {
+        try
+        {
+            if (!SystemHealthService.CanRetry(componentId))
+            {
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                {
+                    error = "No retry is available for this component",
+                    component = componentId
+                }));
+                return;
+            }
+
+            var indicator = await _health.RetryAsync(componentId, context.RequestAborted);
+
+            if (indicator == null)
+            {
+                context.Response.StatusCode = 404;
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                {
+                    error = "Unknown health component",
+                    component = componentId
+                }));
+                return;
+            }
+
+            await WriteJsonAsync(context, new
+            {
+                retried = componentId,
+                component = SerializeIndicator(indicator),
+                health = Serialize(_health.GetReport())
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrying health component {Component}", componentId);
+            context.Response.StatusCode = 500;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+        }
+    }
+
+    /// <summary>Shared shape so the wizard and the dashboard read identical health data.</summary>
+    internal static object Serialize(SystemHealthReport report) => new
+    {
+        status = report.Status,
+        generated_at = report.GeneratedAtUtc,
+        components = report.Components.Select(SerializeIndicator).ToList()
+    };
+
+    internal static object SerializeIndicator(HealthIndicator indicator) => new
+    {
+        id = indicator.Id,
+        name = indicator.Name,
+        status = indicator.Status,
+        reason = indicator.Reason,
+        detail = indicator.Detail,
+        retry = indicator.Retry == null
+            ? null
+            : new
+            {
+                endpoint = indicator.Retry.Endpoint,
+                method = indicator.Retry.Method,
+                label = indicator.Retry.Label
+            }
+    };
+
+    private static Task WriteJsonAsync(HttpContext context, object payload)
+    {
+        context.Response.ContentType = "application/json";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        }));
+    }
+}

--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -13,6 +13,7 @@ public class JournalApiController
     private readonly AppSettings _settings;
     private readonly IJournalEventStore _eventStore;
     private readonly IJournalEventPipeline _pipeline;
+    private readonly JournalMonitorStatus _monitorStatus;
 
     // Replay functionality
     private CancellationTokenSource? _replayTokenSource;
@@ -23,12 +24,14 @@ public class JournalApiController
         ILogger<JournalApiController> logger,
         AppSettings settings,
         IJournalEventStore eventStore,
-        IJournalEventPipeline pipeline)
+        IJournalEventPipeline pipeline,
+        JournalMonitorStatus monitorStatus)
     {
         _logger = logger;
         _settings = settings;
         _eventStore = eventStore;
         _pipeline = pipeline;
+        _monitorStatus = monitorStatus;
     }
 
     public async Task GetJournalStatus(HttpContext context)
@@ -57,17 +60,25 @@ public class JournalApiController
                 }
             }
 
+            // Monitoring means a watcher is attached, not merely that the folder is there: the two
+            // came apart whenever the folder existed but the monitor could not start on it.
+            var monitor = _monitorStatus.Current;
+            var monitoring = monitor.State == JournalWatchState.Watching;
+
             var status = new
             {
                 journal_path = journalPath,
                 path_exists = pathExists,
-                monitoring = pathExists,
+                monitoring,
+                monitor_state = monitor.State.ToString(),
+                monitor_reason = monitor.Reason,
+                monitor_active_file = monitor.ActiveFile,
                 monitor_latest_only = _settings.EliteDangerous.MonitorLatestOnly,
                 recent_files = journalFiles,
                 events_processed = GetRecentEventsCount(),
                 last_event_time = GetLastEventTime(),
-                status = pathExists ? "Connected" : "Disconnected",
-                health = pathExists ? "Healthy" : "Configuration Required"
+                status = monitoring ? "Connected" : "Disconnected",
+                health = monitoring ? "Healthy" : "Configuration Required"
             };
 
             context.Response.ContentType = "application/json";

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -126,7 +126,17 @@ public class SetupApiController
             var candidate = JournalPathDiscovery.Inspect(journalPath, "confirmed", isConfigured: true);
 
             _settings.EliteDangerous.JournalPath = journalPath;
-            await PersistUserSettingsAsync();
+
+            // The watcher may have given up on a folder that did not exist at startup.
+            _journalStatus.RequestRecheck();
+
+            if (!await TryPersistUserSettingsAsync())
+            {
+                // The folder is in use for this session, but it will not come back after a restart,
+                // so the step must not be recorded as confirmed.
+                await WriteNotSavedAsync(context, "journal folder");
+                return;
+            }
 
             var confirmedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _setupState.UpdateAsync(state =>
@@ -134,9 +144,6 @@ public class SetupApiController
                 state.JournalConfirmedAtUtc = confirmedAt;
                 state.JournalPath = journalPath;
             });
-
-            // The watcher may have given up on a folder that did not exist at startup.
-            _journalStatus.RequestRecheck();
 
             _logger.LogInformation(
                 "Setup confirmed journal path {JournalPath} ({FileCount} journal file(s) present)",
@@ -204,7 +211,14 @@ public class SetupApiController
 
             _settings.Audio.AudioDeviceId = device.DeviceId;
             _settings.Audio.AudioDeviceName = isSystemDefault ? string.Empty : device.Name;
-            await PersistUserSettingsAsync();
+
+            if (!await TryPersistUserSettingsAsync())
+            {
+                // Same rule as the journal step: an output that will not survive a restart is not a
+                // confirmed step, and the previously recorded state stays as it was.
+                await WriteNotSavedAsync(context, "output device");
+                return;
+            }
 
             var confirmedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _setupState.UpdateAsync(state =>
@@ -417,17 +431,43 @@ public class SetupApiController
         };
     }
 
-    private async Task PersistUserSettingsAsync()
+    /// <summary>
+    /// Writes the running configuration to the user settings file. Returns false when it could not
+    /// be written: the caller must not then record the step as confirmed, because the choice would
+    /// be gone on the next run while the wizard claimed it was done.
+    /// </summary>
+    private async Task<bool> TryPersistUserSettingsAsync()
     {
         try
         {
             await _userSettings.SaveUserPreferencesAsync(_userSettings.CreatePreferencesFromAppSettings(_settings));
+            return true;
         }
         catch (Exception ex)
         {
-            // The running configuration is already updated; only the persistence failed.
-            _logger.LogError(ex, "Setup could not persist user settings");
+            _logger.LogError(ex, "Setup could not persist user settings to {SettingsPath}", _userSettings.GetUserSettingsPath());
+            return false;
         }
+    }
+
+    /// <summary>
+    /// Reports a choice that applied to this session but could not be saved, leaving the recorded
+    /// setup state exactly as it was.
+    /// </summary>
+    private async Task WriteNotSavedAsync(HttpContext context, string what)
+    {
+        var setup = await BuildStatusAsync();
+
+        context.Response.StatusCode = 500;
+        context.Response.ContentType = "application/json";
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+        {
+            error = $"The {what} is in use for this session but could not be saved to {_userSettings.GetUserSettingsPath()}, " +
+                "so this step is not marked complete. Check that the file is writable and try again.",
+            saved = false,
+            setup
+        }, new JsonSerializerOptions { WriteIndented = true }));
     }
 
     private static async Task<Dictionary<string, JsonElement>?> ReadJsonAsync(HttpContext context)

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -1,0 +1,493 @@
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Controllers;
+
+/// <summary>
+/// The first-run wizard: journal discovery, a stable output choice, a deliberately quiet audio
+/// test, and completion. Every step reports what actually happened - a step is only "done" once the
+/// subsystem it configures accepted the value.
+/// </summary>
+public class SetupApiController
+{
+    /// <summary>
+    /// The test tone is deliberately gentle: a buttkicker is a physical actuator and the user has
+    /// not set their amplifier gain yet when they reach this step.
+    /// </summary>
+    public const int TestIntensityPercent = 30;
+    public const int TestDurationMs = 800;
+    public const int TestFadeInMs = 200;
+    public const int TestFadeOutMs = 300;
+    public const int MinTestFrequency = 20;
+    public const int MaxTestFrequency = 50;
+
+    private readonly ILogger<SetupApiController> _logger;
+    private readonly AppSettings _settings;
+    private readonly SetupStateService _setupState;
+    private readonly UserSettingsService _userSettings;
+    private readonly JournalPathDiscovery _journalDiscovery;
+    private readonly JournalMonitorStatus _journalStatus;
+    private readonly IAudioDeviceCatalog _deviceCatalog;
+    private readonly AudioEngineService _audioEngine;
+    private readonly SystemHealthService _health;
+    private readonly TimeProvider _timeProvider;
+
+    public SetupApiController(
+        ILogger<SetupApiController> logger,
+        AppSettings settings,
+        SetupStateService setupState,
+        UserSettingsService userSettings,
+        JournalPathDiscovery journalDiscovery,
+        JournalMonitorStatus journalStatus,
+        IAudioDeviceCatalog deviceCatalog,
+        AudioEngineService audioEngine,
+        SystemHealthService health,
+        TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _settings = settings;
+        _setupState = setupState;
+        _userSettings = userSettings;
+        _journalDiscovery = journalDiscovery;
+        _journalStatus = journalStatus;
+        _deviceCatalog = deviceCatalog;
+        _audioEngine = audioEngine;
+        _health = health;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task GetStatus(HttpContext context)
+    {
+        try
+        {
+            await WriteJsonAsync(context, await BuildStatusAsync());
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error building setup status");
+        }
+    }
+
+    /// <summary>Step 1: the folders the journal could be in, and what is in each of them.</summary>
+    public async Task GetJournalCandidates(HttpContext context)
+    {
+        try
+        {
+            var candidates = _journalDiscovery.Discover();
+
+            await WriteJsonAsync(context, new
+            {
+                configured_path = _settings.EliteDangerous.JournalPath,
+                candidates = candidates.Select(c => new
+                {
+                    path = c.Path,
+                    source = c.Source,
+                    exists = c.Exists,
+                    journal_files_found = c.JournalFileCount,
+                    latest_journal_write = c.LatestJournalWriteUtc,
+                    is_configured = c.IsConfigured,
+                    is_recommended = c.IsRecommended
+                }).ToList(),
+                recommended_path = candidates.FirstOrDefault(c => c.IsRecommended)?.Path
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error discovering journal folders");
+        }
+    }
+
+    /// <summary>Step 1: confirm a journal folder, persist it, and wake the watcher.</summary>
+    public async Task ConfirmJournalPath(HttpContext context)
+    {
+        try
+        {
+            var body = await ReadJsonAsync(context);
+            var requestedPath = ReadString(body, "path");
+
+            if (string.IsNullOrWhiteSpace(requestedPath))
+            {
+                await WriteBadRequestAsync(context, "A journal folder path is required");
+                return;
+            }
+
+            var journalPath = JournalPathDiscovery.ExpandUserProfile(requestedPath.Trim());
+
+            if (!Directory.Exists(journalPath))
+            {
+                await WriteBadRequestAsync(context, "That folder does not exist", new { path = journalPath });
+                return;
+            }
+
+            var candidate = JournalPathDiscovery.Inspect(journalPath, "confirmed", isConfigured: true);
+
+            _settings.EliteDangerous.JournalPath = journalPath;
+            await PersistUserSettingsAsync();
+
+            var confirmedAt = _timeProvider.GetUtcNow().UtcDateTime;
+            await _setupState.UpdateAsync(state =>
+            {
+                state.JournalConfirmedAtUtc = confirmedAt;
+                state.JournalPath = journalPath;
+            });
+
+            // The watcher may have given up on a folder that did not exist at startup.
+            _journalStatus.RequestRecheck();
+
+            _logger.LogInformation(
+                "Setup confirmed journal path {JournalPath} ({FileCount} journal file(s) present)",
+                journalPath, candidate.JournalFileCount);
+
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                path = journalPath,
+                journal_files_found = candidate.JournalFileCount,
+                // A brand new install has no journal files yet; that is worth saying, not refusing.
+                warning = candidate.JournalFileCount == 0
+                    ? "No journal files here yet. This is normal before Elite Dangerous has been run; monitoring starts when the first one appears."
+                    : null,
+                setup = await BuildStatusAsync()
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error confirming journal path");
+        }
+    }
+
+    /// <summary>Step 2: choose the output. The device name is what gets persisted, because the
+    /// enumeration index moves when devices are plugged in or removed.</summary>
+    public async Task SelectAudioDevice(HttpContext context)
+    {
+        try
+        {
+            var body = await ReadJsonAsync(context);
+            var requestedName = ReadString(body, "name");
+            var requestedId = ReadInt(body, "deviceId");
+
+            if (string.IsNullOrWhiteSpace(requestedName) && requestedId == null)
+            {
+                await WriteBadRequestAsync(context, "An output device name or id is required");
+                return;
+            }
+
+            var devices = _deviceCatalog.GetDevices();
+            var device = !string.IsNullOrWhiteSpace(requestedName)
+                ? devices.FirstOrDefault(d => string.Equals(d.Name, requestedName, StringComparison.OrdinalIgnoreCase))
+                : devices.FirstOrDefault(d => d.DeviceId == requestedId);
+
+            if (device == null)
+            {
+                await WriteBadRequestAsync(context, "That output device is not connected", new
+                {
+                    requested_name = requestedName,
+                    requested_id = requestedId,
+                    available = devices.Select(d => d.Name).ToList()
+                });
+                return;
+            }
+
+            if (!device.IsAvailable)
+            {
+                await WriteBadRequestAsync(context, "That output device is not currently active", new { name = device.Name });
+                return;
+            }
+
+            // The system default entry has no stable name to match on later, so it is stored as the
+            // empty name the audio engine already reads as "use the default".
+            var isSystemDefault = device.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId;
+
+            _settings.Audio.AudioDeviceId = device.DeviceId;
+            _settings.Audio.AudioDeviceName = isSystemDefault ? string.Empty : device.Name;
+            await PersistUserSettingsAsync();
+
+            var confirmedAt = _timeProvider.GetUtcNow().UtcDateTime;
+            await _setupState.UpdateAsync(state =>
+            {
+                state.AudioDeviceConfirmedAtUtc = confirmedAt;
+                state.AudioDeviceName = isSystemDefault ? null : device.Name;
+                state.AudioDeviceId = device.DeviceId;
+
+                // A different output invalidates the previous test result.
+                state.AudioTestedAtUtc = null;
+                state.AudioTestPlayed = null;
+                state.AudioTestReason = null;
+            });
+
+            _logger.LogInformation("Setup selected audio output {DeviceName} (id {DeviceId})", device.Name, device.DeviceId);
+
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                device = new
+                {
+                    id = device.DeviceId,
+                    name = device.Name,
+                    driver = device.Driver,
+                    is_default = device.IsDefault
+                },
+                setup = await BuildStatusAsync()
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error selecting the audio output device");
+        }
+    }
+
+    /// <summary>Step 3: a short, quiet test tone, reported by what the audio engine actually did.</summary>
+    public async Task RunAudioTest(HttpContext context)
+    {
+        try
+        {
+            var pattern = BuildTestPattern();
+            var opened = _audioEngine.RetryInitialization();
+
+            if (opened)
+            {
+                await _audioEngine.PlayHapticPattern(pattern);
+            }
+
+            var status = _audioEngine.GetStatus();
+            var reason = opened
+                ? $"Played a {pattern.Duration} ms tone at {pattern.Frequency} Hz and {pattern.Intensity}% intensity."
+                : string.IsNullOrWhiteSpace(status.LastError)
+                    ? "No audio output device could be opened, so nothing was played."
+                    : $"No audio output device could be opened, so nothing was played: {status.LastError}";
+
+            var testedAt = _timeProvider.GetUtcNow().UtcDateTime;
+            await _setupState.UpdateAsync(state =>
+            {
+                state.AudioTestedAtUtc = testedAt;
+                state.AudioTestPlayed = opened;
+                state.AudioTestReason = reason;
+            });
+
+            _logger.LogInformation("Setup audio test ran, played: {Played}", opened);
+
+            await WriteJsonAsync(context, new
+            {
+                // Truthfully false when no device could be opened - the request succeeded, the
+                // playback did not.
+                played = opened,
+                reason,
+                pattern = new
+                {
+                    name = pattern.Name,
+                    frequency = pattern.Frequency,
+                    duration = pattern.Duration,
+                    intensity = pattern.Intensity
+                },
+                device = new
+                {
+                    id = _settings.Audio.AudioDeviceId,
+                    name = string.IsNullOrWhiteSpace(_settings.Audio.AudioDeviceName)
+                        ? WasapiAudioDeviceCatalog.SystemDefaultDeviceName
+                        : _settings.Audio.AudioDeviceName
+                },
+                setup = await BuildStatusAsync()
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error running the setup audio test");
+        }
+    }
+
+    /// <summary>Step 4: record completion. Skipped steps are listed rather than hidden.</summary>
+    public async Task CompleteSetup(HttpContext context)
+    {
+        try
+        {
+            var completedAt = _timeProvider.GetUtcNow().UtcDateTime;
+            await _setupState.MarkCompletedAsync(completedAt);
+
+            var status = await BuildStatusAsync();
+            _logger.LogInformation("First-run setup marked complete at {CompletedAt:u}", completedAt);
+
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                completed_at = completedAt,
+                setup = status
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error completing setup");
+        }
+    }
+
+    /// <summary>Reopens the wizard without discarding the record that it was completed.</summary>
+    public async Task ReopenSetup(HttpContext context)
+    {
+        try
+        {
+            _setupState.RequestReopen();
+
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                setup = await BuildStatusAsync()
+            });
+        }
+        catch (Exception ex)
+        {
+            await WriteErrorAsync(context, ex, "Error reopening setup");
+        }
+    }
+
+    private HapticPattern BuildTestPattern() => new()
+    {
+        Name = "Setup Audio Test",
+        Pattern = PatternType.SustainedRumble,
+        Frequency = Math.Clamp(_settings.Audio.DefaultFrequency, MinTestFrequency, MaxTestFrequency),
+        Duration = TestDurationMs,
+        Intensity = Math.Min(TestIntensityPercent, Math.Max(1, _settings.Audio.MaxIntensity)),
+        FadeIn = TestFadeInMs,
+        FadeOut = TestFadeOutMs
+    };
+
+    private async Task<object> BuildStatusAsync()
+    {
+        var state = await _setupState.LoadAsync();
+        var journalDone = state.JournalConfirmedAtUtc != null;
+        var deviceDone = state.AudioDeviceConfirmedAtUtc != null;
+        var testDone = state.AudioTestedAtUtc != null;
+
+        var steps = new[]
+        {
+            new
+            {
+                id = "journal",
+                title = "Find your Elite Dangerous journal",
+                complete = journalDone,
+                summary = journalDone
+                    ? $"Journal folder: {state.JournalPath}"
+                    : "Pick the folder Elite Dangerous writes its journal files to."
+            },
+            new
+            {
+                id = "audio-device",
+                title = "Choose your output device",
+                complete = deviceDone,
+                summary = deviceDone
+                    ? $"Output: {state.AudioDeviceName ?? WasapiAudioDeviceCatalog.SystemDefaultDeviceName}"
+                    : "Pick the device your buttkicker amplifier is connected to."
+            },
+            new
+            {
+                id = "audio-test",
+                title = "Run a quiet test",
+                complete = testDone,
+                summary = testDone
+                    ? state.AudioTestReason ?? "Audio test ran."
+                    : $"Plays a short {TestIntensityPercent}% tone so you can set your amplifier gain safely."
+            },
+            new
+            {
+                id = "finish",
+                title = "Finish setup",
+                complete = state.Completed,
+                summary = state.Completed
+                    ? $"Setup completed {state.CompletedAtUtc:yyyy-MM-dd HH:mm} UTC. You can reopen this wizard at any time."
+                    : "Save this configuration and open the dashboard."
+            }
+        };
+
+        var incomplete = steps.Where(s => !s.complete).Select(s => s.id).ToList();
+
+        return new
+        {
+            completed = state.Completed,
+            completed_at = state.CompletedAtUtc,
+            reopen_requested = _setupState.ReopenRequested,
+            // Persisted completion keeps the wizard closed on later runs; a reopen request or an
+            // unfinished setup opens it again.
+            show_wizard = !state.Completed || _setupState.ReopenRequested,
+            current_step = incomplete.FirstOrDefault() ?? "finish",
+            incomplete_steps = incomplete,
+            steps,
+            health = HealthApiController.Serialize(_health.GetReport())
+        };
+    }
+
+    private async Task PersistUserSettingsAsync()
+    {
+        try
+        {
+            await _userSettings.SaveUserPreferencesAsync(_userSettings.CreatePreferencesFromAppSettings(_settings));
+        }
+        catch (Exception ex)
+        {
+            // The running configuration is already updated; only the persistence failed.
+            _logger.LogError(ex, "Setup could not persist user settings");
+        }
+    }
+
+    private static async Task<Dictionary<string, JsonElement>?> ReadJsonAsync(HttpContext context)
+    {
+        using var reader = new StreamReader(context.Request.Body);
+        var json = await reader.ReadToEndAsync();
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+    }
+
+    private static string? ReadString(Dictionary<string, JsonElement>? body, string key) =>
+        body != null && body.TryGetValue(key, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? ReadInt(Dictionary<string, JsonElement>? body, string key)
+    {
+        if (body == null || !body.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetInt32(out var number) => number,
+            JsonValueKind.String when int.TryParse(value.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static Task WriteJsonAsync(HttpContext context, object payload)
+    {
+        context.Response.ContentType = "application/json";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        }));
+    }
+
+    private static Task WriteBadRequestAsync(HttpContext context, string error, object? detail = null)
+    {
+        context.Response.StatusCode = 400;
+        context.Response.ContentType = "application/json";
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(new
+        {
+            error,
+            detail
+        }));
+    }
+
+    private async Task WriteErrorAsync(HttpContext context, Exception ex, string message)
+    {
+        _logger.LogError(ex, "{Message}", message);
+        context.Response.StatusCode = 500;
+        await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+    }
+}

--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -36,6 +36,15 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<PatternSelectionService>();
         services.AddSingleton<ShipPatternService>();
 
+        // First-run setup and the health checklist. The monitor status object is shared state
+        // between the journal watcher and the health API, so it has to be one singleton; the device
+        // catalog is behind an interface so health checks work where WASAPI does not exist.
+        services.AddSingleton<JournalMonitorStatus>();
+        services.AddSingleton<IAudioDeviceCatalog, WasapiAudioDeviceCatalog>();
+        services.AddSingleton<JournalPathDiscovery>();
+        services.AddSingleton<SetupStateService>();
+        services.AddSingleton<SystemHealthService>();
+
         // Journal event pipeline: one ordered path for history, ship state,
         // pattern selection and audio, shared by live monitoring and replay.
         services.AddSingleton<IJournalEventStore, JournalEventStore>();
@@ -63,6 +72,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<PatternFilesController>();
         services.AddSingleton<PatternEditorController>();
         services.AddSingleton<ContextualIntelligenceApiController>();
+        services.AddSingleton<SetupApiController>();
+        services.AddSingleton<HealthApiController>();
 
         // Not routed today, but they belong to the same graph so they stay resolvable.
         services.AddSingleton<UserSettingsController>();

--- a/src/EDButtkicker/Hosting/WebUiConfiguration.cs
+++ b/src/EDButtkicker/Hosting/WebUiConfiguration.cs
@@ -231,6 +231,63 @@ public static class WebUiConfiguration
                     await controller!.GetUserFilesHttpContext(context, author);
                     return;
                 }
+                // First-run setup API
+                else if (path == "/api/setup/status" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.GetStatus(context);
+                    return;
+                }
+                else if (path == "/api/setup/journal/candidates" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.GetJournalCandidates(context);
+                    return;
+                }
+                else if (path == "/api/setup/journal" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.ConfirmJournalPath(context);
+                    return;
+                }
+                else if (path == "/api/setup/audio/device" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.SelectAudioDevice(context);
+                    return;
+                }
+                else if (path == "/api/setup/audio/test" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.RunAudioTest(context);
+                    return;
+                }
+                else if (path == "/api/setup/complete" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.CompleteSetup(context);
+                    return;
+                }
+                else if (path == "/api/setup/reopen" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<SetupApiController>();
+                    await controller!.ReopenSetup(context);
+                    return;
+                }
+                // Health API
+                else if (path == "/api/health" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<HealthApiController>();
+                    await controller!.GetHealth(context);
+                    return;
+                }
+                else if (path.StartsWith("/api/health/") && path.EndsWith("/retry") && method == "POST")
+                {
+                    var componentId = path["/api/health/".Length..^"/retry".Length];
+                    var controller = context.RequestServices.GetService<HealthApiController>();
+                    await controller!.RetryComponent(context, componentId);
+                    return;
+                }
                 // Contextual Intelligence API
                 else if (path == "/api/context/status" && method == "GET")
                 {

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -60,7 +60,8 @@ class Program
 
             // Start services and web UI
             logger.LogInformation("Starting services and web interface...");
-            ShowStartupInfo(debugMode);
+            var setupState = await host.Services.GetRequiredService<SetupStateService>().LoadAsync();
+            ShowStartupInfo(appSettings, setupState, debugMode);
             await host.RunAsync();
         }
         catch (Exception ex)
@@ -261,13 +262,21 @@ class Program
         }
     }
 
-    static void ShowStartupInfo(bool debugMode = false)
+    static void ShowStartupInfo(AppSettings settings, SetupState setupState, bool debugMode = false)
     {
+        var journalPath = settings.EliteDangerous.JournalPath;
+        var journalFolderExists = !string.IsNullOrWhiteSpace(journalPath) && Directory.Exists(journalPath);
+
         Console.WriteLine("✓ Elite Dangerous Buttkicker Extension is running!");
         Console.WriteLine();
-        Console.WriteLine("🌍 Web Interface: http://localhost:47811");
-        Console.WriteLine("🎵 Audio: Using system default device (can be changed in web UI)");
-        Console.WriteLine("📁 Journal: Auto-detecting Elite Dangerous folder");
+        Console.WriteLine($"🌍 Web Interface: http://localhost:{WebUiConfiguration.Port}");
+        Console.WriteLine($"🎵 Audio: {(string.IsNullOrWhiteSpace(settings.Audio.AudioDeviceName) ? "System default device" : settings.Audio.AudioDeviceName)}");
+        // Say what the journal folder actually is, and whether it is there - the old text claimed
+        // auto-detection had worked no matter what.
+        Console.WriteLine($"📁 Journal: {journalPath} ({(journalFolderExists ? "found" : "not found yet")})");
+        Console.WriteLine(setupState.Completed
+            ? "🧭 Setup: completed - reopen the wizard from the dashboard whenever you need it"
+            : "🧭 Setup: not completed - the first-run wizard opens in the web interface");
         Console.WriteLine();
         Console.WriteLine("Supported Events:");
         Console.WriteLine("┌─ Core Events:");

--- a/src/EDButtkicker/Services/AudioDeviceCatalog.cs
+++ b/src/EDButtkicker/Services/AudioDeviceCatalog.cs
@@ -1,0 +1,91 @@
+using EDButtkicker.Models;
+using Microsoft.Extensions.Logging;
+using NAudio.CoreAudioApi;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// The output devices the app can honestly offer. Behind an interface because enumeration talks to
+/// WASAPI: the health checks, the setup wizard and the audio API all need a device list on machines
+/// (and CI agents) where that call cannot succeed at all.
+/// </summary>
+public interface IAudioDeviceCatalog
+{
+    /// <summary>The system default entry (id -1) followed by every active render endpoint.</summary>
+    IReadOnlyList<AudioDevice> GetDevices();
+}
+
+/// <summary>
+/// WASAPI-backed catalog. When enumeration fails the list is not padded with invented entries -
+/// the caller gets the system default and nothing else, which is exactly what is usable.
+/// </summary>
+public class WasapiAudioDeviceCatalog : IAudioDeviceCatalog
+{
+    public const int SystemDefaultDeviceId = -1;
+    public const string SystemDefaultDeviceName = "Default Audio Device";
+
+    private readonly ILogger<WasapiAudioDeviceCatalog> _logger;
+
+    public WasapiAudioDeviceCatalog(ILogger<WasapiAudioDeviceCatalog> logger)
+    {
+        _logger = logger;
+    }
+
+    public IReadOnlyList<AudioDevice> GetDevices()
+    {
+        var devices = new List<AudioDevice>
+        {
+            new()
+            {
+                DeviceId = SystemDefaultDeviceId,
+                Name = SystemDefaultDeviceName,
+                Driver = "Default",
+                Channels = 2,
+                IsDefault = true,
+                IsAvailable = true
+            }
+        };
+
+        try
+        {
+            var enumerator = new MMDeviceEnumerator();
+            var endpoints = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+            var defaultEndpointId = TryGetDefaultEndpointId(enumerator);
+
+            for (int i = 0; i < endpoints.Count; i++)
+            {
+                var endpoint = endpoints[i];
+
+                devices.Add(new AudioDevice
+                {
+                    DeviceId = i,
+                    Name = endpoint.FriendlyName,
+                    Driver = "WASAPI",
+                    Channels = 2,
+                    IsDefault = defaultEndpointId != null && endpoint.ID == defaultEndpointId,
+                    IsAvailable = endpoint.State == DeviceState.Active
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            // No WASAPI here (no hardware, or not Windows): the system default is all we can offer.
+            _logger.LogWarning(ex, "Error enumerating audio devices, offering the system default only");
+        }
+
+        return devices;
+    }
+
+    private string? TryGetDefaultEndpointId(MMDeviceEnumerator enumerator)
+    {
+        try
+        {
+            return enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "No default render endpoint reported");
+            return null;
+        }
+    }
+}

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -17,6 +17,8 @@ public class AudioEngineService : IDisposable
     private readonly object _lock = new object();
     private bool _isInitialized = false;
     private bool _initializationFailed = false;
+    private string? _lastInitializationError;
+    private DateTime? _openedAtUtc;
     private readonly Dictionary<string, SignalGenerator> _activeGenerators = new();
     private readonly Dictionary<string, CancellationTokenSource> _activeCancellations = new();
 
@@ -90,6 +92,8 @@ public class AudioEngineService : IDisposable
                 _logger.LogDebug("Wave output playback state: {PlaybackState}", playbackState);
 
                 _isInitialized = true;
+                _lastInitializationError = null;
+                _openedAtUtc = DateTime.UtcNow;
                 _logger.LogInformation("✓ Audio Engine initialized successfully");
                 _logger.LogInformation("Configuration: Sample Rate: {SampleRate}Hz, Buffer Size: {BufferSize}, Channels: 1", 
                     _settings.Audio.SampleRate, _settings.Audio.BufferSize);
@@ -97,6 +101,8 @@ public class AudioEngineService : IDisposable
             }
             catch (Exception ex)
             {
+                // Kept so the health API can name the actual failure rather than "offline".
+                _lastInitializationError = ex.Message;
                 _logger.LogError(ex, "❌ Failed to initialize audio engine: {ErrorMessage}", ex.Message);
                 LogDetailedAudioError(ex);
                 throw;
@@ -110,7 +116,7 @@ public class AudioEngineService : IDisposable
     /// this never throws: a machine with no usable output device just gets no haptics, and one
     /// failed attempt is remembered so every later pattern does not retry the device enumeration.
     /// </summary>
-    public bool EnsureInitialized()
+    public virtual bool EnsureInitialized()
     {
         lock (_lock)
         {
@@ -124,12 +130,45 @@ public class AudioEngineService : IDisposable
             catch (Exception ex)
             {
                 _initializationFailed = true;
+                _lastInitializationError = ex.Message;
                 _logger.LogError(ex, "Audio engine unavailable, haptics are disabled for this session");
                 return false;
             }
 
             return _isInitialized;
         }
+    }
+
+    /// <summary>
+    /// What the audio output is actually doing. Reading this never opens a device, so the health
+    /// API can report "not opened yet" honestly instead of guessing from an unrelated API call.
+    /// </summary>
+    public virtual AudioEngineStatus GetStatus()
+    {
+        lock (_lock)
+        {
+            return new AudioEngineStatus(
+                _isInitialized,
+                _initializationFailed,
+                _lastInitializationError,
+                _settings.Audio.AudioDeviceName,
+                _openedAtUtc);
+        }
+    }
+
+    /// <summary>
+    /// Forgets a previous failure and tries to open the device again. This is what the health
+    /// indicator's retry runs; it reports the real outcome rather than clearing the warning.
+    /// </summary>
+    public bool RetryInitialization()
+    {
+        lock (_lock)
+        {
+            _initializationFailed = false;
+            _lastInitializationError = null;
+        }
+
+        return EnsureInitialized();
     }
 
     /// <summary>
@@ -327,8 +366,10 @@ public class AudioEngineService : IDisposable
             
             _mixer = null;
             _isInitialized = false;
+            _openedAtUtc = null;
             // A new device deserves a fresh attempt even if the previous one could not be opened.
             _initializationFailed = false;
+            _lastInitializationError = null;
             
             // Clear active cancellations
             foreach (var cancellation in _activeCancellations.Values)
@@ -525,3 +566,14 @@ public class AudioEngineService : IDisposable
         _activeCancellations.Clear();
     }
 }
+
+/// <summary>
+/// A read of the audio output state that costs nothing: whether a device is open, whether opening
+/// one failed and why, and which device the settings ask for.
+/// </summary>
+public sealed record AudioEngineStatus(
+    bool Initialized,
+    bool InitializationFailed,
+    string? LastError,
+    string? ConfiguredDeviceName,
+    DateTime? OpenedAtUtc);

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -46,11 +46,11 @@ public class AudioEngineService : IDisposable
 				if (!string.IsNullOrEmpty(_settings.Audio.AudioDeviceName))
 				{
 					_logger.LogDebug("Attempting to find audio device by name: '{DeviceName}'", _settings.Audio.AudioDeviceName);
-					
+
 					var deviceEnumerator = new MMDeviceEnumerator();
 					var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
 					var matchedDevice = devices.FirstOrDefault(d => d.FriendlyName == _settings.Audio.AudioDeviceName);
-					
+
 					if (matchedDevice != null)
 					{
 						_waveOut = new WasapiOut(matchedDevice, AudioClientShareMode.Shared, true, 200);

--- a/src/EDButtkicker/Services/JournalMonitorService.cs
+++ b/src/EDButtkicker/Services/JournalMonitorService.cs
@@ -9,8 +9,12 @@ public class JournalMonitorService : BackgroundService
 {
     private static readonly TimeSpan RotationCheckInterval = TimeSpan.FromSeconds(1);
 
+    /// <summary>How long to wait before looking at an unusable journal folder again.</summary>
+    private static readonly TimeSpan FolderRecheckInterval = TimeSpan.FromSeconds(5);
+
     private readonly ILogger<JournalMonitorService> _logger;
     private readonly AppSettings _settings;
+    private readonly JournalMonitorStatus _status;
     private readonly IJournalEventPipeline _pipeline;
     private readonly ShipTrackingService _shipTrackingService;
     private readonly ShipPatternService _shipPatternService;
@@ -27,6 +31,7 @@ public class JournalMonitorService : BackgroundService
     public JournalMonitorService(
         ILogger<JournalMonitorService> logger,
         AppSettings settings,
+        JournalMonitorStatus status,
         IJournalEventPipeline pipeline,
         ShipTrackingService shipTrackingService,
         ShipPatternService shipPatternService,
@@ -36,6 +41,7 @@ public class JournalMonitorService : BackgroundService
     {
         _logger = logger;
         _settings = settings;
+        _status = status;
         _pipeline = pipeline;
         _shipTrackingService = shipTrackingService;
         _shipPatternService = shipPatternService;
@@ -52,14 +58,43 @@ public class JournalMonitorService : BackgroundService
         // journal event is processed, otherwise early events use default patterns only.
         await LoadPatternStateAsync();
 
-        var journalPath = _settings.EliteDangerous.JournalPath;
-        if (!Directory.Exists(journalPath))
+        try
         {
-            _logger.LogError("Journal path does not exist: {Path}", journalPath);
-            return;
+            // A folder that does not exist yet is not fatal any more: the setup wizard can point us
+            // somewhere else, and Elite Dangerous creates the folder on its first run. The monitor
+            // keeps re-checking (and re-checks immediately when the health retry asks it to) instead
+            // of giving up for the lifetime of the process.
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var journalPath = _settings.EliteDangerous.JournalPath;
+
+                if (string.IsNullOrWhiteSpace(journalPath) || !Directory.Exists(journalPath))
+                {
+                    var reason = string.IsNullOrWhiteSpace(journalPath)
+                        ? "No journal folder is configured yet."
+                        : $"The journal folder does not exist yet: {journalPath}";
+
+                    _status.ReportWaiting(journalPath, reason);
+                    _logger.LogWarning("Journal folder unavailable, waiting: {Reason}", reason);
+
+                    await _status.WaitForRecheckAsync(FolderRecheckInterval, stoppingToken);
+                    continue;
+                }
+
+                await StartMonitoring(journalPath, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown.
+        }
+        catch (Exception ex)
+        {
+            _status.ReportFaulted($"Journal monitoring stopped after an error: {ex.Message}");
+            throw;
         }
 
-        await StartMonitoring(journalPath, stoppingToken);
+        _status.ReportStopped("Journal monitoring stopped.");
     }
 
     private async Task LoadPatternStateAsync()
@@ -117,7 +152,8 @@ public class JournalMonitorService : BackgroundService
         _reader = new JournalTailReader(journalPath, _settings.EliteDangerous.MonitorLatestOnly, _logger);
         _pump = new JournalSignalPump(DrainJournalAsync, _logger);
 
-        if (_reader.FindLatestJournalFile() == null)
+        var latestFile = _reader.FindLatestJournalFile();
+        if (latestFile == null)
         {
             _logger.LogWarning("No journal files found in {Path}; waiting for one to appear", journalPath);
         }
@@ -125,6 +161,7 @@ public class JournalMonitorService : BackgroundService
         // Watcher signals and the periodic rotation check both feed the same single-reader queue,
         // so overlapping Changed callbacks can never run two reads (or two cursor updates) at once.
         SetupFileWatcher(journalPath);
+        _status.ReportWatching(journalPath, latestFile == null ? null : Path.GetFileName(latestFile));
 
         var pumpTask = _pump.RunAsync(stoppingToken);
 
@@ -135,7 +172,17 @@ public class JournalMonitorService : BackgroundService
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(RotationCheckInterval, stoppingToken);
+                // The wait ends early when a health retry asks for a re-check, so "Retry" acts now
+                // rather than at the end of the next rotation interval.
+                await _status.WaitForRecheckAsync(RotationCheckInterval, stoppingToken);
+
+                if (!Directory.Exists(journalPath) || !IsStillConfigured(journalPath))
+                {
+                    // The folder went away, or setup pointed us at a different one: hand back to the
+                    // outer loop, which reports why and re-attaches.
+                    break;
+                }
+
                 _pump.Signal();
             }
         }
@@ -153,9 +200,14 @@ public class JournalMonitorService : BackgroundService
             _fileWatcher?.Dispose();
             _fileWatcher = null;
             _pump.Dispose();
+            _pump = null;
+            _reader = null;
             await pumpTask.ConfigureAwait(false);
         }
     }
+
+    private bool IsStillConfigured(string journalPath) =>
+        string.Equals(_settings.EliteDangerous.JournalPath, journalPath, StringComparison.OrdinalIgnoreCase);
 
     private void SetupFileWatcher(string journalPath)
     {
@@ -178,10 +230,18 @@ public class JournalMonitorService : BackgroundService
 
     private async Task DrainJournalAsync(CancellationToken cancellationToken)
     {
-        if (_reader == null)
+        var reader = _reader;
+        if (reader == null)
             return;
 
-        var lines = await _reader.ReadNewLinesAsync(cancellationToken).ConfigureAwait(false);
+        var lines = await reader.ReadNewLinesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Which file the watcher is on is part of the health story: "attached, no journal file yet"
+        // and "reading Journal.2026-08-28.log" are different states.
+        var currentFile = reader.CurrentFile;
+        _status.ReportWatching(
+            _settings.EliteDangerous.JournalPath,
+            currentFile == null ? null : Path.GetFileName(currentFile));
 
         foreach (var line in lines)
         {
@@ -191,6 +251,7 @@ public class JournalMonitorService : BackgroundService
 
         if (lines.Count > 0)
         {
+            _status.ReportLinesRead();
             _logger.LogDebug("Processed {Count} new journal entries", lines.Count);
         }
     }

--- a/src/EDButtkicker/Services/JournalMonitorStatus.cs
+++ b/src/EDButtkicker/Services/JournalMonitorStatus.cs
@@ -1,0 +1,162 @@
+namespace EDButtkicker.Services;
+
+/// <summary>What the journal watcher is doing, as opposed to what the configuration says.</summary>
+public enum JournalWatchState
+{
+    /// <summary>The monitor has not run yet (the process just started, or it is not hosted).</summary>
+    NotStarted,
+
+    /// <summary>The configured folder cannot be watched yet; the monitor is re-checking it.</summary>
+    Waiting,
+
+    /// <summary>A watcher is attached to the folder.</summary>
+    Watching,
+
+    /// <summary>Monitoring stopped because of an error.</summary>
+    Faulted,
+
+    /// <summary>Monitoring stopped on shutdown.</summary>
+    Stopped
+}
+
+/// <summary>An immutable read of the watcher state, safe to serialise while the monitor runs.</summary>
+public sealed record JournalMonitorSnapshot(
+    JournalWatchState State,
+    string? Path,
+    string Reason,
+    string? ActiveFile,
+    DateTime? SinceUtc,
+    DateTime? LastLineUtc);
+
+/// <summary>
+/// The journal watcher's real state, published by <see cref="JournalMonitorService"/> and read by
+/// the health API. The dashboard used to call journal monitoring "online" whenever the folder
+/// existed; this reports whether a watcher is actually attached, and why not when it is not.
+/// It also carries the re-check signal the health retry raises, so "Retry" re-attaches immediately
+/// instead of waiting for the monitor's next sweep.
+/// </summary>
+public sealed class JournalMonitorStatus
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly SemaphoreSlim _recheck = new(0, 1);
+    private readonly object _lock = new();
+
+    private JournalMonitorSnapshot _snapshot = new(
+        JournalWatchState.NotStarted,
+        Path: null,
+        Reason: "Journal monitoring has not started yet.",
+        ActiveFile: null,
+        SinceUtc: null,
+        LastLineUtc: null);
+
+    public JournalMonitorStatus(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public JournalMonitorSnapshot Current
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _snapshot;
+            }
+        }
+    }
+
+    public void ReportWaiting(string? path, string reason)
+    {
+        lock (_lock)
+        {
+            var unchanged = _snapshot.State == JournalWatchState.Waiting && _snapshot.Path == path;
+
+            _snapshot = _snapshot with
+            {
+                State = JournalWatchState.Waiting,
+                Path = path,
+                Reason = reason,
+                ActiveFile = null,
+                SinceUtc = unchanged ? _snapshot.SinceUtc : UtcNow
+            };
+        }
+    }
+
+    public void ReportWatching(string path, string? activeFile)
+    {
+        lock (_lock)
+        {
+            var unchanged = _snapshot.State == JournalWatchState.Watching
+                && _snapshot.Path == path
+                && _snapshot.ActiveFile == activeFile;
+
+            _snapshot = _snapshot with
+            {
+                State = JournalWatchState.Watching,
+                Path = path,
+                Reason = activeFile == null
+                    ? "Watching the journal folder; Elite Dangerous has not written a journal file yet."
+                    : $"Reading {activeFile}.",
+                ActiveFile = activeFile,
+                SinceUtc = unchanged ? _snapshot.SinceUtc : UtcNow
+            };
+        }
+    }
+
+    public void ReportLinesRead()
+    {
+        lock (_lock)
+        {
+            _snapshot = _snapshot with { LastLineUtc = UtcNow };
+        }
+    }
+
+    public void ReportFaulted(string reason)
+    {
+        lock (_lock)
+        {
+            _snapshot = _snapshot with
+            {
+                State = JournalWatchState.Faulted,
+                Reason = reason,
+                ActiveFile = null,
+                SinceUtc = UtcNow
+            };
+        }
+    }
+
+    public void ReportStopped(string reason)
+    {
+        lock (_lock)
+        {
+            _snapshot = _snapshot with
+            {
+                State = JournalWatchState.Stopped,
+                Reason = reason,
+                ActiveFile = null,
+                SinceUtc = UtcNow
+            };
+        }
+    }
+
+    /// <summary>Asks the monitor to look at the configured folder again, right now.</summary>
+    public void RequestRecheck()
+    {
+        lock (_lock)
+        {
+            if (_recheck.CurrentCount == 0)
+            {
+                _recheck.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Waits for a re-check request, or for <paramref name="timeout"/> to pass. Returns true when a
+    /// request arrived, so the monitor can tell an on-demand retry from its periodic sweep.
+    /// </summary>
+    public Task<bool> WaitForRecheckAsync(TimeSpan timeout, CancellationToken cancellationToken) =>
+        _recheck.WaitAsync(timeout, cancellationToken);
+
+    private DateTime UtcNow => _timeProvider.GetUtcNow().UtcDateTime;
+}

--- a/src/EDButtkicker/Services/JournalPathDiscovery.cs
+++ b/src/EDButtkicker/Services/JournalPathDiscovery.cs
@@ -1,0 +1,155 @@
+using EDButtkicker.Configuration;
+
+namespace EDButtkicker.Services;
+
+/// <summary>One folder the wizard offers, together with what is actually in it.</summary>
+public sealed record JournalPathCandidate(
+    string Path,
+    string Source,
+    bool Exists,
+    int JournalFileCount,
+    DateTime? LatestJournalWriteUtc,
+    bool IsConfigured,
+    bool IsRecommended);
+
+/// <summary>
+/// Finds the folders Elite Dangerous writes journals to. The wizard shows what was found and what
+/// is in each folder rather than silently assuming the default path exists, which is what the old
+/// startup path did.
+/// </summary>
+public class JournalPathDiscovery
+{
+    private readonly AppSettings _settings;
+    private readonly IReadOnlyList<string> _searchPaths;
+
+    public JournalPathDiscovery(AppSettings settings)
+        : this(settings, DefaultSearchPaths())
+    {
+    }
+
+    /// <summary>Overload that searches explicit folders, so tests can point at a temp directory.</summary>
+    public JournalPathDiscovery(AppSettings settings, IEnumerable<string> searchPaths)
+    {
+        _settings = settings;
+        _searchPaths = searchPaths.ToList();
+    }
+
+    /// <summary>The usual Elite Dangerous journal locations on a Windows install.</summary>
+    public static IReadOnlyList<string> DefaultSearchPaths()
+    {
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        return new[]
+        {
+            Path.Combine(userProfile, "Saved Games", "Frontier Developments", "Elite Dangerous"),
+            // OneDrive's "back up my folders" moves Saved Games without telling the game's tools.
+            Path.Combine(userProfile, "OneDrive", "Saved Games", "Frontier Developments", "Elite Dangerous")
+        };
+    }
+
+    /// <summary>
+    /// The configured folder first, then every known location, de-duplicated. The recommendation is
+    /// the first folder that actually holds journal files, falling back to the first that exists.
+    /// </summary>
+    public IReadOnlyList<JournalPathCandidate> Discover()
+    {
+        var configuredPath = _settings.EliteDangerous.JournalPath;
+        var ordered = new List<(string Path, string Source)>();
+
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            ordered.Add((configuredPath, "configured"));
+        }
+
+        foreach (var searchPath in _searchPaths)
+        {
+            ordered.Add((searchPath, "known-location"));
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var candidates = new List<JournalPathCandidate>();
+
+        foreach (var (path, source) in ordered)
+        {
+            var normalized = NormalizeOrNull(path);
+            if (normalized == null || !seen.Add(normalized))
+            {
+                continue;
+            }
+
+            var isConfigured = !string.IsNullOrWhiteSpace(configuredPath)
+                && string.Equals(normalized, NormalizeOrNull(configuredPath), StringComparison.OrdinalIgnoreCase);
+
+            candidates.Add(Inspect(normalized, source, isConfigured));
+        }
+
+        var recommended = candidates.FirstOrDefault(c => c.JournalFileCount > 0)
+            ?? candidates.FirstOrDefault(c => c.Exists);
+
+        if (recommended == null)
+        {
+            return candidates;
+        }
+
+        return candidates
+            .Select(c => c.Path == recommended.Path ? c with { IsRecommended = true } : c)
+            .ToList();
+    }
+
+    /// <summary>Expands the placeholder Windows users paste from the game's own documentation.</summary>
+    public static string ExpandUserProfile(string path) =>
+        path.Contains("%USERPROFILE%", StringComparison.OrdinalIgnoreCase)
+            ? path.Replace(
+                "%USERPROFILE%",
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                StringComparison.OrdinalIgnoreCase)
+            : path;
+
+    /// <summary>Reads one folder without assuming it exists or can be listed.</summary>
+    public static JournalPathCandidate Inspect(string path, string source, bool isConfigured)
+    {
+        var exists = Directory.Exists(path);
+        var count = 0;
+        DateTime? latestWriteUtc = null;
+
+        if (exists)
+        {
+            try
+            {
+                var files = Directory.GetFiles(path, JournalTailReader.JournalSearchPattern);
+                count = files.Length;
+
+                if (count > 0)
+                {
+                    latestWriteUtc = files.Max(File.GetLastWriteTimeUtc);
+                }
+            }
+            catch (Exception)
+            {
+                // Unreadable folder (permissions, or it vanished mid-scan): report it as empty
+                // rather than failing the whole discovery.
+                count = 0;
+            }
+        }
+
+        return new JournalPathCandidate(path, source, exists, count, latestWriteUtc, isConfigured, IsRecommended: false);
+    }
+
+    private static string? NormalizeOrNull(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(ExpandUserProfile(path.Trim())));
+        }
+        catch (Exception)
+        {
+            // A malformed configured path is not a candidate, but it must not break discovery.
+            return null;
+        }
+    }
+}

--- a/src/EDButtkicker/Services/SetupStateService.cs
+++ b/src/EDButtkicker/Services/SetupStateService.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// What the first-run wizard has actually achieved, as persisted between runs. Each step records
+/// when it was confirmed and what it was confirmed with, so a half-finished setup resumes on the
+/// step the user stopped at instead of starting over or pretending to be done.
+/// </summary>
+public class SetupState
+{
+    public bool Completed { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+
+    public DateTime? JournalConfirmedAtUtc { get; set; }
+    public string? JournalPath { get; set; }
+
+    public DateTime? AudioDeviceConfirmedAtUtc { get; set; }
+    public string? AudioDeviceName { get; set; }
+    public int? AudioDeviceId { get; set; }
+
+    public DateTime? AudioTestedAtUtc { get; set; }
+    public bool? AudioTestPlayed { get; set; }
+    public string? AudioTestReason { get; set; }
+
+    public string? Version { get; set; } = "1.0.0";
+}
+
+/// <summary>
+/// Stores <see cref="SetupState"/> next to the user settings. Completion is persisted so the wizard
+/// does not reappear on every launch, but it is never a one-way door: <see cref="RequestReopen"/>
+/// reopens the wizard for this session while leaving the completion record intact.
+/// </summary>
+public class SetupStateService
+{
+    private readonly ILogger<SetupStateService> _logger;
+    private readonly string _setupStatePath;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    private SetupState? _cached;
+    private bool _reopenRequested;
+
+    public SetupStateService(ILogger<SetupStateService> logger)
+        : this(logger, UserSettingsService.DefaultSettingsDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Overload that puts the state file under an explicit directory, so tests never read from - or
+    /// write to - the developer's real profile.
+    /// </summary>
+    public SetupStateService(ILogger<SetupStateService> logger, string settingsDirectory)
+    {
+        _logger = logger;
+
+        if (string.IsNullOrWhiteSpace(settingsDirectory))
+            throw new ArgumentException("Settings directory must be provided", nameof(settingsDirectory));
+
+        Directory.CreateDirectory(settingsDirectory);
+        _setupStatePath = Path.Combine(settingsDirectory, "setup-state.json");
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            AllowTrailingCommas = true
+        };
+
+        _logger.LogDebug("SetupStateService initialized with path: {SetupStatePath}", _setupStatePath);
+    }
+
+    public string GetSetupStatePath() => _setupStatePath;
+
+    /// <summary>True while the user has asked to see the wizard again after completing it.</summary>
+    public bool ReopenRequested => Volatile.Read(ref _reopenRequested);
+
+    public void RequestReopen()
+    {
+        Volatile.Write(ref _reopenRequested, true);
+        _logger.LogInformation("Setup wizard reopened by request");
+    }
+
+    public async Task<SetupState> LoadAsync()
+    {
+        await _mutex.WaitAsync();
+        try
+        {
+            return await LoadUnsynchronizedAsync();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <summary>Applies <paramref name="mutate"/> to the stored state and writes it back.</summary>
+    public async Task<SetupState> UpdateAsync(Action<SetupState> mutate)
+    {
+        await _mutex.WaitAsync();
+        try
+        {
+            var state = await LoadUnsynchronizedAsync();
+            mutate(state);
+            await SaveUnsynchronizedAsync(state);
+            return state;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <summary>Marks setup finished and closes a wizard that was reopened.</summary>
+    public async Task<SetupState> MarkCompletedAsync(DateTime completedAtUtc)
+    {
+        var state = await UpdateAsync(s =>
+        {
+            s.Completed = true;
+            s.CompletedAtUtc = completedAtUtc;
+        });
+
+        Volatile.Write(ref _reopenRequested, false);
+        return state;
+    }
+
+    private async Task<SetupState> LoadUnsynchronizedAsync()
+    {
+        if (_cached != null)
+        {
+            return _cached;
+        }
+
+        if (!File.Exists(_setupStatePath))
+        {
+            _logger.LogInformation("No setup state found; treating this as a first run");
+            _cached = new SetupState();
+            return _cached;
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_setupStatePath);
+            _cached = JsonSerializer.Deserialize<SetupState>(json, _jsonOptions) ?? new SetupState();
+        }
+        catch (Exception ex)
+        {
+            // A damaged file must not lock the user out of the wizard - reverting to a first run
+            // is the recoverable outcome.
+            _logger.LogError(ex, "Error loading setup state, treating this as a first run");
+            _cached = new SetupState();
+        }
+
+        return _cached;
+    }
+
+    private async Task SaveUnsynchronizedAsync(SetupState state)
+    {
+        _cached = state;
+
+        try
+        {
+            var json = JsonSerializer.Serialize(state, _jsonOptions);
+            await File.WriteAllTextAsync(_setupStatePath, json);
+            _logger.LogDebug("Saved setup state to {SetupStatePath}", _setupStatePath);
+        }
+        catch (Exception ex)
+        {
+            // The in-memory state still reflects the step the user just finished; only the record
+            // of it is lost, so say so instead of failing the request they made.
+            _logger.LogError(ex, "Error saving setup state to {SetupStatePath}", _setupStatePath);
+        }
+    }
+}

--- a/src/EDButtkicker/Services/SystemHealthService.cs
+++ b/src/EDButtkicker/Services/SystemHealthService.cs
@@ -1,0 +1,317 @@
+using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>The action a user can take when an indicator is not green.</summary>
+public sealed record HealthRetry(string Endpoint, string Method, string Label);
+
+/// <summary>
+/// One subsystem, its real state, and why it is in that state. <see cref="Reason"/> is always
+/// filled in - an indicator that cannot say why it is red is the bug this replaces.
+/// </summary>
+public sealed record HealthIndicator(
+    string Id,
+    string Name,
+    string Status,
+    string Reason,
+    string? Detail,
+    HealthRetry? Retry);
+
+public sealed record SystemHealthReport(
+    string Status,
+    DateTime GeneratedAtUtc,
+    IReadOnlyList<HealthIndicator> Components);
+
+/// <summary>
+/// Builds the dashboard's health list from the subsystems themselves. Every indicator is derived
+/// from that subsystem's own state - the journal watcher's attachment, the audio engine's device,
+/// the loaded pattern catalog - rather than from an unrelated API call returning 200.
+/// </summary>
+public class SystemHealthService
+{
+    public const string StatusOk = "ok";
+    public const string StatusPending = "pending";
+    public const string StatusAttention = "attention";
+    public const string StatusError = "error";
+    public const string StatusOff = "off";
+
+    /// <summary>How long a journal retry waits for the monitor to pick the request up.</summary>
+    private static readonly TimeSpan JournalRetryWindow = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan JournalRetryPoll = TimeSpan.FromMilliseconds(25);
+
+    private readonly ILogger<SystemHealthService> _logger;
+    private readonly AppSettings _settings;
+    private readonly JournalMonitorStatus _journalStatus;
+    private readonly AudioEngineService _audioEngine;
+    private readonly IAudioDeviceCatalog _deviceCatalog;
+    private readonly IJournalEventStore _eventStore;
+    private readonly IPatternCatalog _patternCatalog;
+    private readonly EventMappingService _eventMappings;
+    private readonly TimeProvider _timeProvider;
+
+    public SystemHealthService(
+        ILogger<SystemHealthService> logger,
+        AppSettings settings,
+        JournalMonitorStatus journalStatus,
+        AudioEngineService audioEngine,
+        IAudioDeviceCatalog deviceCatalog,
+        IJournalEventStore eventStore,
+        IPatternCatalog patternCatalog,
+        EventMappingService eventMappings,
+        TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _settings = settings;
+        _journalStatus = journalStatus;
+        _audioEngine = audioEngine;
+        _deviceCatalog = deviceCatalog;
+        _eventStore = eventStore;
+        _patternCatalog = patternCatalog;
+        _eventMappings = eventMappings;
+        _timeProvider = timeProvider;
+    }
+
+    public SystemHealthReport GetReport()
+    {
+        var components = new List<HealthIndicator>
+        {
+            GetJournalIndicator(),
+            GetAudioIndicator(),
+            GetPatternIndicator(),
+            GetVoiceIndicator(),
+            GetWebIndicator()
+        };
+
+        return new SystemHealthReport(Overall(components), _timeProvider.GetUtcNow().UtcDateTime, components);
+    }
+
+    public HealthIndicator? GetIndicator(string id) =>
+        GetReport().Components.FirstOrDefault(c => string.Equals(c.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Whether <paramref name="id"/> names a subsystem a retry can actually act on.</summary>
+    public static bool CanRetry(string id) =>
+        string.Equals(id, "journal", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(id, "audio", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Runs the retry for one subsystem and returns its indicator afterwards, so the caller reports
+    /// the state the retry produced instead of an optimistic "retrying...".
+    /// </summary>
+    public async Task<HealthIndicator?> RetryAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (string.Equals(id, "journal", StringComparison.OrdinalIgnoreCase))
+        {
+            await RetryJournalAsync(cancellationToken);
+            return GetIndicator("journal");
+        }
+
+        if (string.Equals(id, "audio", StringComparison.OrdinalIgnoreCase))
+        {
+            var opened = _audioEngine.RetryInitialization();
+            _logger.LogInformation("Audio retry requested from the health API, device opened: {Opened}", opened);
+            return GetIndicator("audio");
+        }
+
+        return null;
+    }
+
+    private async Task RetryJournalAsync(CancellationToken cancellationToken)
+    {
+        var before = _journalStatus.Current;
+        _journalStatus.RequestRecheck();
+        _logger.LogInformation("Journal re-check requested from the health API");
+
+        // Give a running monitor a moment to act, so the response reflects the retry. When no
+        // monitor is running the wait simply expires and the indicator stays honest.
+        var deadline = _timeProvider.GetUtcNow() + JournalRetryWindow;
+
+        while (_timeProvider.GetUtcNow() < deadline && !cancellationToken.IsCancellationRequested)
+        {
+            if (_journalStatus.Current != before)
+            {
+                return;
+            }
+
+            await Task.Delay(JournalRetryPoll, _timeProvider, cancellationToken);
+        }
+    }
+
+    private HealthIndicator GetJournalIndicator()
+    {
+        var snapshot = _journalStatus.Current;
+        var path = snapshot.Path ?? _settings.EliteDangerous.JournalPath;
+        var retry = new HealthRetry("/api/health/journal/retry", "POST", "Re-check journal folder");
+        var detail = BuildJournalDetail(path);
+
+        return snapshot.State switch
+        {
+            JournalWatchState.Watching when snapshot.ActiveFile != null =>
+                new HealthIndicator("journal", "Journal Monitor", StatusOk, snapshot.Reason, detail, retry),
+
+            // Attached, but Elite Dangerous has not produced a journal file yet: not an error, and
+            // not "connected" either.
+            JournalWatchState.Watching =>
+                new HealthIndicator("journal", "Journal Monitor", StatusAttention, snapshot.Reason, detail, retry),
+
+            JournalWatchState.Waiting =>
+                new HealthIndicator("journal", "Journal Monitor", StatusAttention, snapshot.Reason, detail, retry),
+
+            JournalWatchState.Faulted =>
+                new HealthIndicator("journal", "Journal Monitor", StatusError, snapshot.Reason, detail, retry),
+
+            JournalWatchState.Stopped =>
+                new HealthIndicator("journal", "Journal Monitor", StatusAttention, snapshot.Reason, detail, retry),
+
+            _ => new HealthIndicator("journal", "Journal Monitor", StatusPending, snapshot.Reason, detail, retry)
+        };
+    }
+
+    private string BuildJournalDetail(string? path)
+    {
+        var folder = string.IsNullOrWhiteSpace(path) ? "No journal folder configured" : $"Folder: {path}";
+        var events = $"{_eventStore.Count} event(s) seen this session";
+        var last = _eventStore.LastTimestamp is { } timestamp
+            ? $"last at {timestamp:yyyy-MM-dd HH:mm:ss}"
+            : "no events yet";
+
+        return $"{folder} | {events}, {last}";
+    }
+
+    private HealthIndicator GetAudioIndicator()
+    {
+        var status = _audioEngine.GetStatus();
+        var retry = new HealthRetry("/api/health/audio/retry", "POST", "Retry audio device");
+        var devices = _deviceCatalog.GetDevices();
+        var configuredName = status.ConfiguredDeviceName;
+        var detail = $"{devices.Count} output device(s) available | configured: " +
+            (string.IsNullOrWhiteSpace(configuredName) ? "system default" : configuredName);
+
+        if (status.InitializationFailed)
+        {
+            var reason = string.IsNullOrWhiteSpace(status.LastError)
+                ? "The audio output device could not be opened."
+                : $"The audio output device could not be opened: {status.LastError}";
+
+            return new HealthIndicator("audio", "Audio Engine", StatusError, reason, detail, retry);
+        }
+
+        var configuredIsMissing = !string.IsNullOrWhiteSpace(configuredName)
+            && !devices.Any(d => string.Equals(d.Name, configuredName, StringComparison.OrdinalIgnoreCase));
+
+        if (status.Initialized)
+        {
+            var reason = configuredIsMissing
+                ? $"Playing on a fallback device: the saved output '{configuredName}' is not connected."
+                : $"Output open on {(string.IsNullOrWhiteSpace(configuredName) ? "the system default device" : configuredName)}.";
+
+            return new HealthIndicator(
+                "audio",
+                "Audio Engine",
+                configuredIsMissing ? StatusAttention : StatusOk,
+                reason,
+                detail,
+                retry);
+        }
+
+        if (configuredIsMissing)
+        {
+            return new HealthIndicator(
+                "audio",
+                "Audio Engine",
+                StatusAttention,
+                $"The saved output '{configuredName}' is not connected; the system default will be used instead.",
+                detail,
+                retry);
+        }
+
+        return new HealthIndicator(
+            "audio",
+            "Audio Engine",
+            StatusPending,
+            "No audio device has been opened yet - run the audio test to open one.",
+            detail,
+            retry);
+    }
+
+    private HealthIndicator GetPatternIndicator()
+    {
+        var retry = new HealthRetry("/api/PatternFiles/reload", "POST", "Reload pattern files");
+
+        try
+        {
+            var eventPatterns = _eventMappings.GetAllDefaultPatterns().Count;
+            var shipTypes = _patternCatalog.GetAllShipTypes().Count;
+            var detail = $"{eventPatterns} event pattern(s), {shipTypes} ship-specific librar(ies)";
+
+            if (eventPatterns == 0)
+            {
+                return new HealthIndicator(
+                    "patterns",
+                    "Haptic Patterns",
+                    StatusError,
+                    "No event patterns are loaded, so no event can produce haptics.",
+                    detail,
+                    retry);
+            }
+
+            return new HealthIndicator(
+                "patterns",
+                "Haptic Patterns",
+                StatusOk,
+                $"{eventPatterns} event pattern(s) loaded.",
+                detail,
+                retry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading the pattern catalog for the health report");
+
+            return new HealthIndicator(
+                "patterns",
+                "Haptic Patterns",
+                StatusError,
+                $"The pattern catalog could not be read: {ex.Message}",
+                null,
+                retry);
+        }
+    }
+
+    private HealthIndicator GetVoiceIndicator()
+    {
+        // VoiceFeedbackService is not part of the running service graph, so nothing is ever spoken.
+        // The dashboard used to show this as "online"; saying it is off is the truthful reading.
+        var contextualVoice = _settings.ContextualIntelligence?.EnableContextualVoice == true;
+
+        return new HealthIndicator(
+            "voice",
+            "Voice Feedback",
+            StatusOff,
+            "Voice feedback is not running: no voice service is hosted in this build.",
+            contextualVoice
+                ? "Contextual voice is enabled in settings but has no service to drive it."
+                : "Contextual voice is disabled in settings.",
+            Retry: null);
+    }
+
+    private static HealthIndicator GetWebIndicator() =>
+        new(
+            "web",
+            "Web Interface",
+            StatusOk,
+            $"Serving this page on http://localhost:{WebUiConfiguration.Port} (loopback only).",
+            "The interface is reachable from this machine only.",
+            Retry: null);
+
+    private static string Overall(IEnumerable<HealthIndicator> components)
+    {
+        var statuses = components.Select(c => c.Status).ToList();
+
+        if (statuses.Contains(StatusError)) return StatusError;
+        if (statuses.Contains(StatusAttention)) return StatusAttention;
+        if (statuses.Contains(StatusPending)) return StatusPending;
+
+        return StatusOk;
+    }
+}

--- a/src/EDButtkicker/wwwroot/css/styles.css
+++ b/src/EDButtkicker/wwwroot/css/styles.css
@@ -1376,3 +1376,147 @@ input:checked + .toggle-slider:before {
 .loading i.fa-spin {
     margin-right: 0.5rem;
 }
+/* System Health list - one row per subsystem, with the reason it is in that state */
+.health-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.health-item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.health-summary {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.health-item .status-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-top: 0.35rem;
+    flex-shrink: 0;
+}
+
+.health-item .status-indicator.online { background: var(--success-color); }
+.health-item .status-indicator.offline { background: var(--danger-color); }
+.health-item .status-indicator.warning { background: var(--warning-color); }
+.health-item .status-indicator.muted { background: var(--text-secondary); }
+
+.health-name {
+    font-weight: 600;
+}
+
+.health-reason {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.health-detail {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    opacity: 0.8;
+    margin-top: 0.25rem;
+}
+
+/* First-run setup wizard */
+.setup-steps {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.setup-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.setup-step.active {
+    border-color: var(--primary-color);
+}
+
+.setup-step.complete i {
+    color: var(--success-color);
+}
+
+.setup-step-title {
+    font-weight: 600;
+}
+
+.setup-step-summary {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.setup-panel h4 {
+    margin-bottom: 0.5rem;
+}
+
+.setup-help {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+}
+
+.setup-candidates {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.setup-candidate {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.setup-candidate.active {
+    border-color: var(--primary-color);
+}
+
+.setup-candidate-path {
+    font-family: monospace;
+    word-break: break-all;
+}
+
+.setup-candidate-detail {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.setup-result {
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.setup-note {
+    flex: 1;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}

--- a/src/EDButtkicker/wwwroot/index.html
+++ b/src/EDButtkicker/wwwroot/index.html
@@ -49,34 +49,29 @@
             <div class="tab-panel active" id="dashboard">
                 <div class="panel-header">
                     <h2><i class="fas fa-tachometer-alt"></i> System Dashboard</h2>
-                    <button class="btn btn-primary" onclick="refreshDashboard()">
-                        <i class="fas fa-sync-alt"></i> Refresh
-                    </button>
+                    <div class="header-actions">
+                        <button class="btn btn-secondary" onclick="openSetupWizard()">
+                            <i class="fas fa-magic"></i> Setup Wizard
+                        </button>
+                        <button class="btn btn-primary" onclick="refreshDashboard()">
+                            <i class="fas fa-sync-alt"></i> Refresh
+                        </button>
+                    </div>
                 </div>
 
                 <div class="dashboard-grid">
                     <div class="stats-card">
                         <div class="card-header">
-                            <h3><i class="fas fa-heartbeat"></i> System Status</h3>
+                            <h3><i class="fas fa-heartbeat"></i> System Health</h3>
+                            <button class="btn btn-sm" onclick="refreshHealth()">
+                                <i class="fas fa-sync-alt"></i>
+                            </button>
                         </div>
                         <div class="card-content">
-                            <div class="status-grid" id="systemStatusGrid">
-                                <div class="status-item">
-                                    <span class="status-indicator offline" id="audioStatus"></span>
-                                    <span>Audio Engine</span>
-                                </div>
-                                <div class="status-item">
-                                    <span class="status-indicator offline" id="journalStatus"></span>
-                                    <span>Journal Monitor</span>
-                                </div>
-                                <div class="status-item">
-                                    <span class="status-indicator offline" id="voiceStatus"></span>
-                                    <span>Voice Feedback</span>
-                                </div>
-                                <div class="status-item">
-                                    <span class="status-indicator online" id="webStatus"></span>
-                                    <span>Web Interface</span>
-                                </div>
+                            <!-- Every row comes from /api/health, which reads the subsystems
+                                 themselves: status, why, and what retrying it would do. -->
+                            <div class="health-list" id="systemHealthList">
+                                <div class="loading">Checking subsystems...</div>
                             </div>
                         </div>
                     </div>
@@ -515,6 +510,27 @@
                 </div>
             </div>
         </main>
+    </div>
+
+    <!-- First-Run Setup Wizard: opens by itself until setup has been completed once, and can be
+         reopened from the dashboard at any time. -->
+    <div class="modal" id="setupWizard">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3><i class="fas fa-magic"></i> First-Run Setup</h3>
+                <button class="modal-close" onclick="closeSetupWizard()">&times;</button>
+            </div>
+            <div class="modal-body">
+                <ol class="setup-steps" id="setupSteps"></ol>
+                <div class="setup-panel" id="setupPanel">
+                    <div class="loading">Loading setup...</div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <span class="setup-note" id="setupNote"></span>
+                <button class="btn btn-secondary" onclick="closeSetupWizard()">Close</button>
+            </div>
+        </div>
     </div>
 
     <!-- Pattern Editor Modal -->

--- a/src/EDButtkicker/wwwroot/js/app.js
+++ b/src/EDButtkicker/wwwroot/js/app.js
@@ -1,8 +1,10 @@
 // Elite Dangerous Buttkicker Configuration Interface
 class ButtkickerApp {
     constructor() {
+        this.setup = null;
         this.init();
         this.loadDashboard();
+        this.loadSetupState();
     }
 
     init() {
@@ -60,49 +62,287 @@ class ButtkickerApp {
         }
     }
 
+    // Health is read from the subsystems themselves - never inferred from an unrelated request
+    // returning 200 - so every row can say what state it is in and why.
     async updateSystemStatus() {
         try {
-            const [configResponse, journalResponse] = await Promise.all([
-                fetch('/api/config'),
-                fetch('/api/journal/status')
-            ]);
+            const response = await fetch('/api/health');
+            if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
 
-            const config = await configResponse.json();
-            const journal = await journalResponse.json();
-
-            // Update header status
-            const statusElement = document.getElementById('systemStatus');
-            const statusIcon = statusElement.querySelector('.status-icon');
-            const statusText = statusElement.querySelector('.status-text');
-
-            if (configResponse.ok && journalResponse.ok) {
-                statusIcon.className = 'fas fa-circle status-icon online';
-                statusText.textContent = journal.monitoring ? 'Connected' : 'Ready';
-            } else {
-                statusIcon.className = 'fas fa-circle status-icon warning';
-                statusText.textContent = 'Partial Connection';
-            }
-
-            // Update dashboard status indicators
-            const audioStatus = document.getElementById('audioStatus');
-            const journalStatus = document.getElementById('journalStatus');
-            const voiceStatus = document.getElementById('voiceStatus');
-            const webStatus = document.getElementById('webStatus');
-
-            if (audioStatus) audioStatus.className = 'status-indicator online';
-            if (journalStatus) journalStatus.className = `status-indicator ${journal.monitoring ? 'online' : 'offline'}`;
-            if (voiceStatus) voiceStatus.className = 'status-indicator online';
-            if (webStatus) webStatus.className = 'status-indicator online';
-
+            this.renderHealth(await response.json());
         } catch (error) {
             console.error('Error updating system status:', error);
-            const statusElement = document.getElementById('systemStatus');
-            const statusIcon = statusElement.querySelector('.status-icon');
-            const statusText = statusElement.querySelector('.status-text');
-            
-            statusIcon.className = 'fas fa-circle status-icon offline';
-            statusText.textContent = 'Connection Error';
+
+            this.setHeaderStatus('offline', 'Connection Error');
+
+            const list = document.getElementById('systemHealthList');
+            if (list) {
+                list.innerHTML = '<div class="loading">Could not read system health from the local service.</div>';
+            }
         }
+    }
+
+    renderHealth(report) {
+        this.setHeaderStatus(
+            ButtkickerApp.statusIconClass(report.status),
+            ButtkickerApp.statusLabel(report.status));
+
+        const list = document.getElementById('systemHealthList');
+        if (!list) return;
+
+        list.innerHTML = (report.components || []).map(component => `
+            <div class="health-item">
+                <div class="health-summary">
+                    <span class="status-indicator ${ButtkickerApp.statusDotClass(component.status)}"></span>
+                    <div class="health-text">
+                        <div class="health-name">${component.name}</div>
+                        <div class="health-reason">${component.reason || ''}</div>
+                        ${component.detail ? `<div class="health-detail">${component.detail}</div>` : ''}
+                    </div>
+                </div>
+                ${component.retry ? `
+                    <button class="btn btn-sm" onclick="retryHealthComponent('${component.id}')">
+                        <i class="fas fa-redo"></i> ${component.retry.label}
+                    </button>` : ''}
+            </div>
+        `).join('');
+    }
+
+    setHeaderStatus(iconClass, text) {
+        const statusElement = document.getElementById('systemStatus');
+        if (!statusElement) return;
+
+        const statusIcon = statusElement.querySelector('.status-icon');
+        const statusText = statusElement.querySelector('.status-text');
+
+        if (statusIcon) statusIcon.className = `fas fa-circle status-icon ${iconClass}`;
+        if (statusText) statusText.textContent = text;
+    }
+
+    static statusDotClass(status) {
+        switch (status) {
+            case 'ok': return 'online';
+            case 'error': return 'offline';
+            case 'off': return 'muted';
+            default: return 'warning';
+        }
+    }
+
+    static statusIconClass(status) {
+        switch (status) {
+            case 'ok': return 'online';
+            case 'error': return 'offline';
+            default: return 'warning';
+        }
+    }
+
+    static statusLabel(status) {
+        switch (status) {
+            case 'ok': return 'All systems ready';
+            case 'error': return 'Needs attention';
+            case 'pending': return 'Setup incomplete';
+            case 'attention': return 'Needs attention';
+            default: return 'Checking...';
+        }
+    }
+
+    // ----- First-run setup wizard -----
+
+    async loadSetupState(forceOpen = false) {
+        try {
+            const response = await fetch('/api/setup/status');
+            if (!response.ok) throw new Error(`/api/setup/status returned ${response.status}`);
+
+            this.setup = await response.json();
+
+            if (this.setup.show_wizard || forceOpen) {
+                this.openSetupWizard();
+            }
+
+            if (this.setup.health) {
+                this.renderHealth(this.setup.health);
+            }
+        } catch (error) {
+            console.error('Error loading setup state:', error);
+        }
+    }
+
+    applySetupStatus(status) {
+        if (!status) return;
+
+        this.setup = status;
+        this.renderSetup();
+
+        if (status.health) {
+            this.renderHealth(status.health);
+        }
+    }
+
+    openSetupWizard(stepId = null) {
+        const modal = document.getElementById('setupWizard');
+        if (!modal) return;
+
+        this.activeStep = stepId || (this.setup ? this.setup.current_step : 'journal');
+        modal.classList.add('active');
+        this.renderSetup();
+    }
+
+    closeSetupWizard() {
+        const modal = document.getElementById('setupWizard');
+        if (modal) modal.classList.remove('active');
+    }
+
+    renderSetup() {
+        const stepsList = document.getElementById('setupSteps');
+        const panel = document.getElementById('setupPanel');
+        const note = document.getElementById('setupNote');
+        if (!stepsList || !panel || !this.setup) return;
+
+        const steps = this.setup.steps || [];
+        if (!steps.some(step => step.id === this.activeStep)) {
+            this.activeStep = this.setup.current_step;
+        }
+
+        stepsList.innerHTML = steps.map(step => `
+            <li class="setup-step ${step.complete ? 'complete' : ''} ${step.id === this.activeStep ? 'active' : ''}"
+                onclick="showSetupStep('${step.id}')">
+                <i class="fas ${step.complete ? 'fa-check-circle' : 'fa-circle-notch'}"></i>
+                <div>
+                    <div class="setup-step-title">${step.title}</div>
+                    <div class="setup-step-summary">${step.summary || ''}</div>
+                </div>
+            </li>
+        `).join('');
+
+        if (note) {
+            note.textContent = this.setup.completed
+                ? `Setup was completed${this.setup.completed_at ? ' on ' + this.formatDateTime(this.setup.completed_at) : ''}. Reopening it changes nothing until you confirm a step.`
+                : 'Nothing is saved until you confirm each step.';
+        }
+
+        switch (this.activeStep) {
+            case 'journal':
+                this.renderJournalStep(panel);
+                break;
+            case 'audio-device':
+                this.renderAudioDeviceStep(panel);
+                break;
+            case 'audio-test':
+                this.renderAudioTestStep(panel);
+                break;
+            default:
+                this.renderFinishStep(panel);
+                break;
+        }
+    }
+
+    async renderJournalStep(panel) {
+        panel.innerHTML = '<div class="loading">Looking for your Elite Dangerous journal folder...</div>';
+
+        try {
+            const response = await fetch('/api/setup/journal/candidates');
+            const data = await response.json();
+            const candidates = data.candidates || [];
+
+            panel.innerHTML = `
+                <h4>1. Find your Elite Dangerous journal</h4>
+                <p class="setup-help">Elite Dangerous writes a <code>Journal.*.log</code> file every session.
+                   These are the folders found on this machine.</p>
+                <div class="setup-candidates">
+                    ${candidates.length === 0 ? '<div class="loading">No candidate folders found - enter the path below.</div>' : ''}
+                    ${candidates.map(candidate => `
+                        <div class="setup-candidate ${candidate.is_configured ? 'active' : ''}">
+                            <div>
+                                <div class="setup-candidate-path">${candidate.path}</div>
+                                <div class="setup-candidate-detail">
+                                    ${candidate.exists ? `${candidate.journal_files_found} journal file(s)` : 'Folder does not exist'}
+                                    ${candidate.is_recommended ? ' &middot; recommended' : ''}
+                                </div>
+                            </div>
+                            <button class="btn btn-sm btn-primary" ${candidate.exists ? '' : 'disabled'}
+                                    onclick="confirmJournalPath(${JSON.stringify(candidate.path).replace(/"/g, '&quot;')})">
+                                Use this folder
+                            </button>
+                        </div>
+                    `).join('')}
+                </div>
+                <div class="form-group">
+                    <label for="setupJournalPath">Or enter the folder yourself</label>
+                    <input type="text" id="setupJournalPath" value="${data.configured_path || ''}">
+                </div>
+                <button class="btn btn-primary" onclick="confirmJournalPath()">Confirm journal folder</button>
+            `;
+        } catch (error) {
+            console.error('Error loading journal candidates:', error);
+            panel.innerHTML = '<div class="loading">Could not search for journal folders.</div>';
+        }
+    }
+
+    async renderAudioDeviceStep(panel) {
+        panel.innerHTML = '<div class="loading">Reading output devices...</div>';
+
+        try {
+            const response = await fetch('/api/audio/devices');
+            const data = await response.json();
+            const devices = data.devices || [];
+
+            panel.innerHTML = `
+                <h4>2. Choose your output device</h4>
+                <p class="setup-help">Pick the device your buttkicker amplifier is connected to. The device
+                   name is saved, so the choice survives devices being plugged in or removed.</p>
+                <div class="setup-candidates">
+                    ${devices.length === 0 ? '<div class="loading">No output devices reported.</div>' : ''}
+                    ${devices.map(device => `
+                        <div class="setup-candidate ${device.id === data.current.id ? 'active' : ''}">
+                            <div>
+                                <div class="setup-candidate-path">${device.name}</div>
+                                <div class="setup-candidate-detail">
+                                    ${device.driver}${device.isDefault ? ' &middot; system default' : ''}
+                                    ${device.isAvailable ? '' : ' &middot; not active'}
+                                </div>
+                            </div>
+                            <button class="btn btn-sm btn-primary" ${device.isAvailable ? '' : 'disabled'}
+                                    onclick="selectSetupAudioDevice(${device.id})">
+                                Use this device
+                            </button>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+        } catch (error) {
+            console.error('Error loading audio devices:', error);
+            panel.innerHTML = '<div class="loading">Could not read the output devices.</div>';
+        }
+    }
+
+    renderAudioTestStep(panel) {
+        const step = (this.setup.steps || []).find(s => s.id === 'audio-test');
+
+        panel.innerHTML = `
+            <h4>3. Run a quiet test</h4>
+            <p class="setup-help">This plays a short, deliberately quiet low-frequency tone so you can set
+               your amplifier gain from silence upwards rather than being surprised at full intensity.</p>
+            <div class="setup-result" id="setupTestResult">${step && step.complete ? step.summary : 'No test has been run yet.'}</div>
+            <button class="btn btn-primary" onclick="runSetupAudioTest()">
+                <i class="fas fa-volume-down"></i> Play test tone
+            </button>
+        `;
+    }
+
+    renderFinishStep(panel) {
+        const incomplete = this.setup.incomplete_steps || [];
+        const remaining = incomplete.filter(id => id !== 'finish');
+
+        panel.innerHTML = `
+            <h4>4. Finish setup</h4>
+            ${remaining.length > 0 ? `
+                <p class="setup-help">These steps have not been confirmed yet: ${remaining.join(', ')}.
+                   You can still finish - the dashboard will keep showing what is missing.</p>` : `
+                <p class="setup-help">Every step has been confirmed.</p>`}
+            <button class="btn btn-primary" onclick="completeSetup()">
+                <i class="fas fa-check"></i> ${this.setup.completed ? 'Save and close' : 'Finish setup'}
+            </button>
+        `;
     }
 
     async loadDashboard() {
@@ -1286,6 +1526,147 @@ window.refreshJournalFiles = async () => {
         if (journalFileSelect) {
             journalFileSelect.innerHTML = '<option value="">Error loading journal files</option>';
         }
+    }
+};
+
+// ----- First-run setup wizard controls -----
+
+// Reopening is explicit and non-destructive: the persisted completion record stays as it is.
+window.openSetupWizard = async () => {
+    try {
+        const response = await fetch('/api/setup/reopen', { method: 'POST' });
+        if (response.ok) {
+            const result = await response.json();
+            app.applySetupStatus(result.setup);
+        }
+    } catch (error) {
+        console.error('Error reopening setup wizard:', error);
+    }
+
+    app.openSetupWizard();
+};
+
+window.closeSetupWizard = () => app.closeSetupWizard();
+
+window.showSetupStep = (stepId) => app.openSetupWizard(stepId);
+
+window.refreshHealth = () => app.updateSystemStatus();
+
+window.confirmJournalPath = async (path) => {
+    const input = document.getElementById('setupJournalPath');
+    const chosen = path || (input ? input.value.trim() : '');
+
+    if (!chosen) {
+        app.showToast('Enter or pick a journal folder first', 'warning');
+        return;
+    }
+
+    try {
+        const response = await fetch('/api/setup/journal', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ path: chosen })
+        });
+
+        const result = await response.json();
+
+        if (!response.ok) {
+            app.showToast(result.error || 'Could not use that folder', 'error');
+            return;
+        }
+
+        app.showToast(result.warning || `Journal folder set to ${result.path}`, result.warning ? 'warning' : 'success');
+        app.applySetupStatus(result.setup);
+        app.openSetupWizard('audio-device');
+    } catch (error) {
+        console.error('Error confirming journal path:', error);
+        app.showToast('Error confirming journal folder', 'error');
+    }
+};
+
+window.selectSetupAudioDevice = async (deviceId) => {
+    try {
+        const response = await fetch('/api/setup/audio/device', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ deviceId })
+        });
+
+        const result = await response.json();
+
+        if (!response.ok) {
+            app.showToast(result.error || 'Could not select that device', 'error');
+            return;
+        }
+
+        app.showToast(`Output set to ${result.device.name}`, 'success');
+        app.applySetupStatus(result.setup);
+        app.openSetupWizard('audio-test');
+    } catch (error) {
+        console.error('Error selecting audio device:', error);
+        app.showToast('Error selecting the output device', 'error');
+    }
+};
+
+window.runSetupAudioTest = async () => {
+    const resultBox = document.getElementById('setupTestResult');
+    if (resultBox) resultBox.textContent = 'Playing the test tone...';
+
+    try {
+        const response = await fetch('/api/setup/audio/test', { method: 'POST' });
+        const result = await response.json();
+
+        if (!response.ok) {
+            app.showToast(result.error || 'Audio test failed', 'error');
+            if (resultBox) resultBox.textContent = result.error || 'Audio test failed.';
+            return;
+        }
+
+        // played is false when no device could be opened; say so rather than claiming success.
+        if (resultBox) resultBox.textContent = result.reason;
+        app.showToast(result.reason, result.played ? 'success' : 'warning');
+        app.applySetupStatus(result.setup);
+        app.openSetupWizard(result.played ? 'finish' : 'audio-test');
+    } catch (error) {
+        console.error('Error running the audio test:', error);
+        app.showToast('Error running the audio test', 'error');
+    }
+};
+
+window.completeSetup = async () => {
+    try {
+        const response = await fetch('/api/setup/complete', { method: 'POST' });
+        const result = await response.json();
+
+        if (!response.ok) {
+            app.showToast(result.error || 'Could not save setup', 'error');
+            return;
+        }
+
+        app.applySetupStatus(result.setup);
+        app.closeSetupWizard();
+        app.showToast('Setup saved. Reopen it any time from the dashboard.', 'success');
+    } catch (error) {
+        console.error('Error completing setup:', error);
+        app.showToast('Error saving setup', 'error');
+    }
+};
+
+window.retryHealthComponent = async (componentId) => {
+    try {
+        const response = await fetch(`/api/health/${componentId}/retry`, { method: 'POST' });
+        const result = await response.json();
+
+        if (!response.ok) {
+            app.showToast(result.error || 'Retry failed', 'error');
+            return;
+        }
+
+        app.renderHealth(result.health);
+        app.showToast(result.component.reason, result.component.status === 'ok' ? 'success' : 'warning');
+    } catch (error) {
+        console.error('Error retrying health component:', error);
+        app.showToast('Error retrying', 'error');
     }
 };
 

--- a/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
+++ b/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
@@ -8,8 +8,10 @@ using EDButtkicker.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace EDButtkicker.Tests;
@@ -162,6 +164,16 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
         { "GET", "/api/context/status" },
         { "POST", "/api/context/config" },
         { "GET", "/api/context/predictions" },
+        { "GET", "/api/setup/status" },
+        { "GET", "/api/setup/journal/candidates" },
+        { "POST", "/api/setup/journal" },
+        { "POST", "/api/setup/audio/device" },
+        { "POST", "/api/setup/audio/test" },
+        { "POST", "/api/setup/complete" },
+        { "POST", "/api/setup/reopen" },
+        { "GET", "/api/health" },
+        { "POST", "/api/health/journal/retry" },
+        { "POST", "/api/health/audio/retry" },
         { "GET", "/" }
     };
 
@@ -175,6 +187,9 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
         "/api/PatternFiles/packs",
         "/api/PatternEditor/templates",
         "/api/context/predictions",
+        "/api/setup/status",
+        "/api/setup/journal/candidates",
+        "/api/health",
         "/"
     };
 
@@ -219,6 +234,7 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
 public sealed class WebUiTestServerFixture : IDisposable
 {
     private readonly IWebHost _host;
+    private readonly TempDirectory _setupStateDir = new("edbk-di-setup");
 
     public WebUiTestServerFixture()
     {
@@ -233,6 +249,11 @@ public sealed class WebUiTestServerFixture : IDisposable
 
                 // The one composition root, exactly as Program registers it.
                 services.AddEliteButtkicker(settings);
+
+                // The only redirection: setup completion is written to a temp directory so probing
+                // the setup routes cannot mark a developer's own first run as done.
+                services.Replace(ServiceDescriptor.Singleton(
+                    new SetupStateService(NullLogger<SetupStateService>.Instance, _setupStateDir.Path)));
 
                 // Deliberately no AddHostedService: no JournalMonitorService, no StatusMonitorService,
                 // no WebConfigurationService, and AudioEngineService is never Initialize()d.
@@ -253,5 +274,6 @@ public sealed class WebUiTestServerFixture : IDisposable
     {
         Client.Dispose();
         _host.Dispose();
+        _setupStateDir.Dispose();
     }
 }

--- a/tests/EDButtkicker.Tests/JournalMonitorRecoveryTests.cs
+++ b/tests/EDButtkicker.Tests/JournalMonitorRecoveryTests.cs
@@ -1,0 +1,168 @@
+using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
+using EDButtkicker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Recovery: a journal folder that is missing at startup used to end journal monitoring for the
+/// lifetime of the process, and the dashboard showed the folder's existence instead of the watcher.
+/// These drive the real service over temp folders - no game, no audio hardware - and pin that it
+/// waits, says why, attaches when the folder appears, follows a path change from setup, and goes
+/// back to waiting when the folder disappears.
+/// </summary>
+public class JournalMonitorRecoveryTests : IDisposable
+{
+    private const string FsdJumpLine =
+        """{"timestamp":"2026-08-28T12:00:00Z","event":"FSDJump","StarSystem":"Shinrarta Dezhra"}""";
+
+    private readonly TempDirectory _root = new("edbk-monitor");
+    private readonly RecordingJournalPipeline _pipeline = new();
+    private readonly AppSettings _settings = new();
+    private ServiceProvider? _provider;
+
+    private JournalMonitorService CreateMonitor()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+        services.AddEliteButtkicker(_settings);
+
+        // Journal events are recorded instead of played, and per-user state stays in the temp folder.
+        services.Replace(ServiceDescriptor.Singleton<IJournalEventPipeline>(_pipeline));
+        services.Replace(ServiceDescriptor.Singleton<AudioEngineService>(new FakeAudioEngine(_settings)));
+        services.Replace(ServiceDescriptor.Singleton(
+            new UserSettingsService(NullLogger<UserSettingsService>.Instance, _root.Path)));
+
+        _provider = services.BuildServiceProvider();
+        return ActivatorUtilities.CreateInstance<JournalMonitorService>(_provider);
+    }
+
+    private JournalMonitorStatus Status => _provider!.GetRequiredService<JournalMonitorStatus>();
+
+    private static string WriteJournal(string directory, string name, string line)
+    {
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, line + "\n");
+        return path;
+    }
+
+    [Fact]
+    public async Task MissingFolder_IsWaitedOnAndAttachedToWhenItAppears()
+    {
+        var journalPath = Path.Combine(_root.Path, "journals");
+        _settings.EliteDangerous.JournalPath = journalPath;
+        // Read the whole file rather than tailing, so the test does not race the writer.
+        _settings.EliteDangerous.MonitorLatestOnly = false;
+
+        var monitor = CreateMonitor();
+        await monitor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.State == JournalWatchState.Waiting,
+                "the monitor to report that it is waiting for the journal folder");
+
+            // The reason names the folder, which is what the health indicator shows the user.
+            Assert.Contains(journalPath, Status.Current.Reason);
+
+            Directory.CreateDirectory(journalPath);
+            var file = WriteJournal(journalPath, "Journal.2026-08-28T120000.01.log", FsdJumpLine);
+            Status.RequestRecheck();
+
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.State == JournalWatchState.Watching && _pipeline.Processed.Count > 0,
+                "the monitor to attach to the new folder and process the journal line");
+
+            Assert.Equal("FSDJump", _pipeline.Processed[0].Event);
+            Assert.Equal(Path.GetFileName(file), Status.Current.ActiveFile);
+            Assert.Equal(journalPath, Status.Current.Path);
+        }
+        finally
+        {
+            await monitor.StopAsync(CancellationToken.None);
+            monitor.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ConfiguredPathChange_MovesTheWatcherToTheNewFolder()
+    {
+        var first = Path.Combine(_root.Path, "first");
+        var second = Path.Combine(_root.Path, "second");
+        Directory.CreateDirectory(first);
+        Directory.CreateDirectory(second);
+
+        _settings.EliteDangerous.JournalPath = first;
+        _settings.EliteDangerous.MonitorLatestOnly = false;
+
+        var monitor = CreateMonitor();
+        await monitor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.State == JournalWatchState.Watching && Status.Current.Path == first,
+                "the monitor to attach to the first folder");
+
+            // This is what the setup wizard does when the user confirms a different folder.
+            WriteJournal(second, "Journal.2026-08-28T130000.01.log", FsdJumpLine);
+            _settings.EliteDangerous.JournalPath = second;
+            Status.RequestRecheck();
+
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.Path == second && _pipeline.Processed.Count > 0,
+                "the monitor to follow the journal path change");
+
+            Assert.Equal(JournalWatchState.Watching, Status.Current.State);
+            Assert.Equal("FSDJump", _pipeline.Processed[0].Event);
+        }
+        finally
+        {
+            await monitor.StopAsync(CancellationToken.None);
+            monitor.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task FolderDisappearing_ReturnsTheMonitorToWaitingInsteadOfSilence()
+    {
+        var journalPath = Path.Combine(_root.Path, "journals");
+        Directory.CreateDirectory(journalPath);
+        _settings.EliteDangerous.JournalPath = journalPath;
+
+        var monitor = CreateMonitor();
+        await monitor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.State == JournalWatchState.Watching,
+                "the monitor to attach to the journal folder");
+
+            Directory.Delete(journalPath, recursive: true);
+
+            await SetupTestExtensions.WaitForAsync(
+                () => Status.Current.State == JournalWatchState.Waiting,
+                "the monitor to report that the folder is gone");
+
+            Assert.Contains(journalPath, Status.Current.Reason);
+        }
+        finally
+        {
+            await monitor.StopAsync(CancellationToken.None);
+            monitor.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _provider?.Dispose();
+        _root.Dispose();
+    }
+}

--- a/tests/EDButtkicker.Tests/SetupTestSupport.cs
+++ b/tests/EDButtkicker.Tests/SetupTestSupport.cs
@@ -1,0 +1,275 @@
+using System.Text;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// A device list the test owns. Real enumeration talks to WASAPI, which does not exist on a CI
+/// agent, so setup and health behaviour is pinned against a catalog instead of hardware.
+/// </summary>
+internal sealed class FakeAudioDeviceCatalog : IAudioDeviceCatalog
+{
+    private readonly List<AudioDevice> _devices;
+
+    public FakeAudioDeviceCatalog(IEnumerable<AudioDevice> devices)
+    {
+        _devices = devices.ToList();
+    }
+
+    /// <summary>The system default entry plus the named outputs, numbered as WASAPI would.</summary>
+    public static FakeAudioDeviceCatalog With(params string[] names)
+    {
+        var devices = new List<AudioDevice>
+        {
+            new()
+            {
+                DeviceId = WasapiAudioDeviceCatalog.SystemDefaultDeviceId,
+                Name = WasapiAudioDeviceCatalog.SystemDefaultDeviceName,
+                Driver = "Default",
+                Channels = 2,
+                IsDefault = true,
+                IsAvailable = true
+            }
+        };
+
+        devices.AddRange(names.Select((name, index) => new AudioDevice
+        {
+            DeviceId = index,
+            Name = name,
+            Driver = "WASAPI",
+            Channels = 2,
+            IsDefault = index == 0,
+            IsAvailable = true
+        }));
+
+        return new FakeAudioDeviceCatalog(devices);
+    }
+
+    public IReadOnlyList<AudioDevice> GetDevices() => _devices;
+}
+
+/// <summary>
+/// An audio engine that reports device state without opening one. <see cref="FailuresBeforeSuccess"/>
+/// models the machine where the device only opens on a second attempt, which is what the health
+/// retry exists for.
+/// </summary>
+internal sealed class FakeAudioEngine : AudioEngineService
+{
+    private readonly AppSettings _settings;
+    private bool _opened;
+    private bool _attempted;
+
+    public FakeAudioEngine(AppSettings settings, bool canOpen = true, int failuresBeforeSuccess = 0)
+        : base(NullLogger<AudioEngineService>.Instance, settings)
+    {
+        _settings = settings;
+        CanOpen = canOpen;
+        FailuresBeforeSuccess = failuresBeforeSuccess;
+    }
+
+    public bool CanOpen { get; set; }
+
+    public int FailuresBeforeSuccess { get; set; }
+
+    public string FailureReason { get; set; } = "no output device is available";
+
+    public List<HapticPattern> Played { get; } = new();
+
+    public int OpenAttempts { get; private set; }
+
+    public override bool EnsureInitialized()
+    {
+        if (_opened) return true;
+
+        _attempted = true;
+        OpenAttempts++;
+
+        if (!CanOpen || OpenAttempts <= FailuresBeforeSuccess)
+        {
+            return false;
+        }
+
+        _opened = true;
+        return true;
+    }
+
+    public override AudioEngineStatus GetStatus() => new(
+        _opened,
+        _attempted && !_opened,
+        _opened ? null : FailureReason,
+        _settings.Audio.AudioDeviceName,
+        _opened ? DateTime.UtcNow : null);
+
+    public override Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
+    {
+        if (!EnsureInitialized())
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (Played)
+        {
+            Played.Add(pattern);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Records what the journal pipeline was handed, without touching audio or history.</summary>
+internal sealed class RecordingJournalPipeline : IJournalEventPipeline
+{
+    private readonly List<JournalEvent> _processed = new();
+
+    public IReadOnlyList<JournalEvent> Processed
+    {
+        get
+        {
+            lock (_processed)
+            {
+                return _processed.ToList();
+            }
+        }
+    }
+
+    public Task ProcessAsync(JournalEvent journalEvent, bool skipHistory = false)
+    {
+        lock (_processed)
+        {
+            _processed.Add(journalEvent);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// The real web pipeline on a TestServer - same registrations and same Configure callback as
+/// Program - with the per-user state redirected into a temp directory, a device catalog the test
+/// owns, and an audio engine that never opens hardware. No hosted services run.
+/// </summary>
+internal sealed class SetupTestHost : IDisposable
+{
+    private readonly IWebHost _host;
+
+    public SetupTestHost(
+        string settingsDirectory,
+        AppSettings? settings = null,
+        FakeAudioDeviceCatalog? deviceCatalog = null,
+        FakeAudioEngine? audioEngine = null,
+        IEnumerable<string>? journalSearchPaths = null)
+    {
+        Settings = settings ?? new AppSettings();
+        DeviceCatalog = deviceCatalog ?? FakeAudioDeviceCatalog.With("ButtKicker Amp", "Headphones");
+        AudioEngine = audioEngine ?? new FakeAudioEngine(Settings);
+
+        _host = new WebHostBuilder()
+            .UseContentRoot(AppContext.BaseDirectory)
+            .UseTestServer()
+            .ConfigureServices(services =>
+            {
+                services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+                services.AddEliteButtkicker(Settings);
+
+                // Everything below only redirects state that would otherwise land in the real user
+                // profile, or stands in for hardware. The graph itself is the production one.
+                services.Replace(ServiceDescriptor.Singleton(
+                    new UserSettingsService(NullLogger<UserSettingsService>.Instance, settingsDirectory)));
+                services.Replace(ServiceDescriptor.Singleton(
+                    new SetupStateService(NullLogger<SetupStateService>.Instance, settingsDirectory)));
+                services.Replace(ServiceDescriptor.Singleton(
+                    new JournalPathDiscovery(Settings, journalSearchPaths ?? Array.Empty<string>())));
+                services.Replace(ServiceDescriptor.Singleton<IAudioDeviceCatalog>(DeviceCatalog));
+                services.Replace(ServiceDescriptor.Singleton<AudioEngineService>(AudioEngine));
+            })
+            .Configure(WebUiConfiguration.Configure)
+            .Build();
+
+        _host.Start();
+        Client = _host.GetTestClient();
+    }
+
+    public AppSettings Settings { get; }
+
+    public FakeAudioDeviceCatalog DeviceCatalog { get; }
+
+    public FakeAudioEngine AudioEngine { get; }
+
+    public HttpClient Client { get; }
+
+    public IServiceProvider Services => _host.Services;
+
+    public async Task<JsonElement> GetJsonAsync(string path)
+    {
+        var response = await Client.GetAsync(path);
+        Assert.True(response.IsSuccessStatusCode, $"GET {path} returned {(int)response.StatusCode}");
+
+        return await ReadJsonAsync(response);
+    }
+
+    public Task<HttpResponseMessage> PostAsync(string path, object? body = null) =>
+        Client.PostAsync(
+            path,
+            new StringContent(body == null ? "{}" : JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"));
+
+    public static async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return document.RootElement.Clone();
+    }
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        _host.Dispose();
+    }
+}
+
+internal static class SetupTestExtensions
+{
+    /// <summary>The step with the given id, so assertions read like the wizard does.</summary>
+    public static JsonElement Step(this JsonElement setupStatus, string id) =>
+        setupStatus.GetProperty("steps").EnumerateArray().Single(s => s.GetProperty("id").GetString() == id);
+
+    public static bool IsStepComplete(this JsonElement setupStatus, string id) =>
+        setupStatus.Step(id).GetProperty("complete").GetBoolean();
+
+    /// <summary>One health indicator out of a report, in either the health or setup payload.</summary>
+    public static JsonElement Component(this JsonElement healthReport, string id) =>
+        healthReport.GetProperty("components").EnumerateArray().Single(c => c.GetProperty("id").GetString() == id);
+
+    public static string StatusOf(this JsonElement healthReport, string id) =>
+        healthReport.Component(id).GetProperty("status").GetString()!;
+
+    public static string ReasonOf(this JsonElement healthReport, string id) =>
+        healthReport.Component(id).GetProperty("reason").GetString()!;
+
+    /// <summary>Polls until <paramref name="condition"/> holds, so nothing waits on a fixed sleep.</summary>
+    public static async Task WaitForAsync(Func<bool> condition, string description, int timeoutMs = 20000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+
+        Assert.Fail($"Timed out waiting for {description}");
+    }
+}

--- a/tests/EDButtkicker.Tests/SetupWizardApiTests.cs
+++ b/tests/EDButtkicker.Tests/SetupWizardApiTests.cs
@@ -215,6 +215,82 @@ public class SetupWizardApiTests : IDisposable
         Assert.Contains("nothing was played", step.GetProperty("summary").GetString());
     }
 
+    /// <summary>
+    /// Occupying the settings path with a directory makes writing it fail the same way a read-only
+    /// or locked profile would, without needing platform-specific permissions.
+    /// </summary>
+    private void BlockUserSettingsFile()
+    {
+        var settingsFile = Path.Combine(_settingsDir.Path, "user-settings.json");
+
+        if (File.Exists(settingsFile))
+        {
+            File.Delete(settingsFile);
+        }
+
+        Directory.CreateDirectory(settingsFile);
+    }
+
+    [Fact]
+    public async Task JournalStep_IsNotRecordedWhenTheChoiceCannotBeSaved()
+    {
+        WriteJournalFile();
+        BlockUserSettingsFile();
+
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/journal", new { path = _journalDir.Path });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.False(result.GetProperty("saved").GetBoolean());
+        Assert.Contains("could not be saved", result.GetProperty("error").GetString());
+
+        // A step that will not survive a restart must not be reported as done.
+        Assert.False(result.GetProperty("setup").IsStepComplete("journal"));
+
+        var status = await host.GetJsonAsync("/api/setup/status");
+        Assert.False(status.IsStepComplete("journal"));
+        Assert.Equal("journal", status.GetProperty("current_step").GetString());
+    }
+
+    [Fact]
+    public async Task AudioStep_IsNotRecordedWhenTheChoiceCannotBeSaved()
+    {
+        BlockUserSettingsFile();
+
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/audio/device", new { deviceId = 0 });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.False(result.GetProperty("saved").GetBoolean());
+        Assert.False(result.GetProperty("setup").IsStepComplete("audio-device"));
+
+        Assert.False((await host.GetJsonAsync("/api/setup/status")).IsStepComplete("audio-device"));
+    }
+
+    [Fact]
+    public async Task AFailedSave_LeavesAnAlreadyConfirmedStepAsItWas()
+    {
+        WriteJournalFile();
+
+        using var host = NewHost();
+        Assert.True((await host.PostAsync("/api/setup/journal", new { path = _journalDir.Path })).IsSuccessStatusCode);
+
+        BlockUserSettingsFile();
+        var response = await host.PostAsync("/api/setup/audio/device", new { deviceId = 0 });
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        // The earlier, genuinely saved step is untouched by the failure of a later one.
+        var status = await host.GetJsonAsync("/api/setup/status");
+        Assert.True(status.IsStepComplete("journal"));
+        Assert.False(status.IsStepComplete("audio-device"));
+        Assert.Equal(_journalDir.Path, status.Step("journal").GetProperty("summary").GetString()!.Split(": ")[1]);
+    }
+
     [Fact]
     public async Task PartialConfiguration_ResumesAtTheNextStepAfterARestart()
     {

--- a/tests/EDButtkicker.Tests/SetupWizardApiTests.cs
+++ b/tests/EDButtkicker.Tests/SetupWizardApiTests.cs
@@ -1,0 +1,332 @@
+using System.Net;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Controllers;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The first run has to be guided and honest: discovery has to show what is really on disk, a step
+/// only counts once the subsystem accepted it, a half-finished setup has to resume where it stopped,
+/// and completion has to survive a restart without locking the wizard away. Everything runs against
+/// temp directories and a fake device catalog - no audio hardware, no real user profile.
+/// </summary>
+public class SetupWizardApiTests : IDisposable
+{
+    private const string JournalLine =
+        """{"timestamp":"2026-08-28T12:00:00Z","event":"FSDJump","StarSystem":"Shinrarta Dezhra"}""";
+
+    private readonly TempDirectory _settingsDir = new("edbk-setup-state");
+    private readonly TempDirectory _journalDir = new("edbk-setup-journal");
+
+    /// <summary>A fresh host over the same settings directory - i.e. a restart of the app.</summary>
+    private SetupTestHost NewHost(FakeAudioEngine? audioEngine = null, FakeAudioDeviceCatalog? catalog = null)
+    {
+        var settings = new AppSettings();
+        // Point the configured path somewhere that does not exist, so nothing in these tests
+        // depends on the developer's own Elite Dangerous install.
+        settings.EliteDangerous.JournalPath = Path.Combine(_settingsDir.Path, "not-installed");
+
+        return new SetupTestHost(
+            _settingsDir.Path,
+            settings,
+            catalog,
+            audioEngine ?? new FakeAudioEngine(settings),
+            journalSearchPaths: new[] { _journalDir.Path });
+    }
+
+    private string WriteJournalFile(string name = "Journal.2026-08-28T120000.01.log")
+    {
+        var path = Path.Combine(_journalDir.Path, name);
+        File.WriteAllText(path, JournalLine + Environment.NewLine);
+        return path;
+    }
+
+    [Fact]
+    public async Task FirstRun_OpensTheWizardWithNothingConfirmed()
+    {
+        using var host = NewHost();
+
+        var status = await host.GetJsonAsync("/api/setup/status");
+
+        Assert.False(status.GetProperty("completed").GetBoolean());
+        Assert.True(status.GetProperty("show_wizard").GetBoolean());
+        Assert.Equal("journal", status.GetProperty("current_step").GetString());
+        Assert.All(
+            status.GetProperty("steps").EnumerateArray(),
+            step => Assert.False(step.GetProperty("complete").GetBoolean()));
+
+        // The wizard carries real subsystem health from the very first screen.
+        Assert.NotEmpty(status.GetProperty("health").GetProperty("components").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task JournalDiscovery_ReportsWhatIsActuallyInEachFolder()
+    {
+        WriteJournalFile();
+        using var host = NewHost();
+
+        var discovery = await host.GetJsonAsync("/api/setup/journal/candidates");
+        var candidates = discovery.GetProperty("candidates").EnumerateArray().ToList();
+
+        var configured = candidates.Single(c => c.GetProperty("is_configured").GetBoolean());
+        Assert.False(configured.GetProperty("exists").GetBoolean());
+
+        var found = candidates.Single(c => c.GetProperty("path").GetString() == _journalDir.Path);
+        Assert.True(found.GetProperty("exists").GetBoolean());
+        Assert.Equal(1, found.GetProperty("journal_files_found").GetInt32());
+
+        // The folder that actually holds journals is the one recommended.
+        Assert.Equal(_journalDir.Path, discovery.GetProperty("recommended_path").GetString());
+    }
+
+    [Fact]
+    public async Task JournalStep_ConfirmingAFolderPersistsItAndCompletesTheStep()
+    {
+        WriteJournalFile();
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/journal", new { path = _journalDir.Path });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(1, result.GetProperty("journal_files_found").GetInt32());
+        Assert.Equal(JsonValueKind.Null, result.GetProperty("warning").ValueKind);
+
+        Assert.Equal(_journalDir.Path, host.Settings.EliteDangerous.JournalPath);
+        Assert.True(File.Exists(Path.Combine(_settingsDir.Path, "user-settings.json")));
+        Assert.True(File.Exists(Path.Combine(_settingsDir.Path, "setup-state.json")));
+
+        var setup = result.GetProperty("setup");
+        Assert.True(setup.IsStepComplete("journal"));
+        Assert.False(setup.IsStepComplete("audio-device"));
+        Assert.Equal("audio-device", setup.GetProperty("current_step").GetString());
+    }
+
+    [Fact]
+    public async Task JournalStep_RejectsAFolderThatDoesNotExist()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync(
+            "/api/setup/journal",
+            new { path = Path.Combine(_settingsDir.Path, "nowhere") });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var status = await host.GetJsonAsync("/api/setup/status");
+        Assert.False(status.IsStepComplete("journal"));
+    }
+
+    [Fact]
+    public async Task JournalStep_AcceptsAFolderWithNoJournalsYetButSaysSo()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/journal", new { path = _journalDir.Path });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(0, result.GetProperty("journal_files_found").GetInt32());
+        Assert.Contains("No journal files here yet", result.GetProperty("warning").GetString());
+        Assert.True(result.GetProperty("setup").IsStepComplete("journal"));
+    }
+
+    [Fact]
+    public async Task AudioStep_StoresTheDeviceNameSoTheChoiceSurvivesReordering()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/audio/device", new { deviceId = 0 });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal("ButtKicker Amp", result.GetProperty("device").GetProperty("name").GetString());
+
+        // The name is the stable key: the enumeration index moves when devices come and go.
+        Assert.Equal("ButtKicker Amp", host.Settings.Audio.AudioDeviceName);
+        Assert.Equal(0, host.Settings.Audio.AudioDeviceId);
+
+        var persisted = await File.ReadAllTextAsync(Path.Combine(_settingsDir.Path, "setup-state.json"));
+        Assert.Contains("ButtKicker Amp", persisted);
+        Assert.True(result.GetProperty("setup").IsStepComplete("audio-device"));
+    }
+
+    [Fact]
+    public async Task AudioStep_SystemDefaultIsStoredAsTheDefaultRatherThanAName()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/audio/device", new { deviceId = -1 });
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(string.Empty, host.Settings.Audio.AudioDeviceName);
+        Assert.Equal(-1, host.Settings.Audio.AudioDeviceId);
+    }
+
+    [Fact]
+    public async Task AudioStep_RejectsADeviceThatIsNotConnected()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/setup/audio/device", new { name = "Not Plugged In" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(string.Empty, host.Settings.Audio.AudioDeviceName);
+    }
+
+    [Fact]
+    public async Task AudioTest_PlaysAConservativePattern()
+    {
+        var settings = new AppSettings();
+        using var host = NewHost(new FakeAudioEngine(settings));
+
+        var response = await host.PostAsync("/api/setup/audio/test");
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.True(result.GetProperty("played").GetBoolean());
+
+        var played = Assert.Single(host.AudioEngine.Played);
+        Assert.True(played.Intensity <= SetupApiController.TestIntensityPercent, "the test tone must stay quiet");
+        Assert.Equal(SetupApiController.TestDurationMs, played.Duration);
+        Assert.InRange(played.Frequency, SetupApiController.MinTestFrequency, SetupApiController.MaxTestFrequency);
+        Assert.True(played.FadeIn > 0 && played.FadeOut > 0, "the test tone must fade rather than start at full level");
+    }
+
+    [Fact]
+    public async Task AudioTest_SaysNothingPlayedWhenNoDeviceCanBeOpened()
+    {
+        var settings = new AppSettings();
+        using var host = NewHost(new FakeAudioEngine(settings, canOpen: false));
+
+        var response = await host.PostAsync("/api/setup/audio/test");
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.False(result.GetProperty("played").GetBoolean());
+        Assert.Contains("no output device is available", result.GetProperty("reason").GetString());
+        Assert.Empty(host.AudioEngine.Played);
+
+        // The step is recorded as run, with the outcome that actually happened.
+        var step = result.GetProperty("setup").Step("audio-test");
+        Assert.True(step.GetProperty("complete").GetBoolean());
+        Assert.Contains("nothing was played", step.GetProperty("summary").GetString());
+    }
+
+    [Fact]
+    public async Task PartialConfiguration_ResumesAtTheNextStepAfterARestart()
+    {
+        WriteJournalFile();
+
+        using (var first = NewHost())
+        {
+            var response = await first.PostAsync("/api/setup/journal", new { path = _journalDir.Path });
+            Assert.True(response.IsSuccessStatusCode);
+        }
+
+        using var restarted = NewHost();
+        var status = await restarted.GetJsonAsync("/api/setup/status");
+
+        Assert.False(status.GetProperty("completed").GetBoolean());
+        Assert.True(status.GetProperty("show_wizard").GetBoolean());
+        Assert.True(status.IsStepComplete("journal"));
+        Assert.False(status.IsStepComplete("audio-device"));
+        Assert.Equal("audio-device", status.GetProperty("current_step").GetString());
+        Assert.Equal(
+            new[] { "audio-device", "audio-test", "finish" },
+            status.GetProperty("incomplete_steps").EnumerateArray().Select(e => e.GetString()).ToArray());
+    }
+
+    [Fact]
+    public async Task ChangingTheOutputDevice_InvalidatesThePreviousAudioTest()
+    {
+        using var host = NewHost();
+
+        Assert.True((await host.PostAsync("/api/setup/audio/test")).IsSuccessStatusCode);
+        Assert.True((await host.GetJsonAsync("/api/setup/status")).IsStepComplete("audio-test"));
+
+        var response = await host.PostAsync("/api/setup/audio/device", new { deviceId = 1 });
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        // A test on the previous device says nothing about the new one.
+        Assert.False(result.GetProperty("setup").IsStepComplete("audio-test"));
+    }
+
+    [Fact]
+    public async Task Completion_IsPersistedAndStopsTheWizardOpeningItself()
+    {
+        using (var first = NewHost())
+        {
+            var response = await first.PostAsync("/api/setup/complete");
+            var result = await SetupTestHost.ReadJsonAsync(response);
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.True(result.GetProperty("setup").GetProperty("completed").GetBoolean());
+            Assert.False(result.GetProperty("setup").GetProperty("show_wizard").GetBoolean());
+        }
+
+        using var restarted = NewHost();
+        var status = await restarted.GetJsonAsync("/api/setup/status");
+
+        Assert.True(status.GetProperty("completed").GetBoolean());
+        Assert.False(status.GetProperty("show_wizard").GetBoolean());
+        Assert.NotEqual(JsonValueKind.Null, status.GetProperty("completed_at").ValueKind);
+    }
+
+    [Fact]
+    public async Task Reopening_ShowsTheWizardAgainWithoutErasingCompletion()
+    {
+        using var host = NewHost();
+        Assert.True((await host.PostAsync("/api/setup/complete")).IsSuccessStatusCode);
+
+        var reopened = (await SetupTestHost.ReadJsonAsync(await host.PostAsync("/api/setup/reopen")))
+            .GetProperty("setup");
+
+        Assert.True(reopened.GetProperty("show_wizard").GetBoolean());
+        Assert.True(reopened.GetProperty("reopen_requested").GetBoolean());
+        // Completion is a record, not something a reopen throws away.
+        Assert.True(reopened.GetProperty("completed").GetBoolean());
+
+        var finished = (await SetupTestHost.ReadJsonAsync(await host.PostAsync("/api/setup/complete")))
+            .GetProperty("setup");
+
+        Assert.False(finished.GetProperty("show_wizard").GetBoolean());
+        Assert.True(finished.GetProperty("completed").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Reopening_DoesNotSurviveARestart()
+    {
+        using (var first = NewHost())
+        {
+            Assert.True((await first.PostAsync("/api/setup/complete")).IsSuccessStatusCode);
+            Assert.True((await first.PostAsync("/api/setup/reopen")).IsSuccessStatusCode);
+        }
+
+        using var restarted = NewHost();
+        var status = await restarted.GetJsonAsync("/api/setup/status");
+
+        Assert.False(status.GetProperty("show_wizard").GetBoolean());
+        Assert.False(status.GetProperty("reopen_requested").GetBoolean());
+    }
+
+    [Fact]
+    public async Task DamagedSetupState_FallsBackToAFirstRunInsteadOfFailing()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_settingsDir.Path, "setup-state.json"), "{ not json");
+
+        using var host = NewHost();
+        var status = await host.GetJsonAsync("/api/setup/status");
+
+        Assert.False(status.GetProperty("completed").GetBoolean());
+        Assert.True(status.GetProperty("show_wizard").GetBoolean());
+    }
+
+    public void Dispose()
+    {
+        _settingsDir.Dispose();
+        _journalDir.Dispose();
+    }
+}

--- a/tests/EDButtkicker.Tests/SystemHealthApiTests.cs
+++ b/tests/EDButtkicker.Tests/SystemHealthApiTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using EDButtkicker.Configuration;
+using EDButtkicker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Every indicator has to come from the subsystem it names. These pin the states the dashboard used
+/// to fake: journal monitoring reported from an existing folder rather than a live watcher, audio
+/// and voice reported "online" because an unrelated request succeeded. Each indicator also has to
+/// carry a reason, and a retry that does something.
+/// </summary>
+public class SystemHealthApiTests : IDisposable
+{
+    private readonly TempDirectory _settingsDir = new("edbk-health");
+
+    private SetupTestHost NewHost(AppSettings? settings = null, FakeAudioEngine? audioEngine = null)
+    {
+        var appSettings = settings ?? new AppSettings();
+        return new SetupTestHost(_settingsDir.Path, appSettings, audioEngine: audioEngine ?? new FakeAudioEngine(appSettings));
+    }
+
+    [Fact]
+    public async Task Journal_TracksTheWatcherRatherThanTheFolder()
+    {
+        using var host = NewHost();
+        var monitor = host.Services.GetRequiredService<JournalMonitorStatus>();
+
+        var report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("pending", report.StatusOf("journal"));
+        Assert.Contains("has not started", report.ReasonOf("journal"));
+
+        monitor.ReportWaiting("C:\\journals", "The journal folder does not exist yet: C:\\journals");
+        report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("attention", report.StatusOf("journal"));
+        Assert.Contains("does not exist yet", report.ReasonOf("journal"));
+
+        // Attached but with no journal file yet is still not "connected".
+        monitor.ReportWatching("C:\\journals", null);
+        report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("attention", report.StatusOf("journal"));
+
+        monitor.ReportWatching("C:\\journals", "Journal.2026-08-28T120000.01.log");
+        report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("ok", report.StatusOf("journal"));
+        Assert.Contains("Journal.2026-08-28T120000.01.log", report.ReasonOf("journal"));
+    }
+
+    [Fact]
+    public async Task Journal_FaultIsReportedAsAnErrorWithItsReason()
+    {
+        using var host = NewHost();
+        host.Services.GetRequiredService<JournalMonitorStatus>()
+            .ReportFaulted("Journal monitoring stopped after an error: access denied");
+
+        var report = await host.GetJsonAsync("/api/health");
+
+        Assert.Equal("error", report.StatusOf("journal"));
+        Assert.Contains("access denied", report.ReasonOf("journal"));
+    }
+
+    [Fact]
+    public async Task JournalStatusApi_OnlyReportsMonitoringWhenAWatcherIsAttached()
+    {
+        using var dir = new TempDirectory("edbk-health-journal");
+        var settings = new AppSettings();
+        settings.EliteDangerous.JournalPath = dir.Path;
+
+        using var host = NewHost(settings);
+        var monitor = host.Services.GetRequiredService<JournalMonitorStatus>();
+
+        // The folder exists, which used to be enough to claim "Connected".
+        var status = await host.GetJsonAsync("/api/journal/status");
+        Assert.True(status.GetProperty("path_exists").GetBoolean());
+        Assert.False(status.GetProperty("monitoring").GetBoolean());
+        Assert.Equal("Disconnected", status.GetProperty("status").GetString());
+
+        monitor.ReportWatching(dir.Path, "Journal.2026-08-28T120000.01.log");
+        status = await host.GetJsonAsync("/api/journal/status");
+
+        Assert.True(status.GetProperty("monitoring").GetBoolean());
+        Assert.Equal("Connected", status.GetProperty("status").GetString());
+        Assert.Equal("Watching", status.GetProperty("monitor_state").GetString());
+    }
+
+    [Fact]
+    public async Task Audio_IsPendingUntilADeviceIsActuallyOpened()
+    {
+        using var host = NewHost();
+
+        var report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("pending", report.StatusOf("audio"));
+        Assert.Contains("has been opened yet", report.ReasonOf("audio"));
+
+        Assert.True((await host.PostAsync("/api/setup/audio/test")).IsSuccessStatusCode);
+
+        report = await host.GetJsonAsync("/api/health");
+        Assert.Equal("ok", report.StatusOf("audio"));
+    }
+
+    [Fact]
+    public async Task Audio_ReportsWhyTheDeviceCouldNotBeOpened()
+    {
+        var settings = new AppSettings();
+        using var host = NewHost(settings, new FakeAudioEngine(settings, canOpen: false));
+
+        Assert.True((await host.PostAsync("/api/setup/audio/test")).IsSuccessStatusCode);
+
+        var report = await host.GetJsonAsync("/api/health");
+        var audio = report.Component("audio");
+
+        Assert.Equal("error", audio.GetProperty("status").GetString());
+        Assert.Contains("no output device is available", audio.GetProperty("reason").GetString());
+        Assert.Equal("/api/health/audio/retry", audio.GetProperty("retry").GetProperty("endpoint").GetString());
+    }
+
+    [Fact]
+    public async Task Audio_FlagsASavedDeviceThatIsNoLongerConnected()
+    {
+        var settings = new AppSettings();
+        settings.Audio.AudioDeviceName = "ButtKicker Amp That Went Away";
+
+        using var host = NewHost(settings);
+
+        var report = await host.GetJsonAsync("/api/health");
+
+        Assert.Equal("attention", report.StatusOf("audio"));
+        Assert.Contains("is not connected", report.ReasonOf("audio"));
+    }
+
+    [Fact]
+    public async Task Voice_IsReportedOffInsteadOfOnline()
+    {
+        using var host = NewHost();
+
+        var report = await host.GetJsonAsync("/api/health");
+
+        Assert.Equal("off", report.StatusOf("voice"));
+        Assert.Contains("not running", report.ReasonOf("voice"));
+    }
+
+    [Fact]
+    public async Task WebAndPatterns_ReportWhatTheProcessIsActuallyDoing()
+    {
+        using var host = NewHost();
+
+        var report = await host.GetJsonAsync("/api/health");
+
+        Assert.Equal("ok", report.StatusOf("web"));
+        Assert.Contains("loopback", report.ReasonOf("web"));
+
+        // Default event mappings are loaded by the running service, so this is a real reading.
+        Assert.Equal("ok", report.StatusOf("patterns"));
+        Assert.Contains("pattern", report.ReasonOf("patterns"));
+    }
+
+    [Fact]
+    public async Task Retry_ForTheJournal_AsksTheMonitorToLookAgain()
+    {
+        using var host = NewHost();
+        var monitor = host.Services.GetRequiredService<JournalMonitorStatus>();
+
+        var response = await host.PostAsync("/api/health/journal/retry");
+        var result = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal("journal", result.GetProperty("retried").GetString());
+        Assert.NotEmpty(result.GetProperty("health").GetProperty("components").EnumerateArray());
+
+        // The recheck signal is queued for the watcher, which is what makes the retry real.
+        Assert.True(await monitor.WaitForRecheckAsync(TimeSpan.Zero, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Retry_ForAudio_ReopensTheDeviceAndReportsTheNewState()
+    {
+        var settings = new AppSettings();
+        var engine = new FakeAudioEngine(settings, failuresBeforeSuccess: 1);
+        using var host = NewHost(settings, engine);
+
+        // First attempt fails, exactly like a device that was not ready at startup.
+        Assert.False((await SetupTestHost.ReadJsonAsync(await host.PostAsync("/api/setup/audio/test")))
+            .GetProperty("played").GetBoolean());
+        Assert.Equal("error", (await host.GetJsonAsync("/api/health")).StatusOf("audio"));
+
+        var retry = await SetupTestHost.ReadJsonAsync(await host.PostAsync("/api/health/audio/retry"));
+
+        Assert.Equal("ok", retry.GetProperty("component").GetProperty("status").GetString());
+        Assert.Equal("ok", retry.GetProperty("health").StatusOf("audio"));
+        Assert.Equal(2, engine.OpenAttempts);
+    }
+
+    [Fact]
+    public async Task Retry_ForAComponentWithoutOne_IsRejected()
+    {
+        using var host = NewHost();
+
+        var response = await host.PostAsync("/api/health/web/retry");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task EveryIndicator_CarriesAReason()
+    {
+        using var host = NewHost();
+
+        var report = await host.GetJsonAsync("/api/health");
+
+        Assert.All(report.GetProperty("components").EnumerateArray(), component =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(component.GetProperty("name").GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(component.GetProperty("reason").GetString()));
+        });
+
+        // Overall status is the worst of the parts, so a green header cannot hide a red row.
+        Assert.Equal("pending", report.GetProperty("status").GetString());
+    }
+
+    public void Dispose() => _settingsDir.Dispose();
+}


### PR DESCRIPTION
## Summary
- Adds a persistent, reopenable first-run wizard for journal selection, stable audio output selection, and a conservative audio test.
- Replaces optimistic dashboard status with actual subsystem health, reasons, and retry actions.
- Adds recovery for journal folders that appear, disappear, or change after startup.
- Keeps setup state truthful when settings persistence fails.

## Verification
- `dotnet test EDButtkicker.sln --no-restore` — 362 passed
- `dotnet build EDButtkicker.sln --no-restore`
- `git diff origin/main...HEAD --check`

Validated on Linux only; Windows and physical Buttkicker hardware were not tested.

Closes #27