### PR TITLE
fix(audio): persist MMDevice endpoint ids instead of list indexes

### DIFF
--- a/docs/windows-audio-enumeration-checklist.md
+++ b/docs/windows-audio-enumeration-checklist.md
@@ -1,0 +1,72 @@
+# Windows audio enumeration checklist
+
+Linux CI can prove the catalog, resolver, settings round-trip, and API
+selection against fake devices. It cannot open WASAPI, play a tone, or
+click the Windows UI. None of the checks below have been run. Do not
+treat a green `dotnet test` as playback.
+
+Machine: Windows, a real render endpoint, and the ButtKicker output you
+actually use. Record the MMDevice endpoint id from the log line
+`Audio devices - WASAPI render position … endpoint='…'` so a later
+report can name the same device.
+
+## Before you start
+
+- [ ] Fresh install or a settings reset, then pick the ButtKicker output
+      in the web UI (or the setup wizard). Confirm the log shows
+      `configured: endpoint id '…' is name '…'` rather than a DeviceId
+      match or a WaveOut device number.
+- [ ] Restart the app. The same endpoint id and friendly name come back
+      from `user-settings.json` (`audioDeviceEndpointId` plus
+      `audioDeviceName`). The previously selected row is still highlighted.
+
+## Reorder
+
+- [ ] In Windows sound settings, change the default device or the order
+      of playback devices so the ButtKicker is no longer at the same
+      list position.
+- [ ] Restart EDButtkicker. Playback (and the highlighted row) still
+      names the saved endpoint, not whichever device now occupies the
+      old index.
+
+## Unplug / disable
+
+- [ ] Disable or unplug the saved output. The UI must not highlight a
+      neighbour. Logs should say `UNRESOLVED` or `UNAVAILABLE` and
+      playback should fall back to the system default.
+- [ ] Plug it back in. The saved endpoint is selected again without
+      picking the device by hand.
+
+## Duplicate names
+
+- [ ] Two render endpoints that share a friendly name (two "USB Audio
+      Device" entries, or similar). Select the second. Restart. The
+      saved endpoint id still opens that one, not the first match by
+      name.
+
+## Newly connected
+
+- [ ] Plug in a new output so it appears *ahead* of the saved device in
+      the WASAPI list. The saved selection must not move to the new
+      device.
+
+## Default highlight
+
+- [ ] Choose "Default Audio Device". Settings store an empty endpoint id
+      and empty name. The default row is highlighted. After restart,
+      Windows' current default is what actually opens.
+- [ ] The endpoint Windows reports as the multimedia default is marked
+      as the default in the device list even when it is not the saved
+      selection.
+
+## Reboot
+
+- [ ] Reboot Windows, start EDButtkicker, play a test tone. The tone
+      comes from the saved ButtKicker output, not the system default,
+      unless that output is gone.
+
+## Out of this checklist
+
+- Linux or macOS audio
+- Buttplug.io
+- Claiming that this repository's CI played audio

--- a/src/EDButtkicker/Configuration/AppSettings.cs
+++ b/src/EDButtkicker/Configuration/AppSettings.cs
@@ -22,6 +22,9 @@ public class AudioSettings
 	public int DefaultFrequency { get; set; } = 40;
 	public int MaxIntensity { get; set; } = 80;
 	public string AudioDeviceName { get; set; } = string.Empty;
+	/// <summary>MMDevice endpoint id of the chosen output; empty means the system default.</summary>
+	public string AudioDeviceEndpointId { get; set; } = string.Empty;
+	/// <summary>Enumeration ordinal of the chosen output (-1 = system default). Display only.</summary>
 	public int AudioDeviceId { get; set; } = -1;
 }
 

--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -4,8 +4,6 @@ using EDButtkicker.Configuration;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
-using NAudio.CoreAudioApi;
-using NAudio.Wave;
 
 namespace EDButtkicker.Controllers;
 
@@ -41,24 +39,34 @@ public class AudioApiController
                 _logger.LogInformation("Audio devices - {Device}", line);
             }
 
-            _logger.LogInformation("Audio devices - {Selection}", AudioDeviceDiagnostics.DescribeConfiguredSelection(
-                devices, _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName));
+            var resolution = ResolveConfiguredDevice(devices);
+            _logger.LogInformation("Audio devices - {Selection}", resolution.Reason);
 
             var response = new
             {
                 devices = devices.Select(d => new
                 {
                     id = d.DeviceId,
+                    endpointId = d.EndpointId,
                     name = d.Name,
                     driver = d.Driver,
                     channels = d.Channels,
                     isDefault = d.IsDefault,
-                    isAvailable = d.IsAvailable
+                    isAvailable = d.IsAvailable,
+                    // Which row the web UI highlights: the resolved endpoint, or the system default
+                    // entry when nothing is saved or the saved device is gone.
+                    isSelected = IsSelected(d, resolution)
                 }),
                 current = new
                 {
                     id = _settings.Audio.AudioDeviceId,
-                    name = _settings.Audio.AudioDeviceName
+                    endpointId = _settings.Audio.AudioDeviceEndpointId,
+                    name = _settings.Audio.AudioDeviceName,
+                    resolved = resolution.Status.ToString(),
+                    resolvedEndpointId = resolution.EndpointId,
+                    resolvedName = resolution.Name,
+                    usesSystemDefault = resolution.UsesSystemDefault,
+                    reason = resolution.Reason
                 },
                 metadata = new
                 {
@@ -95,25 +103,25 @@ public class AudioApiController
                 return;
             }
 
-            var deviceData = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (deviceData == null || !deviceData.ContainsKey("deviceId"))
-            {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Device ID is required" }));
-                return;
-            }
+            var deviceData = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+            var requestedEndpointId = ReadString(deviceData, "endpointId");
+            var requestedDeviceId = ReadInt(deviceData, "deviceId");
 
-            var deviceIdString = deviceData["deviceId"].ToString();
-            if (!int.TryParse(deviceIdString, out int deviceId))
+            if (string.IsNullOrWhiteSpace(requestedEndpointId) && requestedDeviceId == null)
             {
                 context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid device ID format" }));
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "An endpoint id or device ID is required" }));
                 return;
             }
 
             var devices = GetAvailableAudioDevices();
-            var selectedDevice = devices.FirstOrDefault(d => d.DeviceId == deviceId);
-            
+
+            // Endpoint id is the identity, so it wins whenever the caller sends one; the numeric id
+            // stays accepted for the existing UI, where it addresses this very list.
+            var selectedDevice = !string.IsNullOrWhiteSpace(requestedEndpointId)
+                ? devices.FirstOrDefault(d => string.Equals(d.EndpointId, requestedEndpointId, StringComparison.Ordinal))
+                : devices.FirstOrDefault(d => d.DeviceId == requestedDeviceId);
+
             if (selectedDevice == null)
             {
                 context.Response.StatusCode = 404;
@@ -128,22 +136,23 @@ public class AudioApiController
                 return;
             }
 
-            // Update settings
+            // The synthetic default entry is a choice, not an endpoint: it is stored as the empty
+            // endpoint id and empty name the audio engine already reads as "use the default".
+            var isSystemDefault = selectedDevice.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId;
+
+            _settings.Audio.AudioDeviceEndpointId = isSystemDefault ? string.Empty : selectedDevice.EndpointId;
+            _settings.Audio.AudioDeviceName = isSystemDefault ? string.Empty : selectedDevice.Name;
             _settings.Audio.AudioDeviceId = selectedDevice.DeviceId;
-            _settings.Audio.AudioDeviceName = selectedDevice.Name;
 
-            _logger.LogInformation("Audio device changed to: {DeviceName} (ID: {DeviceId})", 
-                selectedDevice.Name, selectedDevice.DeviceId);
-
-            // Convert device ID to WaveOut device ID if needed
-            var waveOutDeviceId = ConvertToWaveOutDeviceId(selectedDevice.DeviceId, selectedDevice.Name);
-            _settings.Audio.AudioDeviceId = waveOutDeviceId;
+            _logger.LogInformation("Audio device changed to: {DeviceName} (endpoint {EndpointId}, ordinal {DeviceId})",
+                selectedDevice.Name, _settings.Audio.AudioDeviceEndpointId, selectedDevice.DeviceId);
 
             // Reinitialize the audio engine with the new device
