### PR TITLE
fix(security): reject cross-origin mutations on the localhost API

### DIFF
--- a/src/EDButtkicker/Hosting/CsrfTokenProvider.cs
+++ b/src/EDButtkicker/Hosting/CsrfTokenProvider.cs
@@ -1,0 +1,86 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// The anti-forgery token for this process. It is generated once at startup from the system CSPRNG
+/// and handed to the same-origin UI over a GET (cookies plus <c>/api/csrf</c>); every mutation has
+/// to echo it back in the <see cref="HeaderName"/> header. A page on another origin cannot read the
+/// GET response or the cookies, so it cannot forge a mutation even though the listener is reachable
+/// from the browser it runs in.
+/// </summary>
+public sealed class CsrfTokenProvider
+{
+    /// <summary>The header a mutation must carry. A JSON body field would be forgeable by a form post.</summary>
+    public const string HeaderName = "X-CSRF-Token";
+
+    /// <summary>Server-side copy of the token: HttpOnly, so no script can read it.</summary>
+    public const string CookieName = "EDBK-CSRF";
+
+    /// <summary>The copy the same-origin page reads to build the header. Deliberately not HttpOnly.</summary>
+    public const string ScriptCookieName = "EDBK-CSRF-JS";
+
+    private readonly byte[] _tokenHash;
+
+    public CsrfTokenProvider()
+    {
+        Token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+        _tokenHash = SHA256.HashData(Encoding.UTF8.GetBytes(Token));
+    }
+
+    /// <summary>The token as 64 lowercase hex characters (32 random bytes).</summary>
+    public string Token { get; }
+
+    /// <summary>Constant-time comparison, so a candidate cannot be recovered a character at a time.</summary>
+    public bool Matches(string? candidate)
+    {
+        if (string.IsNullOrEmpty(candidate))
+        {
+            return false;
+        }
+
+        // FixedTimeEquals throws when the two spans differ in length, and a candidate is attacker
+        // controlled. Comparing SHA-256 digests keeps both sides 32 bytes, so any candidate - short,
+        // long or empty - is answered by the same constant-time comparison rather than an exception.
+        var candidateHash = SHA256.HashData(Encoding.UTF8.GetBytes(candidate));
+
+        return CryptographicOperations.FixedTimeEquals(_tokenHash, candidateHash);
+    }
+
+    /// <summary>
+    /// Puts both cookies on a safe (GET/HEAD/OPTIONS) response, so loading the UI is enough to arm
+    /// its mutations. Skipped when the caller already holds the current token.
+    /// </summary>
+    public void IssueCookies(HttpContext context)
+    {
+        if (context.Response.HasStarted)
+        {
+            return;
+        }
+
+        if (context.Request.Cookies.TryGetValue(CookieName, out var existing) && Matches(existing) &&
+            context.Request.Cookies.TryGetValue(ScriptCookieName, out var script) && Matches(script))
+        {
+            return;
+        }
+
+        var options = new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true
+        };
+
+        context.Response.Cookies.Append(CookieName, Token, options);
+        context.Response.Cookies.Append(ScriptCookieName, Token, new CookieOptions
+        {
+            HttpOnly = false,
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true
+        });
+    }
+}

