### PR TITLE
fix(journal): constrain replay to enumerated Journal.*.log files

### DIFF
--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -46,7 +46,9 @@ public class JournalApiController
             {
                 try
                 {
-                    journalFiles = Directory.GetFiles(journalPath, "Journal.*.log")
+                    // Same glob the replay guard resolves against, so the names offered here are
+                    // exactly the names replay will accept.
+                    journalFiles = Directory.GetFiles(journalPath, JournalFileGuard.JournalGlob)
                         .OrderByDescending(f => File.GetLastWriteTime(f))
                         .Take(5)
                         .Select(Path.GetFileName)
@@ -254,11 +256,38 @@ public class JournalApiController
                 }
             }
 
-            // Get events from the selected journal file or fallback to recent events (outside of lock)
-            List<JournalEvent> eventsToReplay;
+            // A requested file is only ever one of the journal files the server enumerated; anything
+            // else is refused here, before a path exists, so no file outside the folder is read.
+            string? sourceFile = null;
+            string? resolvedPath = null;
             if (!string.IsNullOrEmpty(selectedJournalFile))
             {
-                eventsToReplay = await ReadLastFiveMinutesFromJournalFile(selectedJournalFile);
+                resolvedPath = JournalFileGuard.Resolve(
+                    _settings.EliteDangerous.JournalPath, selectedJournalFile);
+
+                if (resolvedPath == null)
+                {
+                    _logger.LogWarning(
+                        "Rejected journal replay for a file that is not one of the {Glob} files in the configured journal folder",
+                        JournalFileGuard.JournalGlob);
+
+                    context.Response.StatusCode = 400;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                    {
+                        error = "Journal file must be one of the journal files listed by the journal status API"
+                    }));
+                    return;
+                }
+
+                sourceFile = Path.GetFileName(resolvedPath);
+            }
+
+            // Get events from the selected journal file or fallback to recent events (outside of lock)
+            List<JournalEvent> eventsToReplay;
+            if (resolvedPath != null)
+            {
+                eventsToReplay = await ReadLastFiveMinutesFromJournalFile(resolvedPath);
             }
             else
             {
@@ -283,17 +312,17 @@ public class JournalApiController
                     _replayTokenSource = new CancellationTokenSource();
                     _replayTask = Task.Run(async () => await ReplayEventsAsync(eventsToReplay, _replayTokenSource.Token));
 
-                    _logger.LogInformation("Started journal replay with {Count} events from {Source}", 
-                        eventsToReplay.Count, 
-                        !string.IsNullOrEmpty(selectedJournalFile) ? selectedJournalFile : "recent events");
+                    _logger.LogInformation("Started journal replay with {Count} events from {Source}",
+                        eventsToReplay.Count,
+                        sourceFile ?? "recent events");
                 }
             }
             
             if (!eventsToReplay.Any())
             {
                 context.Response.StatusCode = 404;
-                var errorMessage = !string.IsNullOrEmpty(selectedJournalFile) 
-                    ? $"No events found in the last 5 minutes of journal file: {selectedJournalFile}"
+                var errorMessage = sourceFile != null
+                    ? $"No events found in the last 5 minutes of journal file: {sourceFile}"
                     : "No events found in the last 5 minutes";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = errorMessage }));
                 return;
@@ -303,9 +332,9 @@ public class JournalApiController
             await context.Response.WriteAsync(JsonSerializer.Serialize(new 
             { 
                 success = true,
-                message = $"Journal replay started from {(!string.IsNullOrEmpty(selectedJournalFile) ? Path.GetFileName(selectedJournalFile) : "recent events")}",
+                message = $"Journal replay started from {sourceFile ?? "recent events"}",
                 events_count = eventsToReplay.Count,
-                source = !string.IsNullOrEmpty(selectedJournalFile) ? Path.GetFileName(selectedJournalFile) : "recent_events"
+                source = sourceFile ?? "recent_events"
             }));
         }
         catch (Exception ex)
@@ -417,20 +446,17 @@ public class JournalApiController
         return _eventStore.GetSince(cutoffTime).Count;
     }
 