-            try 
+            try
             {
                 _audioEngine.Reinitialize();
-                _logger.LogInformation("Audio engine reinitialized successfully with device ID {DeviceId}", waveOutDeviceId);
+                _logger.LogInformation("Audio engine reinitialized successfully with endpoint {EndpointId}",
+                    _settings.Audio.AudioDeviceEndpointId);
             }
             catch (Exception ex)
             {
@@ -161,6 +170,7 @@ public class AudioApiController
                 device = new
                 {
                     id = selectedDevice.DeviceId,
+                    endpointId = selectedDevice.EndpointId,
                     name = selectedDevice.Name,
                     driver = selectedDevice.Driver
                 }
@@ -209,6 +219,7 @@ public class AudioApiController
                 device = new
                 {
                     id = _settings.Audio.AudioDeviceId,
+                    endpointId = _settings.Audio.AudioDeviceEndpointId,
                     name = _settings.Audio.AudioDeviceName
                 }
             }));
@@ -225,18 +236,39 @@ public class AudioApiController
     // the same catalog, so they can never disagree about which devices exist.
     private List<AudioDevice> GetAvailableAudioDevices() => _deviceCatalog.GetDevices().ToList();
 
-    private int ConvertToWaveOutDeviceId(int mmDeviceId, string deviceName)
+    private AudioDeviceResolution ResolveConfiguredDevice(IReadOnlyList<AudioDevice> devices) =>
+        AudioDeviceResolver.Resolve(
+            devices,
+            _settings.Audio.AudioDeviceEndpointId,
+            _settings.Audio.AudioDeviceName,
+            _settings.Audio.AudioDeviceId);
+
+    /// <summary>
+    /// The saved selection, by endpoint id where there is one. When nothing resolves, the system
+    /// default entry is the honest highlight - that is the output playback will actually use.
+    /// </summary>
+    private static bool IsSelected(AudioDevice device, AudioDeviceResolution resolution) =>
+        resolution.UsesSystemDefault
+            ? device.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId
+            : string.Equals(device.EndpointId, resolution.EndpointId, StringComparison.Ordinal);
+
+    private static string? ReadString(Dictionary<string, JsonElement>? body, string key) =>
+        body != null && body.TryGetValue(key, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static int? ReadInt(Dictionary<string, JsonElement>? body, string key)
     {
-        // Simple heuristic: try to match device names with WaveOut devices
-        // For now, just use the default device (-1) for any non-default selection
-        // This is a temporary workaround until proper device mapping is implemented
-        
-        if (mmDeviceId == -1)
+        if (body == null || !body.TryGetValue(key, out var value))
         {
-            return -1; // Default device
+            return null;
         }
-        
-        // Return the actual device ID without capping to allow selection of all available devices
-        return mmDeviceId;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetInt32(out var number) => number,
+            JsonValueKind.String when int.TryParse(value.GetString(), out var parsed) => parsed,
+            _ => null
+        };
     }
 }

--- a/src/EDButtkicker/Controllers/ConfigurationApiController.cs
+++ b/src/EDButtkicker/Controllers/ConfigurationApiController.cs
@@ -83,6 +83,8 @@ public class ConfigurationApiController
                     {
                         if (audioSettings.ContainsKey("AudioDeviceId") && int.TryParse(audioSettings["AudioDeviceId"].ToString(), out int deviceId))
                             _settings.Audio.AudioDeviceId = deviceId;
+                        if (audioSettings.ContainsKey("AudioDeviceEndpointId"))
+                            _settings.Audio.AudioDeviceEndpointId = audioSettings["AudioDeviceEndpointId"].ToString() ?? _settings.Audio.AudioDeviceEndpointId;
                         if (audioSettings.ContainsKey("AudioDeviceName"))
                             _settings.Audio.AudioDeviceName = audioSettings["AudioDeviceName"].ToString() ?? _settings.Audio.AudioDeviceName;
                         if (audioSettings.ContainsKey("MaxIntensity") && int.TryParse(audioSettings["MaxIntensity"].ToString(), out int maxIntensity))

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -167,31 +167,40 @@ public class SetupApiController
         }
     }
 