--- a/src/EDButtkicker/Hosting/LocalhostRequestGuard.cs
+++ b/src/EDButtkicker/Hosting/LocalhostRequestGuard.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// The gate in front of the whole web pipeline. The listener is loopback only, but "loopback only"
+/// is not a permission check: any page the user visits can make their browser POST to
+/// http://localhost:47811. So every state-changing request has to prove it came from this
+/// application's own UI - a loopback Host, no foreign Origin, and the process anti-forgery token.
+/// Safe methods (GET/HEAD/OPTIONS) are untouched, which keeps static files, the HTML page and every
+/// read-only API readable.
+/// </summary>
+public static class LocalhostRequestGuard
+{
+    /// <summary>Exact Host header values this application answers to. Matching the raw header (rather
+    /// than a parsed host) is what rejects <c>localhost:47811.evil.com</c>, whose port segment is not
+    /// a number and therefore parses back to a bare "localhost".</summary>
+    private static readonly HashSet<string> AllowedHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "localhost",
+        $"localhost:{WebUiConfiguration.Port}",
+        "127.0.0.1",
+        $"127.0.0.1:{WebUiConfiguration.Port}",
+        "[::1]",
+        $"[::1]:{WebUiConfiguration.Port}"
+    };
+
+    /// <summary>The only origins that are this application.</summary>
+    private static readonly HashSet<string> AllowedOrigins = new(StringComparer.OrdinalIgnoreCase)
+    {
+        $"http://localhost:{WebUiConfiguration.Port}",
+        $"http://127.0.0.1:{WebUiConfiguration.Port}",
+        $"http://[::1]:{WebUiConfiguration.Port}"
+    };
+
+    public static bool IsSafeMethod(string method) =>
+        HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method);
+
+    /// <summary>
+    /// Returns null when the mutation may proceed, otherwise the reason it was refused.
+    /// A missing Origin is not trusted on its own - it still needs the loopback Host and the token,
+    /// which is exactly what a same-origin fetch from our own page carries.
+    /// </summary>
+    public static string? Validate(HttpContext context, CsrfTokenProvider tokens)
+    {
+        // The header exactly as it was sent, not HttpRequest.Host: parsing a host can normalise away
+        // the very trickery this check exists to catch, and a repeated Host header must not be able
+        // to smuggle one allowed value past the allowlist either.
+        var sent = context.Request.Headers.Host;
+        var host = sent.Count == 1 ? sent[0] : null;
+        if (string.IsNullOrEmpty(host) || !AllowedHosts.Contains(host))
+        {
+            return "host is not the local application";
+        }
+
+        var origin = context.Request.Headers["Origin"].ToString();
+        if (!string.IsNullOrEmpty(origin) && !AllowedOrigins.Contains(origin))
+        {
+            return "origin is not the local application";
+        }
+
+        var header = context.Request.Headers[CsrfTokenProvider.HeaderName].ToString();
+        if (!tokens.Matches(header))
+        {
+            return $"missing or invalid {CsrfTokenProvider.HeaderName}";
+        }
+
+        // Double submit: when the browser sent the cookie it has to be the same token, so a stale
+        // tab from a previous run is refused rather than half trusted.
+        if (context.Request.Cookies.TryGetValue(CsrfTokenProvider.CookieName, out var cookie) &&
+            !tokens.Matches(cookie))
+        {
+            return "anti-forgery cookie does not match";
+        }
+
+        return null;
+    }
+
+    /// <summary>The refusal the caller sees: 403 and a reason, never the handler's side effects.</summary>
+    public static async Task WriteRejectionAsync(HttpContext context, string reason)
+    {
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        context.Response.ContentType = "application/json";
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+        {
+            error = "Request rejected: this endpoint only accepts same-origin requests from the local UI.",
+            reason
+        }));
+    }
+}

--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -25,6 +25,9 @@ public static class ServiceCollectionExtensions
         // in tests; the process always runs on the system clock.
         services.AddSingleton(TimeProvider.System);
 
+        // One anti-forgery token per process, guarding every state-changing web request.
+        services.AddSingleton<CsrfTokenProvider>();
+
         // Add core services
         services.AddSingleton<AudioEngineService>();
         services.AddSingleton<PatternSequencer>();

--- a/src/EDButtkicker/Hosting/WebUiConfiguration.cs
+++ b/src/EDButtkicker/Hosting/WebUiConfiguration.cs
@@ -28,6 +28,36 @@ public static class WebUiConfiguration
             .CreateLogger(typeof(WebUiConfiguration).FullName!);
 
         var webRootPath = ResolveWebRootPath(logger);