-    private async Task<List<JournalEvent>> ReadLastFiveMinutesFromJournalFile(string journalFileName)
+    /// <summary>
+    /// Reads a journal file that <see cref="JournalFileGuard.Resolve"/> has already resolved to a
+    /// full path inside the configured journal folder. Never call this with a caller-supplied name.
+    /// </summary>
+    private async Task<List<JournalEvent>> ReadLastFiveMinutesFromJournalFile(string fullPath)
     {
         var events = new List<JournalEvent>();
-        
+        var journalFileName = Path.GetFileName(fullPath);
+
         try
         {
-            var journalPath = _settings.EliteDangerous.JournalPath;
-            if (string.IsNullOrEmpty(journalPath) || !Directory.Exists(journalPath))
-            {
-                _logger.LogWarning("Journal path not configured or does not exist");
-                return events;
-            }
-
-            var fullPath = Path.Combine(journalPath, journalFileName);
             if (!File.Exists(fullPath))
             {
                 _logger.LogWarning("Journal file not found: {FilePath}", fullPath);

--- a/src/EDButtkicker/Services/JournalFileGuard.cs
+++ b/src/EDButtkicker/Services/JournalFileGuard.cs
@@ -1,0 +1,103 @@
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Single place where a caller-supplied journal file name is turned into a filesystem path.
+/// Replay may only ever address a file the server itself enumerated, so a name is resolved against
+/// <see cref="JournalGlob"/> inside the configured journal folder and then matched against the
+/// live enumeration - a name that is not currently one of those files has no path at all.
+/// </summary>
+public static class JournalFileGuard
+{
+    /// <summary>The Elite Dangerous journal file glob. Never caller-controlled.</summary>
+    public const string JournalGlob = "Journal.*.log";
+
+    private const string NamePrefix = "Journal.";
+    private const string NameSuffix = ".log";
+
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Returns the sanitized journal file name, or null when the value carries any directory
+    /// component or percent-encoded variant of one, or is not shaped like a journal file name.
+    /// Shape only: existence is <see cref="Resolve"/>'s job.
+    /// </summary>
+    public static string? SanitizeFileName(string? name)
+    {
+        // The pattern guard already rejects every separator, drive/stream qualifier, "."/"..",
+        // control character and percent-encoded variant thereof; journal names add the glob.
+        var fileName = PatternPathGuard.SanitizeFileName(name);
+        if (fileName == null)
+        {
+            return null;
+        }
+
+        // "Journal." + at least one character + ".log", which is what the glob matches - so
+        // "Journal.log" and "status.json" are out.
+        if (fileName.Length <= NamePrefix.Length + NameSuffix.Length ||
+            !fileName.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase) ||
+            !fileName.EndsWith(NameSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return fileName;
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="requestedName"/> to a full path inside
+    /// <paramref name="journalDirectory"/>, but only when that path is one of the journal files the
+    /// directory currently holds. Returns null otherwise, and never touches the requested file.
+    /// </summary>
+    public static string? Resolve(string? journalDirectory, string? requestedName)
+    {
+        if (string.IsNullOrWhiteSpace(journalDirectory) || !Directory.Exists(journalDirectory))
+        {
+            return null;
+        }
+
+        var safeName = SanitizeFileName(requestedName);
+        if (safeName == null)
+        {
+            return null;
+        }
+
+        string rootFull;
+        string candidate;
+        try
+        {
+            rootFull = Path.GetFullPath(journalDirectory);
+            candidate = Path.GetFullPath(Path.Combine(rootFull, safeName));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
+
+        var rootPrefix = rootFull.EndsWith(Path.DirectorySeparatorChar)
+            ? rootFull
+            : rootFull + Path.DirectorySeparatorChar;
+
+        // The trailing separator is what keeps a sibling "…-evil" folder from counting as inside.
+        if (!candidate.StartsWith(rootPrefix, PathComparison))
+        {
+            return null;
+        }
+
+        // The allow-list: the resolved path has to be one of the files the server would have
+        // offered, which is the same enumeration the journal status API returns.
+        try
+        {
+            var enumerated = Directory.GetFiles(rootFull, JournalGlob);
+
+            return enumerated.Any(file =>
+                string.Equals(Path.GetFullPath(file), candidate, PathComparison))
+                ? candidate
+                : null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/EDButtkicker.Tests/JournalFileGuardTests.cs
+++ b/tests/EDButtkicker.Tests/JournalFileGuardTests.cs
@@ -1,0 +1,125 @@
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Journal replay takes a file name off an HTTP request, so this guard is the only thing between
+/// that name and File.ReadAllLines. Every traversal shape the request can carry is pinned here,
+/// along with the rule that only a currently enumerated journal file resolves at all.
+/// </summary>
+public class JournalFileGuardTests
+{
+    private const string LegitName = "Journal.2026-01-01T000000.01.log";
+
+    [Theory]
+    [InlineData("../secret.log")]
+    [InlineData("..\\secret.log")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("C:/Windows/win.ini")]
+    [InlineData("Journal.foo/../../etc/passwd")]
+    [InlineData("..%2fsecret.log")]
+    [InlineData("%2e%2e%2fsecret.log")]
+    [InlineData("%2e%2e%5csecret.log")]
+    [InlineData("%252e%252e%252fJournal.2026-01-01T000000.01.log")]
+    [InlineData("subdir/Journal.2026-01-01T000000.01.log")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("notes.txt")]
+    [InlineData("Journal.log")]
+    [InlineData("status.json")]
+    [InlineData("Journal.2026-01-01T000000.01.log.bak")]
+    [InlineData(null)]
+    public void SanitizeFileName_RejectsAnythingThatIsNotAPlainJournalName(string? name)
+    {
+        Assert.Null(JournalFileGuard.SanitizeFileName(name));
+    }
+
+    [Theory]
+    [InlineData(LegitName)]
+    [InlineData("Journal.220101120000.01.log")]
+    [InlineData("Journal.2026-01-01T000000.01.LOG")]
+    public void SanitizeFileName_AcceptsJournalShapedNames(string name)
+    {
+        Assert.Equal(name, JournalFileGuard.SanitizeFileName(name));
+    }
+
+    [Theory]
+    [InlineData("../secret.log")]
+    [InlineData("..\\secret.log")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("Journal.foo/../../etc/passwd")]
+    [InlineData("..%2fsecret.log")]
+    [InlineData("%2e%2e%2fsecret.log")]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("notes.txt")]
+    [InlineData("Journal.log")]
+    [InlineData("status.json")]
+    [InlineData(null)]
+    public void Resolve_RejectsTraversalAndNonJournalNames(string? name)
+    {
+        using var journalDir = new TempDirectory("edbk-journal-guard");
+        File.WriteAllText(journalDir.File(LegitName), "{}");
+
+        Assert.Null(JournalFileGuard.Resolve(journalDir.Path, name));
+    }
+
+    [Fact]
+    public void Resolve_AcceptsAnEnumeratedJournalFile()
+    {
+        using var journalDir = new TempDirectory("edbk-journal-guard");
+        var path = journalDir.File(LegitName);
+        File.WriteAllText(path, "{}");
+
+        Assert.Equal(Path.GetFullPath(path), JournalFileGuard.Resolve(journalDir.Path, LegitName));
+    }
+
+    [Fact]
+    public void Resolve_RejectsAJournalShapedNameThatIsNotInTheDirectory()
+    {
+        using var journalDir = new TempDirectory("edbk-journal-guard");
+        File.WriteAllText(journalDir.File(LegitName), "{}");
+
+        Assert.Null(JournalFileGuard.Resolve(journalDir.Path, "Journal.2026-02-02T000000.01.log"));
+    }
+
+    [Fact]
+    public void Resolve_RejectsAJournalFileThatOnlyExistsOutsideTheDirectory()
+    {
+        using var parent = new TempDirectory("edbk-journal-guard");
+        var journalDir = Path.Combine(parent.Path, "journals");
+        Directory.CreateDirectory(journalDir);
+        File.WriteAllText(Path.Combine(parent.Path, LegitName), "{}");
+
+        Assert.Null(JournalFileGuard.Resolve(journalDir, LegitName));
+        Assert.Null(JournalFileGuard.Resolve(journalDir, $"..{Path.DirectorySeparatorChar}{LegitName}"));
+    }
+
+    [Fact]
+    public void Resolve_DoesNotTreatASiblingPrefixDirectoryAsInside()
+    {
+        using var parent = new TempDirectory("edbk-journal-guard");
+        var journalDir = Path.Combine(parent.Path, "journals");
+        var sibling = Path.Combine(parent.Path, "journals-evil");
+        Directory.CreateDirectory(journalDir);
+        Directory.CreateDirectory(sibling);
+        File.WriteAllText(Path.Combine(sibling, LegitName), "{}");
+
+        Assert.Null(JournalFileGuard.Resolve(journalDir, LegitName));
+    }
+
+    [Fact]
+    public void Resolve_RejectsAnUnconfiguredOrMissingJournalDirectory()
+    {
+        Assert.Null(JournalFileGuard.Resolve(null, LegitName));
+        Assert.Null(JournalFileGuard.Resolve("", LegitName));
+        Assert.Null(JournalFileGuard.Resolve(
+            Path.Combine(Path.GetTempPath(), $"edbk-journal-missing-{Guid.NewGuid():N}"), LegitName));
+    }
+}

--- a/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
+++ b/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Controllers;
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Replay used to combine the caller's journalFile onto the journal folder and read whatever came
+/// out. These drive the controller directly - no port, no audio, no Elite Dangerous - so the
+/// assertion can be the strong one: the file outside the journal folder is never replayed.
+/// </summary>
+public class JournalReplayPathTraversalTests
+{
+    private const string LegitJournalName = "Journal.2026-01-01T000000.01.log";
+    private const string SecretEventName = "SecretLeakEvent";
+
+    [Theory]
+    [InlineData("../secret.log")]
+    [InlineData("..\\secret.log")]
+    [InlineData("..%2fsecret.log")]
+    [InlineData("%2e%2e%2fsecret.log")]
+    [InlineData("Journal.foo/../../secret.log")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    [InlineData("secret.log")]
+    [InlineData("Journal.2026-09-09T000000.01.log")]
+    public async Task StartJournalReplay_WithAFileOutsideTheEnumeration_Returns400AndReplaysNothing(string journalFile)
+    {
+        using var fixture = new ReplayFixture();
+
+        var response = await fixture.PostReplayStart(journalFile);
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.DoesNotContain(SecretEventName, response.Body);
+        await fixture.AssertNothingWasReplayed();
+    }
+
+    [Fact]
+    public async Task StartJournalReplay_WithARootedPathToTheSecret_Returns400AndReplaysNothing()
+    {
+        using var fixture = new ReplayFixture();
+
+        var response = await fixture.PostReplayStart(fixture.SecretPath);
+
+        Assert.Equal(400, response.StatusCode);
+        await fixture.AssertNothingWasReplayed();
+    }
+
+    [Fact]
+    public async Task StartJournalReplay_WithAnEnumeratedJournalFile_IsAccepted()
+    {
+        using var fixture = new ReplayFixture();
+
+        var response = await fixture.PostReplayStart(LegitJournalName);
+
+        Assert.Equal(200, response.StatusCode);
+
+        using var document = JsonDocument.Parse(response.Body);
+        Assert.True(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(LegitJournalName, document.RootElement.GetProperty("source").GetString());
+        Assert.Equal(2, document.RootElement.GetProperty("events_count").GetInt32());
+
+        await fixture.StopReplay();
+    }
+
+    [Fact]
+    public async Task StartJournalReplay_WithoutAJournalFile_StillFallsBackToRecentEvents()
+    {
+        using var fixture = new ReplayFixture();
+        fixture.EventStore.Add(new JournalEvent
+        {
+            Timestamp = DateTime.UtcNow,
+            Event = "FSDJump",
+            StarSystem = "In Memory"
+        });
+
+        var response = await fixture.PostReplayStart(journalFile: null);
+
+        Assert.Equal(200, response.StatusCode);
+
+        using var document = JsonDocument.Parse(response.Body);
+        Assert.Equal("recent_events", document.RootElement.GetProperty("source").GetString());
+
+        await fixture.StopReplay();
+    }
+
+    private sealed record ReplayResponse(int StatusCode, string Body);
+
+    /// <summary>
+    /// A temp journal folder holding one legitimate journal file, and a secret file in the parent
+    /// folder that no request may reach. The controller is the real one, wired to fakes.
+    /// </summary>
+    private sealed class ReplayFixture : IDisposable
+    {
+        private readonly TempDirectory _root = new("edbk-journal-replay");
+
+        public ReplayFixture()
+        {
+            JournalDirectory = Path.Combine(_root.Path, "journals");
+            Directory.CreateDirectory(JournalDirectory);
+
+            var now = DateTime.UtcNow;
+            File.WriteAllLines(Path.Combine(JournalDirectory, LegitJournalName), new[]
+            {
+                JournalLine(now.AddSeconds(-30), "FSDJump", "Shinrarta Dezhra"),
+                JournalLine(now, "HullDamage", "Shinrarta Dezhra")
+            });
+
+            // Outside the journal folder, but shaped so that it would replay cleanly if ever read -
+            // so a leak shows up as a replayed SecretLeakEvent rather than as a parse failure.
+            SecretPath = Path.Combine(_root.Path, "secret.log");
+            File.WriteAllLines(SecretPath, new[] { JournalLine(now, SecretEventName, "Sol") });
+
+            Settings = new AppSettings();
+            Settings.EliteDangerous.JournalPath = JournalDirectory;
+
+            Controller = new JournalApiController(
+                NullLogger<JournalApiController>.Instance,
+                Settings,
+                EventStore,
+                Pipeline,
+                new JournalMonitorStatus(TimeProvider.System));
+        }
+
+        public string JournalDirectory { get; }
+
+        public string SecretPath { get; }
+
+        public AppSettings Settings { get; }
+
+        public JournalEventStore EventStore { get; } = new();
+
+        public RecordingJournalPipeline Pipeline { get; } = new();
+
+        public JournalApiController Controller { get; }
+
+        public async Task<ReplayResponse> PostReplayStart(string? journalFile)
+        {
+            var context = new DefaultHttpContext();
+            var responseBody = new MemoryStream();
+            context.Response.Body = responseBody;
+
+            if (journalFile != null)
+            {
+                var bytes = Encoding.UTF8.GetBytes(
+                    JsonSerializer.Serialize(new Dictionary<string, string> { ["journalFile"] = journalFile }));
+                context.Request.ContentType = "application/json";
+                context.Request.ContentLength = bytes.Length;
+                context.Request.Body = new MemoryStream(bytes);
+            }
+
+            await Controller.StartJournalReplay(context);
+
+            return new ReplayResponse(context.Response.StatusCode, Encoding.UTF8.GetString(responseBody.ToArray()));
+        }
+
+        public Task StopReplay()
+        {
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            return Controller.StopJournalReplay(context);
+        }
+
+        /// <summary>
+        /// Nothing reached the pipeline, including after the delay a started replay would have
+        /// needed to hand over its first event.
+        /// </summary>
+        public async Task AssertNothingWasReplayed()
+        {
+            Assert.Empty(Pipeline.Processed);
+
+            await Task.Delay(50);
+
+            Assert.Empty(Pipeline.Processed);
+        }
+
+        public void Dispose() => _root.Dispose();
+
+        private static string JournalLine(DateTime timestamp, string eventName, string starSystem) =>
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["timestamp"] = timestamp.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+                ["event"] = eventName,
+                ["StarSystem"] = starSystem
+            });
+    }
+}


### PR DESCRIPTION
## Summary
Replay used to `Path.Combine` the caller-supplied `journalFile` onto the journal folder and read whatever came out. A rooted or traversal value could escape the configured journal root.

`JournalFileGuard` now resolves a request only when the name is a single `Journal.*.log` file currently enumerated in that folder. Anything else is HTTP 400 before a path exists. Empty/omitted `journalFile` still falls back to in-memory recent events.

## Test Plan
- [x] `dotnet test` — 446 passed, 0 failed (Linux)
- [x] Unit tests reject traversal, rooted, encoded, and non-`Journal.*.log` names
- [x] Controller tests prove a sibling `secret.log` is never replayed
- [ ] WASAPI / physical Buttkicker — not required for this change

Closes #15