-    /// <summary>Step 2: choose the output. The device name is what gets persisted, because the
-    /// enumeration index moves when devices are plugged in or removed.</summary>
+    /// <summary>Step 2: choose the output. The MMDevice endpoint id is what gets persisted, because
+    /// the enumeration index moves when devices are plugged in or removed.</summary>
     public async Task SelectAudioDevice(HttpContext context)
     {
         try
         {
             var body = await ReadJsonAsync(context);
+            var requestedEndpointId = ReadString(body, "endpointId");
             var requestedName = ReadString(body, "name");
             var requestedId = ReadInt(body, "deviceId");
 
-            if (string.IsNullOrWhiteSpace(requestedName) && requestedId == null)
+            if (string.IsNullOrWhiteSpace(requestedEndpointId) &&
+                string.IsNullOrWhiteSpace(requestedName) &&
+                requestedId == null)
             {
-                await WriteBadRequestAsync(context, "An output device name or id is required");
+                await WriteBadRequestAsync(context, "An output device endpoint id, name or id is required");
                 return;
             }
 
             var devices = _deviceCatalog.GetDevices();
-            var device = !string.IsNullOrWhiteSpace(requestedName)
-                ? devices.FirstOrDefault(d => string.Equals(d.Name, requestedName, StringComparison.OrdinalIgnoreCase))
-                : devices.FirstOrDefault(d => d.DeviceId == requestedId);
+
+            // Endpoint id is the identity, so it wins; a name is the next best key, and the numeric
+            // id addresses this list only, which is why it is tried last.
+            var device = !string.IsNullOrWhiteSpace(requestedEndpointId)
+                ? devices.FirstOrDefault(d => string.Equals(d.EndpointId, requestedEndpointId, StringComparison.Ordinal))
+                : !string.IsNullOrWhiteSpace(requestedName)
+                    ? devices.FirstOrDefault(d => string.Equals(d.Name, requestedName, StringComparison.OrdinalIgnoreCase))
+                    : devices.FirstOrDefault(d => d.DeviceId == requestedId);
 
             if (device == null)
             {
                 await WriteBadRequestAsync(context, "That output device is not connected", new
                 {
+                    requested_endpoint_id = requestedEndpointId,
                     requested_name = requestedName,
                     requested_id = requestedId,
                     available = devices.Select(d => d.Name).ToList()
@@ -210,6 +219,7 @@ public class SetupApiController
             var isSystemDefault = device.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId;
 
             _settings.Audio.AudioDeviceId = device.DeviceId;
+            _settings.Audio.AudioDeviceEndpointId = isSystemDefault ? string.Empty : device.EndpointId;
             _settings.Audio.AudioDeviceName = isSystemDefault ? string.Empty : device.Name;
 
             if (!await TryPersistUserSettingsAsync())
@@ -225,6 +235,7 @@ public class SetupApiController
             {
                 state.AudioDeviceConfirmedAtUtc = confirmedAt;
                 state.AudioDeviceName = isSystemDefault ? null : device.Name;
+                state.AudioDeviceEndpointId = isSystemDefault ? null : device.EndpointId;
                 state.AudioDeviceId = device.DeviceId;
 
                 // A different output invalidates the previous test result.
@@ -233,7 +244,8 @@ public class SetupApiController
                 state.AudioTestReason = null;
             });
 
-            _logger.LogInformation("Setup selected audio output {DeviceName} (id {DeviceId})", device.Name, device.DeviceId);
+            _logger.LogInformation("Setup selected audio output {DeviceName} (endpoint {EndpointId}, ordinal {DeviceId})",
+                device.Name, _settings.Audio.AudioDeviceEndpointId, device.DeviceId);
 
             await WriteJsonAsync(context, new
             {
@@ -241,6 +253,7 @@ public class SetupApiController
                 device = new
                 {
                     id = device.DeviceId,
+                    endpointId = device.EndpointId,
                     name = device.Name,
                     driver = device.Driver,
                     is_default = device.IsDefault

--- a/src/EDButtkicker/Controllers/UserSettingsApiController.cs
+++ b/src/EDButtkicker/Controllers/UserSettingsApiController.cs
@@ -54,6 +54,7 @@ public class UserSettingsController : ControllerBase
             {
                 // Audio settings
                 AudioDeviceId = request.AudioDeviceId ?? _appSettings.Audio.AudioDeviceId,
+                AudioDeviceEndpointId = request.AudioDeviceEndpointId ?? _appSettings.Audio.AudioDeviceEndpointId,
                 AudioDeviceName = request.AudioDeviceName ?? _appSettings.Audio.AudioDeviceName,
                 MaxIntensity = request.MaxIntensity ?? _appSettings.Audio.MaxIntensity,
                 DefaultFrequency = request.DefaultFrequency ?? _appSettings.Audio.DefaultFrequency,
@@ -80,7 +81,9 @@ public class UserSettingsController : ControllerBase
             _userSettingsService.ApplyUserPreferencesToAppSettings(preferences, _appSettings);
             
             // If audio device changed, reinitialize audio engine
-            if (request.AudioDeviceId.HasValue || !string.IsNullOrEmpty(request.AudioDeviceName))
+            if (request.AudioDeviceId.HasValue ||
+                request.AudioDeviceEndpointId != null ||
+                !string.IsNullOrEmpty(request.AudioDeviceName))
             {
                 _logger.LogInformation("Audio device settings changed, reinitializing audio engine");
                 try
@@ -130,6 +133,7 @@ public class UserSettingsController : ControllerBase
             
             // Reset app settings to defaults (you might want to reload from appsettings.json)
             _appSettings.Audio.AudioDeviceId = -1;
+            _appSettings.Audio.AudioDeviceEndpointId = string.Empty;
             _appSettings.Audio.AudioDeviceName = "Default";
             // Reset other settings as needed
             
@@ -152,6 +156,7 @@ public class UserSettingsController : ControllerBase
                 Audio = new CurrentAudioSettings
                 {
                     DeviceId = _appSettings.Audio.AudioDeviceId,
+                    DeviceEndpointId = _appSettings.Audio.AudioDeviceEndpointId,
                     DeviceName = _appSettings.Audio.AudioDeviceName,
                     MaxIntensity = _appSettings.Audio.MaxIntensity,
                     DefaultFrequency = _appSettings.Audio.DefaultFrequency,
@@ -189,6 +194,9 @@ public class SaveUserSettingsRequest
 {
     // Audio settings
     public int? AudioDeviceId { get; set; }
+
+    /// <summary>Endpoint id of the chosen output; empty means the system default.</summary>
+    public string? AudioDeviceEndpointId { get; set; }
     public string? AudioDeviceName { get; set; }
     public int? MaxIntensity { get; set; }
     public int? DefaultFrequency { get; set; }
@@ -216,6 +224,7 @@ public class CurrentSettingsResponse
 public class CurrentAudioSettings
 {
     public int DeviceId { get; set; }
+    public string DeviceEndpointId { get; set; } = string.Empty;
     public string DeviceName { get; set; } = string.Empty;
     public int MaxIntensity { get; set; }
     public int DefaultFrequency { get; set; }

--- a/src/EDButtkicker/Models/AudioDevice.cs
+++ b/src/EDButtkicker/Models/AudioDevice.cs
@@ -2,6 +2,18 @@ namespace EDButtkicker.Models;
 
 public class AudioDevice
 {
+    /// <summary>
+    /// The MMDevice endpoint id, which is this device's identity: it is stable across reordering,
+    /// unplugging and replugging, and it distinguishes two outputs that share a friendly name.
+    /// Empty for the synthetic "system default" entry, which is a choice rather than an endpoint.
+    /// </summary>
+    public string EndpointId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Position in the enumeration this device came from (-1 for the system default entry). A
+    /// display and compatibility coordinate only - it moves when devices come and go, so it must
+    /// never be used to identify a device.
+    /// </summary>
     public int DeviceId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Driver { get; set; } = string.Empty;

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -329,6 +329,9 @@ class Program
                     Console.WriteLine($"  {line}");
                 }
                 Console.WriteLine($"  {AudioDeviceDiagnostics.DescribeConfiguredSelection(devices, settings.Audio.AudioDeviceId, settings.Audio.AudioDeviceName)}");
+                // The resolver is what playback actually follows, so the console says the same
+                // thing the log will.
+                Console.WriteLine($"  {AudioDeviceResolver.Resolve(devices, settings.Audio.AudioDeviceEndpointId, settings.Audio.AudioDeviceName, settings.Audio.AudioDeviceId).Reason}");
                 Console.WriteLine();
             }
             
@@ -414,6 +417,7 @@ class Program
                     if (selection == devices.Count + 1)
                     {
                         settings.Audio.AudioDeviceId = -1;
+                        settings.Audio.AudioDeviceEndpointId = string.Empty;
                         settings.Audio.AudioDeviceName = "Default";
                         Console.WriteLine("✓ Using default audio device.");
                         if (debugMode)
@@ -426,6 +430,7 @@ class Program
                     {
                         var selectedDevice = devices[selection - 1];
                         settings.Audio.AudioDeviceId = selectedDevice.DeviceId;
+                        settings.Audio.AudioDeviceEndpointId = selectedDevice.EndpointId;
                         settings.Audio.AudioDeviceName = selectedDevice.Name;
                         Console.WriteLine($"✓ Selected: {selectedDevice.Name}");
                         if (debugMode)
@@ -491,6 +496,8 @@ class Program
                 
                 devices.Add(new AudioDevice
                 {
+                    // The endpoint id is the identity; the index is only where it sits today.
+                    EndpointId = device.ID,
                     DeviceId = i,
                     Name = device.FriendlyName,
                     Driver = "WASAPI",

--- a/src/EDButtkicker/Services/AudioDeviceCatalog.cs
+++ b/src/EDButtkicker/Services/AudioDeviceCatalog.cs
@@ -58,6 +58,8 @@ public class WasapiAudioDeviceCatalog : IAudioDeviceCatalog
 
                 devices.Add(new AudioDevice
                 {
+                    // The endpoint id is the identity; the index is only where it happens to sit today.
+                    EndpointId = endpoint.ID,
                     DeviceId = i,
                     Name = endpoint.FriendlyName,
                     Driver = "WASAPI",

--- a/src/EDButtkicker/Services/AudioDeviceDiagnostics.cs
+++ b/src/EDButtkicker/Services/AudioDeviceDiagnostics.cs
@@ -32,7 +32,7 @@ public static class AudioDeviceDiagnostics
             var device = devices[i];
             lines.Add(
                 $"{ordinalSpace} position {i + 1} of {devices.Count}: " +
-                $"DeviceId={device.DeviceId} name='{device.Name}' " +
+                $"DeviceId={device.DeviceId} endpoint='{device.EndpointId}' name='{device.Name}' " +
                 $"default={YesNo(device.IsDefault)} available={YesNo(device.IsAvailable)}");
         }
 

--- a/src/EDButtkicker/Services/AudioDeviceResolver.cs
+++ b/src/EDButtkicker/Services/AudioDeviceResolver.cs
@@ -1,0 +1,224 @@
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>What a saved audio selection turned out to mean against a live device list.</summary>
+public enum AudioDeviceResolutionStatus
+{
+    /// <summary>Nothing was saved (or the system default entry was saved): use the default output.</summary>
+    SystemDefault,
+
+    /// <summary>Exactly one connected, active device is the saved one.</summary>
+    Resolved,
+
+    /// <summary>The saved device is not in this enumeration - unplugged, disabled or renamed.</summary>
+    Unresolved,
+
+    /// <summary>Several devices answer to the saved name and nothing distinguishes them.</summary>
+    Ambiguous,
+
+    /// <summary>The saved device is present but not in an active state, so it cannot be opened.</summary>
+    Unavailable
+}
+
+/// <summary>
+/// The outcome of resolving saved settings against an enumeration. Only <see cref="IsUsable"/>
+/// means "open this device"; every other status means playback has to fall back to the system
+/// default output, and <see cref="Reason"/> says which case it was in words a log can carry.
+/// </summary>
+public sealed record AudioDeviceResolution(
+    AudioDeviceResolutionStatus Status,
+    AudioDevice? Device,
+    string Reason)
+{
+    /// <summary>The resolved device can be opened by endpoint id.</summary>
+    public bool IsUsable => Status == AudioDeviceResolutionStatus.Resolved;
+
+    /// <summary>Playback should use the default output rather than a named endpoint.</summary>
+    public bool UsesSystemDefault => Status != AudioDeviceResolutionStatus.Resolved;
+
+    /// <summary>Nothing was saved at all, as opposed to a saved device that could not be honoured.</summary>
+    public bool IsSystemDefault => Status == AudioDeviceResolutionStatus.SystemDefault;
+
+    public string EndpointId => Device?.EndpointId ?? string.Empty;
+
+    public string Name => Device?.Name ?? string.Empty;
+
+    /// <summary>True when the resolved device is also the endpoint Windows reports as the default.</summary>
+    public bool IsDefaultEndpoint => Device?.IsDefault ?? Status == AudioDeviceResolutionStatus.SystemDefault;
+}
+
+/// <summary>
+/// Turns saved audio settings into one device out of an enumeration. The identity is the MMDevice
+/// endpoint id: it survives devices being reordered, unplugged and plugged back in, and it tells
+/// two outputs with the same friendly name apart. The list ordinal (DeviceId) is not identity -
+/// it moves whenever the endpoint list changes - so it is only ever used to disambiguate settings
+/// written before endpoint ids were persisted, and never to pick a neighbouring device.
+///
+/// Deliberately free of NAudio types: callers map their enumeration into <see cref="AudioDevice"/>
+/// first, so every resolution rule is exercisable without an audio device.
+/// </summary>
+public static class AudioDeviceResolver
+{
+    public static AudioDeviceResolution Resolve(
+        IReadOnlyList<AudioDevice>? devices,
+        string? endpointId,
+        string? name,
+        int deviceId = WasapiAudioDeviceCatalog.SystemDefaultDeviceId)
+    {
+        var enumerated = devices ?? Array.Empty<AudioDevice>();
+        var savedEndpointId = (endpointId ?? string.Empty).Trim();
+        var savedName = (name ?? string.Empty).Trim();
+
+        if (savedEndpointId.Length > 0)
+        {
+            return ResolveByEndpointId(enumerated, savedEndpointId, savedName);
+        }
+
+        if (savedName.Length == 0)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.SystemDefault,
+                null,
+                $"configured: no endpoint id and no device name saved, playback uses the system default output " +
+                $"(saved DeviceId={deviceId} does not identify a device)");
+        }
+
+        return ResolveByName(enumerated, savedName, deviceId);
+    }
+
+    private static AudioDeviceResolution ResolveByEndpointId(
+        IReadOnlyList<AudioDevice> enumerated,
+        string savedEndpointId,
+        string savedName)
+    {
+        var match = enumerated.FirstOrDefault(d =>
+            string.Equals(d.EndpointId, savedEndpointId, StringComparison.Ordinal));
+
+        if (match == null)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.Unresolved,
+                null,
+                $"configured: UNRESOLVED - endpoint id '{savedEndpointId}'{DescribeSavedName(savedName)} is not in this " +
+                $"enumeration; playback falls back to the system default");
+        }
+
+        if (!match.IsAvailable)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.Unavailable,
+                match,
+                $"configured: UNAVAILABLE - endpoint id '{savedEndpointId}' is name '{match.Name}' but is not active; " +
+                $"playback falls back to the system default");
+        }
+
+        var renamed = savedName.Length > 0 && !string.Equals(savedName, match.Name, StringComparison.Ordinal)
+            ? $", saved under the name '{savedName}'"
+            : string.Empty;
+
+        return new AudioDeviceResolution(
+            AudioDeviceResolutionStatus.Resolved,
+            match,
+            $"configured: endpoint id '{savedEndpointId}' is name '{match.Name}' at position " +
+            $"{PositionOf(enumerated, match)} of {enumerated.Count}{renamed}");
+    }
+
+    private static AudioDeviceResolution ResolveByName(
+        IReadOnlyList<AudioDevice> enumerated,
+        string savedName,
+        int deviceId)
+    {
+        // Ordinal equality, matching how MMDevice.FriendlyName is compared everywhere else.
+        var matches = enumerated
+            .Where(d => string.Equals(d.Name, savedName, StringComparison.Ordinal))
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.Unresolved,
+                null,
+                $"configured: UNRESOLVED - name '{savedName}' is not in this enumeration " +
+                $"(saved DeviceId={deviceId} is an ordinal, not an identity); playback falls back to the system default");
+        }
+
+        if (matches.Count == 1)
+        {
+            return DescribeSingleNameMatch(enumerated, matches[0], savedName);
+        }
+
+        // Settings written before endpoint ids were persisted carry only a name and a list ordinal.
+        // The ordinal is accepted here only when it still lands on a device of that same name; it is
+        // never allowed to select a differently named neighbour.
+        var legacy = matches.Where(d => d.DeviceId == deviceId).ToList();
+        if (legacy.Count == 1)
+        {
+            var match = legacy[0];
+            if (!match.IsAvailable)
+            {
+                return new AudioDeviceResolution(
+                    AudioDeviceResolutionStatus.Unavailable,
+                    match,
+                    $"configured: UNAVAILABLE - name '{savedName}' at saved DeviceId={deviceId} is not active; " +
+                    $"playback falls back to the system default");
+            }
+
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.Resolved,
+                match,
+                $"configured: {matches.Count} devices share name '{savedName}'; the saved DeviceId={deviceId} still " +
+                $"names one of them (endpoint id '{match.EndpointId}'), so it is used - re-select this device to save its endpoint id");
+        }
+
+        var ids = string.Join(", ", matches.Select(m => $"DeviceId={m.DeviceId}"));
+        return new AudioDeviceResolution(
+            AudioDeviceResolutionStatus.Ambiguous,
+            null,
+            $"configured: AMBIGUOUS - {matches.Count} devices share name '{savedName}' ({ids}) and no endpoint id is " +
+            $"saved; playback falls back to the system default");
+    }
+
+    private static AudioDeviceResolution DescribeSingleNameMatch(
+        IReadOnlyList<AudioDevice> enumerated,
+        AudioDevice match,
+        string savedName)
+    {
+        // The synthetic "system default" entry is a choice, not an endpoint: it has no id to open.
+        if (match.EndpointId.Length == 0 && match.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.SystemDefault,
+                null,
+                $"configured: name '{savedName}' is the system default entry, playback uses the system default output");
+        }
+
+        if (!match.IsAvailable)
+        {
+            return new AudioDeviceResolution(
+                AudioDeviceResolutionStatus.Unavailable,
+                match,
+                $"configured: UNAVAILABLE - name '{savedName}' is present but not active; " +
+                $"playback falls back to the system default");
+        }
+
+        return new AudioDeviceResolution(
+            AudioDeviceResolutionStatus.Resolved,
+            match,
+            $"configured: name '{savedName}' resolves to endpoint id '{match.EndpointId}' at position " +
+            $"{PositionOf(enumerated, match)} of {enumerated.Count}; no endpoint id was saved, so it was matched by name");
+    }
+
+    private static int PositionOf(IReadOnlyList<AudioDevice> enumerated, AudioDevice device)
+    {
+        for (var i = 0; i < enumerated.Count; i++)
+        {
+            if (ReferenceEquals(enumerated[i], device)) return i + 1;
+        }
+
+        return 0;
+    }
+
+    private static string DescribeSavedName(string savedName) =>
+        savedName.Length == 0 ? string.Empty : $" (name '{savedName}')";
+}

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -44,33 +44,7 @@ public class AudioEngineService : IDisposable
             {
                 _logger.LogInformation("Initializing Audio Engine");
                 LogSystemAudioInfo();
-                // Create wave output device
-				if (!string.IsNullOrEmpty(_settings.Audio.AudioDeviceName))
-				{
-					_logger.LogDebug("Attempting to find audio device by name: '{DeviceName}'", _settings.Audio.AudioDeviceName);
-
-					var deviceEnumerator = new MMDeviceEnumerator();
-					var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-					LogWasapiEnumeration(devices);
-					var matchedDevice = devices.FirstOrDefault(d => d.FriendlyName == _settings.Audio.AudioDeviceName);
-
-					if (matchedDevice != null)
-					{
-						_waveOut = new WasapiOut(matchedDevice, AudioClientShareMode.Shared, true, 200);
-						_logger.LogInformation("✓ Using audio device: {DeviceName}", matchedDevice.FriendlyName);
-					}
-					else
-					{
-						_logger.LogWarning("⚠ Device '{DeviceName}' not found, falling back to default", _settings.Audio.AudioDeviceName);
-						_waveOut = new WaveOutEvent();
-					}
-				}
-				else
-				{
-					_waveOut = new WaveOutEvent();
-					var defaultDevice = GetDefaultAudioDevice();
-					_logger.LogInformation("Using default audio device: {DefaultDevice}", defaultDevice ?? "Unknown");
-				}
+                _waveOut = OpenConfiguredOutput();
 
                 // Log wave output configuration
                 LogWaveOutConfiguration();
@@ -425,31 +399,6 @@ public class AudioEngineService : IDisposable
         }
     }
 
-    private bool ValidateAudioDevice(int deviceId)
-    {
-        try
-        {
-            // Use MMDevice API for validation (compatible with NAudio 2.2.1)
-            var deviceEnumerator = new MMDeviceEnumerator();
-            var devices = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-            
-            if (deviceId < 0 || deviceId >= devices.Count)
-            {
-                _logger.LogWarning("Device ID {DeviceId} is out of range (0-{MaxId})", deviceId, devices.Count - 1);
-                return false;
-            }
-
-            var device = devices[deviceId];
-            _logger.LogDebug("Validated device {DeviceId}: '{FriendlyName}' - Available", deviceId, device.FriendlyName);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to validate audio device {DeviceId}: {Error}", deviceId, ex.Message);
-            return false;
-        }
-    }
-
     private string? GetDefaultAudioDevice()
     {
         try
@@ -466,51 +415,99 @@ public class AudioEngineService : IDisposable
     }
 
     /// <summary>
-    /// Logs every WASAPI render endpoint with both its list position and its DeviceId, then what the
-    /// saved settings resolve to. This is the record to read when a device selection appears to land
-    /// on the neighbouring device: it shows whether the saved name and the saved DeviceId disagree.
+    /// Opens the output the saved settings actually name. The saved MMDevice endpoint id is the
+    /// identity, so a device that has moved in the enumeration still opens, and a device that has
+    /// gone away falls back to the system default output rather than to whatever now occupies its
+    /// old index. Every WASAPI render endpoint and the resolution itself are logged first, so a
+    /// mis-selection report can be read against the endpoint ids.
     /// </summary>
-    private void LogWasapiEnumeration(MMDeviceCollection devices)
+    private IWavePlayer OpenConfiguredOutput()
     {
+        MMDeviceEnumerator enumerator;
+        IReadOnlyList<AudioDevice> enumerated;
+
         try
         {
-            string? defaultDeviceId = null;
-            try
-            {
-                defaultDeviceId = new MMDeviceEnumerator()
-                    .GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug("No default render endpoint available: {Error}", ex.Message);
-            }
-
-            var enumerated = new List<AudioDevice>(devices.Count);
-            for (var i = 0; i < devices.Count; i++)
-            {
-                var device = devices[i];
-                enumerated.Add(new AudioDevice
-                {
-                    DeviceId = i,
-                    Name = device.FriendlyName,
-                    Driver = "WASAPI",
-                    IsDefault = defaultDeviceId != null && device.ID == defaultDeviceId,
-                    IsAvailable = device.State == DeviceState.Active
-                });
-            }
-
-            foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(enumerated, "WASAPI render"))
-            {
-                _logger.LogInformation("Audio devices - {Device}", line);
-            }
-
-            _logger.LogInformation("Audio devices - {Selection}", AudioDeviceDiagnostics.DescribeConfiguredSelection(
-                enumerated, _settings.Audio.AudioDeviceId, _settings.Audio.AudioDeviceName));
+            enumerator = new MMDeviceEnumerator();
+            enumerated = EnumerateRenderEndpoints(enumerator);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to log WASAPI device enumeration");
+            // No WASAPI here: the default output is the only thing left to try.
+            _logger.LogWarning(ex, "Failed to enumerate WASAPI render endpoints, using the default output");
+            return new WaveOutEvent();
         }
+
+        foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(enumerated, "WASAPI render"))
+        {
+            _logger.LogInformation("Audio devices - {Device}", line);
+        }
+
+        var resolution = AudioDeviceResolver.Resolve(
+            enumerated,
+            _settings.Audio.AudioDeviceEndpointId,
+            _settings.Audio.AudioDeviceName,
+            _settings.Audio.AudioDeviceId);
+
+        _logger.LogInformation("Audio devices - {Selection}", resolution.Reason);
+
+        if (resolution.IsUsable)
+        {
+            try
+            {
+                var endpoint = enumerator.GetDevice(resolution.EndpointId);
+                _logger.LogInformation("✓ Using audio device: {DeviceName} (endpoint {EndpointId})",
+                    endpoint.FriendlyName, resolution.EndpointId);
+
+                return new WasapiOut(endpoint, AudioClientShareMode.Shared, true, 200);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "⚠ Endpoint {EndpointId} could not be opened, falling back to default",
+                    resolution.EndpointId);
+            }
+        }
+        else if (!resolution.IsSystemDefault)
+        {
+            _logger.LogWarning("⚠ {Selection}", resolution.Reason);
+        }
+
+        _logger.LogInformation("Using default audio device: {DefaultDevice}", GetDefaultAudioDevice() ?? "Unknown");
+        return new WaveOutEvent();
+    }
+
+    /// <summary>Active render endpoints as plain models, each carrying its endpoint id.</summary>
+    private IReadOnlyList<AudioDevice> EnumerateRenderEndpoints(MMDeviceEnumerator enumerator)
+    {
+        string? defaultEndpointId = null;
+        try
+        {
+            defaultEndpointId = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia).ID;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("No default render endpoint available: {Error}", ex.Message);
+        }
+
+        var endpoints = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+        var enumerated = new List<AudioDevice>(endpoints.Count);
+
+        for (var i = 0; i < endpoints.Count; i++)
+        {
+            var endpoint = endpoints[i];
+            enumerated.Add(new AudioDevice
+            {
+                EndpointId = endpoint.ID,
+                DeviceId = i,
+                Name = endpoint.FriendlyName,
+                Driver = "WASAPI",
+                Channels = 2,
+                IsDefault = defaultEndpointId != null && endpoint.ID == defaultEndpointId,
+                IsAvailable = endpoint.State == DeviceState.Active
+            });
+        }
+
+        return enumerated;
     }
 
     private void LogWaveOutConfiguration()

--- a/src/EDButtkicker/Services/SetupStateService.cs
+++ b/src/EDButtkicker/Services/SetupStateService.cs
@@ -18,6 +18,9 @@ public class SetupState
 
     public DateTime? AudioDeviceConfirmedAtUtc { get; set; }
     public string? AudioDeviceName { get; set; }
+
+    /// <summary>Endpoint id of the confirmed output; null when the system default was chosen.</summary>
+    public string? AudioDeviceEndpointId { get; set; }
     public int? AudioDeviceId { get; set; }
 
     public DateTime? AudioTestedAtUtc { get; set; }

--- a/src/EDButtkicker/Services/UserSettingsService.cs
+++ b/src/EDButtkicker/Services/UserSettingsService.cs
@@ -109,6 +109,14 @@ public class UserSettingsService
                 _logger.LogDebug("Applied audio device ID: {DeviceId}", preferences.AudioDeviceId.Value);
             }
 