+        var tokens = app.ApplicationServices.GetRequiredService<CsrfTokenProvider>();
+
+        // Ahead of everything, including static files: a mutation that cannot prove it came from our
+        // own page never reaches a handler, and a safe request leaves with the token it needs.
+        app.Use(async (context, next) =>
+        {
+            if (LocalhostRequestGuard.IsSafeMethod(context.Request.Method))
+            {
+                tokens.IssueCookies(context);
+                await next();
+                return;
+            }
+
+            var rejection = LocalhostRequestGuard.Validate(context, tokens);
+            if (rejection != null)
+            {
+                logger.LogWarning(
+                    "Rejected {Method} {Path} (host {Host}, origin {Origin}): {Reason}",
+                    context.Request.Method,
+                    context.Request.Path.ToString(),
+                    context.Request.Host.Value,
+                    context.Request.Headers["Origin"].ToString(),
+                    rejection);
+
+                await LocalhostRequestGuard.WriteRejectionAsync(context, rejection);
+                return;
+            }
+
+            await next();
+        });
 
         app.UseStaticFiles(new StaticFileOptions
         {
@@ -43,8 +73,21 @@ public static class WebUiConfiguration
 
             try
             {
+                // Anti-forgery token for the same-origin UI. A cross-origin page can issue this GET
+                // but cannot read its response or its cookies, so the token stays ours.
+                // The cookies are already on the response - every safe request leaves with them.
+                if (path == "/api/csrf" && method == "GET")
+                {
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        token = tokens.Token,
+                        header = CsrfTokenProvider.HeaderName
+                    }));
+                    return;
+                }
                 // Configuration API