+            // The endpoint id is the identity, so an explicitly saved empty value still applies:
+            // it is how "use the system default" is recorded.
+            if (preferences.AudioDeviceEndpointId != null)
+            {
+                appSettings.Audio.AudioDeviceEndpointId = preferences.AudioDeviceEndpointId;
+                _logger.LogDebug("Applied audio device endpoint id: {EndpointId}", preferences.AudioDeviceEndpointId);
+            }
+
             if (!string.IsNullOrEmpty(preferences.AudioDeviceName))
             {
                 appSettings.Audio.AudioDeviceName = preferences.AudioDeviceName;
@@ -179,6 +187,7 @@ public class UserSettingsService
             var preferences = new UserPreferences
             {
                 AudioDeviceId = appSettings.Audio.AudioDeviceId,
+                AudioDeviceEndpointId = appSettings.Audio.AudioDeviceEndpointId,
                 AudioDeviceName = appSettings.Audio.AudioDeviceName,
                 MaxIntensity = appSettings.Audio.MaxIntensity,
                 DefaultFrequency = appSettings.Audio.DefaultFrequency,
@@ -258,6 +267,12 @@ public class UserPreferences
 {
     // Audio preferences
     public int? AudioDeviceId { get; set; }
+
+    /// <summary>
+    /// MMDevice endpoint id of the chosen output. This is what survives a restart with the devices
+    /// reordered; the id and the name are only fallbacks for settings written before it existed.
+    /// </summary>
+    public string? AudioDeviceEndpointId { get; set; }
     public string? AudioDeviceName { get; set; }
     public int? MaxIntensity { get; set; }
     public int? DefaultFrequency { get; set; }

--- a/src/EDButtkicker/wwwroot/js/app.js
+++ b/src/EDButtkicker/wwwroot/js/app.js
@@ -289,11 +289,11 @@ class ButtkickerApp {
             panel.innerHTML = `
                 <h4>2. Choose your output device</h4>
                 <p class="setup-help">Pick the device your buttkicker amplifier is connected to. The device
-                   name is saved, so the choice survives devices being plugged in or removed.</p>
+                   endpoint id is saved, so the choice survives devices being plugged in or removed.</p>
                 <div class="setup-candidates">
                     ${devices.length === 0 ? '<div class="loading">No output devices reported.</div>' : ''}
                     ${devices.map(device => `
-                        <div class="setup-candidate ${device.id === data.current.id ? 'active' : ''}">
+                        <div class="setup-candidate ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}">
                             <div>
                                 <div class="setup-candidate-path">${device.name}</div>
                                 <div class="setup-candidate-detail">
@@ -302,7 +302,7 @@ class ButtkickerApp {
                                 </div>
                             </div>
                             <button class="btn btn-sm btn-primary" ${device.isAvailable ? '' : 'disabled'}
-                                    onclick="selectSetupAudioDevice(${device.id})">
+                                    onclick="selectSetupAudioDevice(${audioDeviceArgs(device)})">
                                 Use this device
                             </button>
                         </div>
@@ -593,8 +593,8 @@ class ButtkickerApp {
             }
 
             deviceList.innerHTML = data.devices.map(device => `
-                <div class="device-item ${device.id === data.current.id ? 'active' : ''}" 
-                     onclick="selectAudioDevice(${device.id})">
+                <div class="device-item ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}"
+                     onclick="selectAudioDevice(${audioDeviceArgs(device)})">
                     <div class="device-info">
                         <div class="device-name">
                             ${device.name}
@@ -951,12 +951,34 @@ window.createNewPattern = () => {
     app.showToast('New pattern creation - Coming soon!', 'warning');
 };
 
-window.selectAudioDevice = async (deviceId) => {
+// The endpoint id is the device identity, so it decides the highlight whenever the API reports
+// one; the numeric id only addresses the list that was just returned. isSelected, when the API
+// sends it, already accounts for a saved device that is no longer connected.
+function isSelectedAudioDevice(device, current) {
+    if (typeof device.isSelected === 'boolean') return device.isSelected;
+    if (current && current.endpointId) return device.endpointId === current.endpointId;
+    return current ? device.id === current.id : false;
+}
+
+// Endpoint ids contain braces and dots, so they are JSON-encoded - and then escaped for the
+// attribute they land in - instead of being pasted into onclick raw.
+function audioDeviceArgs(device) {
+    const endpointId = JSON.stringify(device.endpointId || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/"/g, '&quot;');
+
+    return `${endpointId}, ${Number(device.id)}`;
+}
+
+window.selectAudioDevice = async (endpointId, deviceId) => {
     try {
         const response = await fetch('/api/audio/device', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ deviceId: deviceId })
+            // The endpoint id survives reordering; the numeric id is only sent as a fallback for
+            // the system default entry, which has no endpoint of its own.
+            body: JSON.stringify(endpointId ? { endpointId, deviceId } : { deviceId })
         });
 
         if (response.ok) {
@@ -1584,12 +1606,12 @@ window.confirmJournalPath = async (path) => {
     }
 };
 
-window.selectSetupAudioDevice = async (deviceId) => {
+window.selectSetupAudioDevice = async (endpointId, deviceId) => {
     try {
         const response = await fetch('/api/setup/audio/device', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ deviceId })
+            body: JSON.stringify(endpointId ? { endpointId, deviceId } : { deviceId })
         });
 
         const result = await response.json();

--- a/tests/EDButtkicker.Tests/AudioDeviceDiagnosticsTests.cs
+++ b/tests/EDButtkicker.Tests/AudioDeviceDiagnosticsTests.cs
@@ -12,9 +12,15 @@ namespace EDButtkicker.Tests;
 /// </summary>
 public class AudioDeviceDiagnosticsTests
 {
-    private static AudioDevice Device(int deviceId, string name, bool isDefault = false, bool isAvailable = true) =>
+    private static AudioDevice Device(
+        int deviceId,
+        string name,
+        bool isDefault = false,
+        bool isAvailable = true,
+        string? endpointId = null) =>
         new()
         {
+            EndpointId = endpointId ?? $"{{0.0.0.00000000}}.{{{deviceId:D8}}}",
             DeviceId = deviceId,
             Name = name,
             Driver = "WASAPI",
@@ -37,13 +43,16 @@ public class AudioDeviceDiagnosticsTests
 
         Assert.Equal(3, lines.Count);
         Assert.Equal(
-            "WASAPI render position 1 of 3: DeviceId=0 name='Speakers (Realtek)' default=no available=yes",
+            "WASAPI render position 1 of 3: DeviceId=0 endpoint='{0.0.0.00000000}.{00000000}' " +
+            "name='Speakers (Realtek)' default=no available=yes",
             lines[0]);
         Assert.Equal(
-            "WASAPI render position 2 of 3: DeviceId=1 name='Buttkicker (USB Audio)' default=yes available=yes",
+            "WASAPI render position 2 of 3: DeviceId=1 endpoint='{0.0.0.00000000}.{00000001}' " +
+            "name='Buttkicker (USB Audio)' default=yes available=yes",
             lines[1]);
         Assert.Equal(
-            "WASAPI render position 3 of 3: DeviceId=2 name='Headphones (USB Audio)' default=no available=yes",
+            "WASAPI render position 3 of 3: DeviceId=2 endpoint='{0.0.0.00000000}.{00000002}' " +
+            "name='Headphones (USB Audio)' default=no available=yes",
             lines[2]);
     }
 
@@ -54,7 +63,8 @@ public class AudioDeviceDiagnosticsTests
         // more than one. Both coordinates still have to appear on every line.
         var webList = new List<AudioDevice>
         {
-            Device(-1, "Default Audio Device", isDefault: true),
+            // The synthetic default is a choice rather than an endpoint, so it has no endpoint id.
+            Device(-1, "Default Audio Device", isDefault: true, endpointId: ""),
             Device(0, "Speakers (Realtek)"),
             Device(1, "Buttkicker (USB Audio)")
         };
@@ -62,10 +72,12 @@ public class AudioDeviceDiagnosticsTests
         var lines = AudioDeviceDiagnostics.DescribeEnumeration(webList, "web device list");
 
         Assert.Equal(
-            "web device list position 1 of 3: DeviceId=-1 name='Default Audio Device' default=yes available=yes",
+            "web device list position 1 of 3: DeviceId=-1 endpoint='' name='Default Audio Device' " +
+            "default=yes available=yes",
             lines[0]);
         Assert.Equal(
-            "web device list position 3 of 3: DeviceId=1 name='Buttkicker (USB Audio)' default=no available=yes",
+            "web device list position 3 of 3: DeviceId=1 endpoint='{0.0.0.00000000}.{00000001}' " +
+            "name='Buttkicker (USB Audio)' default=no available=yes",
             lines[2]);
     }
 
@@ -76,7 +88,10 @@ public class AudioDeviceDiagnosticsTests
             new List<AudioDevice> { Device(0, "Unplugged", isAvailable: false) },
             "WASAPI render");
 
-        Assert.Equal("WASAPI render position 1 of 1: DeviceId=0 name='Unplugged' default=no available=no", lines[0]);
+        Assert.Equal(
+            "WASAPI render position 1 of 1: DeviceId=0 endpoint='{0.0.0.00000000}.{00000000}' " +
+            "name='Unplugged' default=no available=no",
+            lines[0]);
     }
 
     [Fact]

--- a/tests/EDButtkicker.Tests/AudioDeviceResolverTests.cs
+++ b/tests/EDButtkicker.Tests/AudioDeviceResolverTests.cs
@@ -1,0 +1,281 @@
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The saved output selection has to mean the same device tomorrow as it did today. These pin the
+/// rules that make that true: the endpoint id is the identity, the DeviceId is an ordinal that may
+/// not be used to pick a neighbour, and anything that cannot be honoured has to say so rather than
+/// quietly open something else. All of it runs against constructed device lists, so no audio
+/// hardware - and no WASAPI - is involved.
+/// </summary>
+public class AudioDeviceResolverTests
+{
+    private const string SpeakersEndpoint = "{0.0.0.00000000}.{aaaaaaaa-1111-2222-3333-444444444444}";
+    private const string ButtkickerEndpoint = "{0.0.0.00000000}.{bbbbbbbb-1111-2222-3333-444444444444}";
+    private const string HeadphonesEndpoint = "{0.0.0.00000000}.{cccccccc-1111-2222-3333-444444444444}";
+
+    private static AudioDevice Device(
+        string endpointId,
+        int deviceId,
+        string name,
+        bool isDefault = false,
+        bool isAvailable = true) =>
+        new()
+        {
+            EndpointId = endpointId,
+            DeviceId = deviceId,
+            Name = name,
+            Driver = "WASAPI",
+            Channels = 2,
+            IsDefault = isDefault,
+            IsAvailable = isAvailable
+        };
+
+    private static AudioDevice SystemDefaultEntry() =>
+        new()
+        {
+            DeviceId = WasapiAudioDeviceCatalog.SystemDefaultDeviceId,
+            Name = WasapiAudioDeviceCatalog.SystemDefaultDeviceName,
+            Driver = "Default",
+            Channels = 2,
+            IsDefault = true,
+            IsAvailable = true
+        };
+
+    private static List<AudioDevice> Enumeration() => new()
+    {
+        Device(SpeakersEndpoint, 0, "Speakers (Realtek)"),
+        Device(ButtkickerEndpoint, 1, "Buttkicker (USB Audio)", isDefault: true),
+        Device(HeadphonesEndpoint, 2, "Headphones (USB Audio)")
+    };
+
+    [Fact]
+    public void SavedEndpointId_StillResolvesAfterTheDevicesAreReordered()
+    {
+        // Same endpoints, different order: every DeviceId has moved, so a resolver that trusted
+        // the ordinal would now open the speakers.
+        var reordered = new List<AudioDevice>
+        {
+            Device(HeadphonesEndpoint, 0, "Headphones (USB Audio)"),
+            Device(ButtkickerEndpoint, 1, "Buttkicker (USB Audio)", isDefault: true),
+            Device(SpeakersEndpoint, 2, "Speakers (Realtek)")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(
+            reordered, ButtkickerEndpoint, "Buttkicker (USB Audio)", deviceId: 2);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.True(resolution.IsUsable);
+        Assert.Equal(ButtkickerEndpoint, resolution.EndpointId);
+        Assert.Equal("Buttkicker (USB Audio)", resolution.Name);
+    }
+
+    [Fact]
+    public void SavedEndpointIdThatIsGone_IsUnresolvedRatherThanTheNeighbourAtThatDeviceId()
+    {
+        var withoutButtkicker = new List<AudioDevice>
+        {
+            Device(SpeakersEndpoint, 0, "Speakers (Realtek)"),
+            Device(HeadphonesEndpoint, 1, "Headphones (USB Audio)")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(
+            withoutButtkicker, ButtkickerEndpoint, "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Unresolved, resolution.Status);
+        Assert.False(resolution.IsUsable);
+        Assert.True(resolution.UsesSystemDefault);
+        Assert.False(resolution.IsSystemDefault);
+        Assert.Null(resolution.Device);
+        Assert.Contains("UNRESOLVED", resolution.Reason);
+    }
+
+    [Fact]
+    public void SavedEndpointIdThatIsPresentButNotActive_IsUnavailable()
+    {
+        var disabled = new List<AudioDevice>
+        {
+            Device(SpeakersEndpoint, 0, "Speakers (Realtek)"),
+            Device(ButtkickerEndpoint, 1, "Buttkicker (USB Audio)", isAvailable: false)
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(
+            disabled, ButtkickerEndpoint, "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Unavailable, resolution.Status);
+        Assert.False(resolution.IsUsable);
+        Assert.True(resolution.UsesSystemDefault);
+        // The device is still named, because "your buttkicker is disabled" is the useful report.
+        Assert.Equal("Buttkicker (USB Audio)", resolution.Device!.Name);
+        Assert.Contains("UNAVAILABLE", resolution.Reason);
+    }
+
+    [Fact]
+    public void DuplicateNames_AreToldApartByTheSavedEndpointId()
+    {
+        var duplicates = new List<AudioDevice>
+        {
+            Device(SpeakersEndpoint, 0, "USB Audio Device"),
+            Device(ButtkickerEndpoint, 1, "USB Audio Device"),
+            Device(HeadphonesEndpoint, 2, "USB Audio Device")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(duplicates, ButtkickerEndpoint, "USB Audio Device", deviceId: 0);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal(ButtkickerEndpoint, resolution.EndpointId);
+    }
+
+    [Fact]
+    public void DuplicateNamesWithNoEndpointIdSaved_AreAmbiguousWhenTheOrdinalNamesNoneOfThem()
+    {
+        var duplicates = new List<AudioDevice>
+        {
+            Device(SpeakersEndpoint, 0, "USB Audio Device"),
+            Device(ButtkickerEndpoint, 1, "Realtek Speakers"),
+            Device(HeadphonesEndpoint, 2, "USB Audio Device")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(duplicates, endpointId: null, name: "USB Audio Device", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Ambiguous, resolution.Status);
+        Assert.Null(resolution.Device);
+        Assert.True(resolution.UsesSystemDefault);
+        Assert.Contains("AMBIGUOUS", resolution.Reason);
+    }
+
+    [Fact]
+    public void DuplicateNamesWithNoEndpointIdSaved_AcceptTheOrdinalOnlyWhenItNamesOneOfThem()
+    {
+        // Legacy settings carry a name and an ordinal. The ordinal is allowed to break the tie
+        // between two devices of that same name, and nothing more.
+        var duplicates = new List<AudioDevice>
+        {
+            Device(SpeakersEndpoint, 0, "USB Audio Device"),
+            Device(ButtkickerEndpoint, 1, "Realtek Speakers"),
+            Device(HeadphonesEndpoint, 2, "USB Audio Device")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(duplicates, endpointId: "", name: "USB Audio Device", deviceId: 2);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal(HeadphonesEndpoint, resolution.EndpointId);
+    }
+
+    [Fact]
+    public void ANewlyConnectedDevice_DoesNotStealTheSavedSelection()
+    {
+        // A device plugged in ahead of the saved one pushes every later DeviceId along by one.
+        var withNewDevice = new List<AudioDevice>
+        {
+            Device("{0.0.0.00000000}.{dddddddd-0000-0000-0000-000000000000}", 0, "New Interface"),
+            Device(SpeakersEndpoint, 1, "Speakers (Realtek)"),
+            Device(ButtkickerEndpoint, 2, "Buttkicker (USB Audio)"),
+            Device(HeadphonesEndpoint, 3, "Headphones (USB Audio)")
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(
+            withNewDevice, ButtkickerEndpoint, "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal(ButtkickerEndpoint, resolution.EndpointId);
+        Assert.Equal("Buttkicker (USB Audio)", resolution.Name);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("   ", "  ")]
+    public void NothingSaved_IsTheSystemDefault(string? endpointId, string? name)
+    {
+        var resolution = AudioDeviceResolver.Resolve(Enumeration(), endpointId, name);
+
+        Assert.Equal(AudioDeviceResolutionStatus.SystemDefault, resolution.Status);
+        Assert.True(resolution.IsSystemDefault);
+        Assert.True(resolution.UsesSystemDefault);
+        Assert.False(resolution.IsUsable);
+        Assert.Null(resolution.Device);
+        Assert.Equal(string.Empty, resolution.EndpointId);
+    }
+
+    [Fact]
+    public void AUniqueNameWithNoEndpointIdSaved_StillResolves()
+    {
+        // Settings written before endpoint ids were persisted must keep working.
+        var resolution = AudioDeviceResolver.Resolve(
+            Enumeration(), endpointId: null, name: "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal(ButtkickerEndpoint, resolution.EndpointId);
+        Assert.Contains("matched by name", resolution.Reason);
+    }
+
+    [Fact]
+    public void AUniqueNameThatIsNoLongerActive_IsUnavailable()
+    {
+        var disabled = new List<AudioDevice>
+        {
+            Device(ButtkickerEndpoint, 0, "Buttkicker (USB Audio)", isAvailable: false)
+        };
+
+        var resolution = AudioDeviceResolver.Resolve(
+            disabled, endpointId: null, name: "Buttkicker (USB Audio)", deviceId: 0);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Unavailable, resolution.Status);
+        Assert.False(resolution.IsUsable);
+    }
+
+    [Fact]
+    public void TheSystemDefaultEntry_ResolvesToTheSystemDefaultRatherThanAnEndpoint()
+    {
+        var webList = new List<AudioDevice> { SystemDefaultEntry() };
+        webList.AddRange(Enumeration());
+
+        var resolution = AudioDeviceResolver.Resolve(
+            webList,
+            endpointId: null,
+            name: WasapiAudioDeviceCatalog.SystemDefaultDeviceName,
+            deviceId: WasapiAudioDeviceCatalog.SystemDefaultDeviceId);
+
+        Assert.Equal(AudioDeviceResolutionStatus.SystemDefault, resolution.Status);
+        Assert.True(resolution.IsSystemDefault);
+        Assert.Null(resolution.Device);
+    }
+
+    [Fact]
+    public void ARenamedDevice_StillResolvesByEndpointIdAndSaysSo()
+    {
+        var resolution = AudioDeviceResolver.Resolve(
+            Enumeration(), ButtkickerEndpoint, "Buttkicker (old name)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal("Buttkicker (USB Audio)", resolution.Name);
+        Assert.Contains("saved under the name 'Buttkicker (old name)'", resolution.Reason);
+    }
+
+    [Fact]
+    public void AnEmptyEnumeration_LeavesASavedEndpointUnresolved()
+    {
+        var resolution = AudioDeviceResolver.Resolve(
+            new List<AudioDevice>(), ButtkickerEndpoint, "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Unresolved, resolution.Status);
+
+        Assert.Equal(
+            AudioDeviceResolutionStatus.Unresolved,
+            AudioDeviceResolver.Resolve(null, ButtkickerEndpoint, "Buttkicker (USB Audio)").Status);
+    }
+
+    [Fact]
+    public void EndpointIdsAreMatchedExactly()
+    {
+        // MMDevice ids are opaque strings; a case-insensitive match could pick a different endpoint.
+        var resolution = AudioDeviceResolver.Resolve(
+            Enumeration(), ButtkickerEndpoint.ToUpperInvariant(), "Buttkicker (USB Audio)", deviceId: 1);
+
+        Assert.Equal(AudioDeviceResolutionStatus.Unresolved, resolution.Status);
+    }
+}

--- a/tests/EDButtkicker.Tests/SetupTestSupport.cs
+++ b/tests/EDButtkicker.Tests/SetupTestSupport.cs
@@ -27,7 +27,17 @@ internal sealed class FakeAudioDeviceCatalog : IAudioDeviceCatalog
         _devices = devices.ToList();
     }
 
-    /// <summary>The system default entry plus the named outputs, numbered as WASAPI would.</summary>
+    /// <summary>
+    /// A stable stand-in for an MMDevice endpoint id, shaped like the real thing so that anything
+    /// which round trips one through JSON or settings is exercised on the real character set.
+    /// </summary>
+    public static string EndpointIdFor(int index) => $"{{0.0.0.00000000}}.{{{index:D8}}}";
+
+    /// <summary>
+    /// The system default entry plus the named outputs, numbered as WASAPI would and each carrying
+    /// its own endpoint id. The default entry gets an empty endpoint id, because it is a choice
+    /// rather than an endpoint.
+    /// </summary>
     public static FakeAudioDeviceCatalog With(params string[] names)
     {
         var devices = new List<AudioDevice>
@@ -45,6 +55,7 @@ internal sealed class FakeAudioDeviceCatalog : IAudioDeviceCatalog
 
         devices.AddRange(names.Select((name, index) => new AudioDevice
         {
+            EndpointId = EndpointIdFor(index),
             DeviceId = index,
             Name = name,
             Driver = "WASAPI",

--- a/tests/EDButtkicker.Tests/UserSettingsRoundTripTests.cs
+++ b/tests/EDButtkicker.Tests/UserSettingsRoundTripTests.cs
@@ -34,6 +34,7 @@ public class UserSettingsRoundTripTests : IDisposable
         var saved = new UserPreferences
         {
             AudioDeviceId = 3,
+            AudioDeviceEndpointId = "{0.0.0.00000000}.{9f6c1e2a-0000-0000-0000-000000000003}",
             AudioDeviceName = "ButtKicker Gamer Pro",
             MaxIntensity = 65,
             DefaultFrequency = 42,
@@ -56,6 +57,8 @@ public class UserSettingsRoundTripTests : IDisposable
         var loaded = await _service.LoadUserPreferencesAsync();
 
         Assert.Equal(saved.AudioDeviceId, loaded.AudioDeviceId);
+        // The endpoint id is what makes the selection survive a restart, braces and all.
+        Assert.Equal(saved.AudioDeviceEndpointId, loaded.AudioDeviceEndpointId);
         Assert.Equal(saved.AudioDeviceName, loaded.AudioDeviceName);
         Assert.Equal(saved.MaxIntensity, loaded.MaxIntensity);
         Assert.Equal(saved.DefaultFrequency, loaded.DefaultFrequency);
@@ -100,6 +103,7 @@ public class UserSettingsRoundTripTests : IDisposable
         var loaded = await _service.LoadUserPreferencesAsync();
 
         Assert.Null(loaded.AudioDeviceId);
+        Assert.Null(loaded.AudioDeviceEndpointId);
         Assert.Null(loaded.AudioDeviceName);
     }
 
@@ -121,6 +125,7 @@ public class UserSettingsRoundTripTests : IDisposable
             Audio =
             {
                 AudioDeviceId = 7,
+                AudioDeviceEndpointId = "{0.0.0.00000000}.{9f6c1e2a-0000-0000-0000-000000000007}",
                 AudioDeviceName = "Test Device",
                 MaxIntensity = 55,
                 DefaultFrequency = 38
@@ -145,6 +150,7 @@ public class UserSettingsRoundTripTests : IDisposable
         _service.ApplyUserPreferencesToAppSettings(await _service.LoadUserPreferencesAsync(), restored);
 
         Assert.Equal(original.Audio.AudioDeviceId, restored.Audio.AudioDeviceId);
+        Assert.Equal(original.Audio.AudioDeviceEndpointId, restored.Audio.AudioDeviceEndpointId);
         Assert.Equal(original.Audio.AudioDeviceName, restored.Audio.AudioDeviceName);
         Assert.Equal(original.Audio.MaxIntensity, restored.Audio.MaxIntensity);
         Assert.Equal(original.Audio.DefaultFrequency, restored.Audio.DefaultFrequency);
@@ -167,6 +173,7 @@ public class UserSettingsRoundTripTests : IDisposable
         Assert.Equal(defaults.Audio.MaxIntensity, settings.Audio.MaxIntensity);
         Assert.Equal(defaults.Audio.DefaultFrequency, settings.Audio.DefaultFrequency);
         Assert.Equal(defaults.Audio.AudioDeviceId, settings.Audio.AudioDeviceId);
+        Assert.Equal(defaults.Audio.AudioDeviceEndpointId, settings.Audio.AudioDeviceEndpointId);
         Assert.Equal(defaults.EliteDangerous.JournalPath, settings.EliteDangerous.JournalPath);
         Assert.Equal(defaults.EliteDangerous.MonitorLatestOnly, settings.EliteDangerous.MonitorLatestOnly);
     }


### PR DESCRIPTION
## Summary
- Persist the WASAPI/MMDevice endpoint id plus friendly name as the output identity. List ordinals remain display-only.
- Resolve saved selections by endpoint id (then unique name, then a same-name legacy ordinal). Reorder, unplug, duplicate names, and a newly connected device no longer steal the saved output.
- Open `WasapiOut` by endpoint id, or the system default. Removed the WaveOut DeviceNumber mapping.
- Web/setup APIs accept `endpointId` and highlight the resolved row. User settings and setup state round-trip the id.

## Test Plan
- [x] `dotnet test tests/EDButtkicker.Tests/EDButtkicker.Tests.csproj` — 392 passed on Linux
- [ ] Windows hardware checklist in `docs/windows-audio-enumeration-checklist.md` (not run from this environment)

Windows playback was not run. This PR does not claim a hardware fix.

Closes #5