-                if (path == "/api/config" && method == "GET")
+                else if (path == "/api/config" && method == "GET")
                 {
                     var controller = context.RequestServices.GetService<ConfigurationApiController>();
                     await controller!.GetConfiguration(context);

--- a/src/EDButtkicker/wwwroot/index.html
+++ b/src/EDButtkicker/wwwroot/index.html
@@ -556,6 +556,7 @@
     <!-- Toast Notifications -->
     <div class="toast-container" id="toastContainer"></div>
 
+    <script src="js/csrf.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/src/EDButtkicker/wwwroot/js/csrf.js
+++ b/src/EDButtkicker/wwwroot/js/csrf.js
@@ -1,0 +1,54 @@
+// Anti-forgery token for state-changing requests.
+//
+// The server refuses any POST/PUT/DELETE that does not carry the token it handed this page, so a
+// site the user happens to have open cannot drive the local API through their browser. Rather than
+// thread a header through every call site, this wraps fetch once: mutations get the header, safe
+// requests are untouched. Load it before any script that talks to the API.
+(function () {
+    const HEADER = 'X-CSRF-Token';
+    const COOKIE = 'EDBK-CSRF-JS';
+    const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+    const nativeFetch = window.fetch.bind(window);
+    let pending = null;
+
+    function tokenFromCookie() {
+        const match = document.cookie.match(new RegExp('(?:^|; )' + COOKIE + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    // The cookie is set on any GET of the UI; the endpoint is the fallback for a page that was
+    // opened before the cookie existed. Only one request is ever in flight.
+    function token() {
+        const fromCookie = tokenFromCookie();
+        if (fromCookie) {
+            return Promise.resolve(fromCookie);
+        }
+
+        if (!pending) {
+            pending = nativeFetch('/api/csrf', { credentials: 'same-origin' })
+                .then(response => response.json())
+                .then(body => body.token)
+                .finally(() => { pending = null; });
+        }
+
+        return pending;
+    }
+
+    window.fetch = async function (input, init) {
+        const options = init || {};
+        const method = (options.method || (input && input.method) || 'GET').toUpperCase();
+
+        if (SAFE_METHODS.includes(method)) {
+            return nativeFetch(input, init);
+        }
+
+        const headers = new Headers(options.headers || (input && input.headers) || undefined);
+        headers.set(HEADER, await token());
+
+        return nativeFetch(input, { ...options, headers, credentials: 'same-origin' });
+    };
+
+    // Warm the token up front so the first mutation does not pay for a round trip.
+    token();
+})();

--- a/src/EDButtkicker/wwwroot/pattern-conflicts.html
+++ b/src/EDButtkicker/wwwroot/pattern-conflicts.html
@@ -322,6 +322,7 @@
         </main>
     </div>
 
+    <script src="js/csrf.js"></script>
     <script src="js/pattern-conflicts.js"></script>
 </body>
 </html>

--- a/src/EDButtkicker/wwwroot/pattern-editor.html
+++ b/src/EDButtkicker/wwwroot/pattern-editor.html
@@ -1211,6 +1211,7 @@
         </div>
     </div>
 
+    <script src="js/csrf.js"></script>
     <script src="js/timeline-editor.js"></script>
     <script src="js/pattern-editor.js"></script>
 </body>

--- a/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
+++ b/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
@@ -131,6 +131,7 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
     /// <summary>Every route wired up in <see cref="WebUiConfiguration.Configure"/>.</summary>
     public static TheoryData<string, string> MappedRoutes() => new()
     {
+        { "GET", "/api/csrf" },
         { "GET", "/api/config" },
         { "POST", "/api/config" },
         { "GET", "/api/config/export" },
@@ -180,6 +181,7 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
     /// <summary>GETs that need no request body, so anything but success is a real failure.</summary>
     public static TheoryData<string> ReadOnlyRoutes() => new()
     {
+        "/api/csrf",
         "/api/config",
         "/api/patterns",
         "/api/journal/status",
@@ -263,16 +265,22 @@ public sealed class WebUiTestServerFixture : IDisposable
             .Build();
 
         _host.Start();
-        Client = _host.GetTestClient();
+        Client = LoopbackTestClient.Create(_host);
+        RawClient = _host.GetTestClient();
     }
 
+    /// <summary>Speaks like the application's own page: loopback Host, same-origin Origin, token.</summary>
     public HttpClient Client { get; }
+
+    /// <summary>No default headers at all, so a test can spell out exactly what a caller sent.</summary>
+    public HttpClient RawClient { get; }
 
     public IServiceProvider Services => _host.Services;
 
     public void Dispose()
     {
         Client.Dispose();
+        RawClient.Dispose();
         _host.Dispose();
         _setupStateDir.Dispose();
     }

--- a/tests/EDButtkicker.Tests/LocalhostCsrfApiTests.cs
+++ b/tests/EDButtkicker.Tests/LocalhostCsrfApiTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using EDButtkicker.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The listener is loopback only, but a page on any site can still make the user's browser post to
+/// it. These run the real pipeline on a TestServer and pin that a state-changing request only gets
+/// through when it proves it came from this application's own UI - and that reading stays open.
+/// </summary>
+public class LocalhostCsrfApiTests : IClassFixture<WebUiTestServerFixture>
+{
+    /// <summary>A mutation that needs nothing from the request body, so only the guard decides.</summary>
+    private const string MutationPath = "/api/health/journal/retry";
+
+    private readonly WebUiTestServerFixture _fixture;
+    private readonly string _token;
+
+    public LocalhostCsrfApiTests(WebUiTestServerFixture fixture)
+    {
+        _fixture = fixture;
+        _token = fixture.Services.GetRequiredService<CsrfTokenProvider>().Token;
+    }
+
+    [Theory]
+    [InlineData("https://evil.example")]
+    [InlineData("http://evil.example")]
+    [InlineData("http://localhost.evil.example")]
+    [InlineData("http://localhost:8080")]
+    [InlineData("null")]
+    public async Task Mutation_FromAForeignOrigin_IsRejected(string origin)
+    {
+        // Everything else about this request is right: loopback host, real token.
+        var response = await SendMutationAsync(host: $"localhost:{WebUiConfiguration.Port}", origin: origin, token: _token);
+
+        await AssertRejectedAsync(response);
+    }
+
+    [Fact]
+    public async Task Mutation_WithoutTheAntiForgeryToken_IsRejected()
+    {
+        var response = await SendMutationAsync(
+            host: $"localhost:{WebUiConfiguration.Port}", origin: LoopbackTestClient.Origin, token: null);
+
+        await AssertRejectedAsync(response);
+    }
+
+    [Fact]
+    public async Task Mutation_WithAGuessedToken_IsRejected()
+    {
+        var response = await SendMutationAsync(
+            host: $"localhost:{WebUiConfiguration.Port}",
+            origin: LoopbackTestClient.Origin,
+            token: new string('a', 64));
+
+        await AssertRejectedAsync(response);
+    }
+
+    [Fact]
+    public async Task Mutation_WithAStaleAntiForgeryCookie_IsRejected()
+    {
+        var request = MutationRequest($"localhost:{WebUiConfiguration.Port}", LoopbackTestClient.Origin, _token);
+        request.Headers.TryAddWithoutValidation("Cookie", $"{CsrfTokenProvider.CookieName}={new string('b', 64)}");
+
+        await AssertRejectedAsync(await _fixture.RawClient.SendAsync(request));
+    }
+
+    [Theory]
+    [InlineData("evil.com")]
+    [InlineData("localhost.evil.com")]
+    [InlineData("localhost:47811.evil.com")]
+    [InlineData("127.0.0.1.evil.com")]
+    [InlineData("localhost:8080")]
+    public async Task Mutation_WithAForeignHost_IsRejected(string host)
+    {
+        // No Origin header at all - a missing Origin is never trusted on its own.
+        var response = await SendMutationAsync(host: host, origin: null, token: _token);
+
+        await AssertRejectedAsync(response);
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("localhost:47811")]
+    [InlineData("127.0.0.1:47811")]
+    [InlineData("[::1]:47811")]
+    public async Task Mutation_WithLoopbackHostAndToken_ReachesTheHandler(string host)
+    {
+        var response = await SendMutationAsync(host: host, origin: null, token: _token);
+
+        await AssertNotRejectedAsync(response);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:47811")]
+    [InlineData("http://127.0.0.1:47811")]
+    [InlineData("http://[::1]:47811")]
+    public async Task Mutation_FromTheSameOriginWithAToken_ReachesTheHandler(string origin)
+    {
+        var response = await SendMutationAsync(host: $"localhost:{WebUiConfiguration.Port}", origin: origin, token: _token);
+
+        await AssertNotRejectedAsync(response);
+    }
+
+    [Fact]
+    public async Task CsrfEndpoint_ServesATokenAndBothCookies()
+    {
+        var response = await _fixture.RawClient.GetAsync("/api/csrf");
+
+        Assert.True(response.IsSuccessStatusCode, $"GET /api/csrf returned {(int)response.StatusCode}");
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var token = document.RootElement.GetProperty("token").GetString();
+
+        Assert.Equal(64, token!.Length);
+        Assert.All(token, c => Assert.True(Uri.IsHexDigit(c), $"'{c}' is not hex"));
+
+        var cookies = response.Headers.GetValues("Set-Cookie").ToList();
+
+        var serverCookie = Assert.Single(cookies, c => c.StartsWith($"{CsrfTokenProvider.CookieName}="));
+        Assert.Contains("httponly", serverCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=strict", serverCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("path=/", serverCookie, StringComparison.OrdinalIgnoreCase);
+
+        // The page needs one copy it can actually read to build the header from.
+        var scriptCookie = Assert.Single(cookies, c => c.StartsWith($"{CsrfTokenProvider.ScriptCookieName}="));
+        Assert.DoesNotContain("httponly", scriptCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=strict", scriptCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/api/health")]
+    [InlineData("/api/config")]
+    [InlineData("/api/patterns")]
+    [InlineData("/api/setup/status")]
+    public async Task SafeRequests_StayReadableWithoutAToken(string path)
+    {
+        // No token, no Origin, and the bare default host: reads are not the attack surface.
+        var response = await _fixture.RawClient.GetAsync(path);
+
+        Assert.True(
+            response.IsSuccessStatusCode,
+            $"GET {path} returned {(int)response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
+
+    private Task<HttpResponseMessage> SendMutationAsync(string host, string? origin, string? token) =>
+        _fixture.RawClient.SendAsync(MutationRequest(host, origin, token));
+
+    private static HttpRequestMessage MutationRequest(string host, string? origin, string? token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, MutationPath)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+
+        // Unvalidated so the malformed hosts an attacker would try survive to the server.
+        request.Headers.TryAddWithoutValidation("Host", host);
+
+        if (origin != null)
+        {
+            request.Headers.TryAddWithoutValidation("Origin", origin);
+        }
+
+        if (token != null)
+        {
+            request.Headers.TryAddWithoutValidation(CsrfTokenProvider.HeaderName, token);
+        }
+
+        return request;
+    }
+
+    private static async Task AssertRejectedAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Contains("same-origin", body);
+    }
+
+    private static async Task AssertNotRejectedAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        // The handler may still answer 4xx for its own reasons; what must not happen is the guard
+        // turning our own UI away.
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"{MutationPath} was refused by the request guard: {body}");
+        Assert.DoesNotContain("Request rejected", body);
+    }
+}

--- a/tests/EDButtkicker.Tests/LoopbackTestClient.cs
+++ b/tests/EDButtkicker.Tests/LoopbackTestClient.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using EDButtkicker.Hosting;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// A TestServer client that looks like the application's own page: it addresses the loopback host
+/// on the real port, sends the same-origin Origin header, and carries the anti-forgery token it
+/// picked up from the token endpoint. Every existing integration test posts through one of these,
+/// so the guard is exercised rather than bypassed.
+/// </summary>
+internal static class LoopbackTestClient
+{
+    public static readonly string Origin = $"http://localhost:{WebUiConfiguration.Port}";
+
+    public static HttpClient Create(IWebHost host)
+    {
+        var client = host.GetTestClient();
+        client.BaseAddress = new Uri(Origin + "/");
+        client.DefaultRequestHeaders.Add("Origin", Origin);
+        client.DefaultRequestHeaders.Add(CsrfTokenProvider.HeaderName, FetchToken(client));
+
+        return client;
+    }
+
+    /// <summary>
+    /// The same GET the browser page makes on load. Run on the thread pool so a synchronous fixture
+    /// constructor cannot deadlock against a test framework synchronization context.
+    /// </summary>
+    private static string FetchToken(HttpClient client) =>
+        Task.Run(async () =>
+        {
+            var response = await client.GetAsync("/api/csrf");
+            Assert.True(response.IsSuccessStatusCode, $"GET /api/csrf returned {(int)response.StatusCode}");
+
+            using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            return document.RootElement.GetProperty("token").GetString()!;
+        }).GetAwaiter().GetResult();
+}

--- a/tests/EDButtkicker.Tests/SetupTestSupport.cs
+++ b/tests/EDButtkicker.Tests/SetupTestSupport.cs
@@ -208,7 +208,7 @@ internal sealed class SetupTestHost : IDisposable
             .Build();
 
         _host.Start();
-        Client = _host.GetTestClient();
+        Client = LoopbackTestClient.Create(_host);
     }
 
     public AppSettings Settings { get; }


### PR DESCRIPTION
## Summary
Loopback is not a permission check. Any page in the user's browser can POST to `http://localhost:47811`. Mutations now require:

- a loopback `Host` (`localhost` / `127.0.0.1` / `[::1]`, with or without port 47811)
- a same-origin `Origin` when one is sent (foreign Origin is always rejected)
- an application-generated anti-forgery token (`X-CSRF-Token`, plus HttpOnly + JS cookies)

GET/HEAD/OPTIONS stay open. `wwwroot/js/csrf.js` wraps `fetch` so the existing UI POSTs send the header.

## Test Plan
- [x] `dotnet test` on Linux: 474 passed, 0 failed
- [x] Integration tests for foreign Origin, missing token, guessed token, stale cookie, malformed Host, valid same-origin Host+Origin+token, GET without a token
- [ ] Windows WASAPI / physical Buttkicker: not required for this change

Closes #16
