### PR TITLE
fix(ui): render API text as nodes and block inline script

### DIFF
--- a/src/EDButtkicker/Hosting/WebUiConfiguration.cs
+++ b/src/EDButtkicker/Hosting/WebUiConfiguration.cs
@@ -30,6 +30,31 @@ public static class WebUiConfiguration
         var webRootPath = ResolveWebRootPath(logger);
         var tokens = app.ApplicationServices.GetRequiredService<CsrfTokenProvider>();
 
+        // Second line of defence behind the DOM-building helpers in wwwroot/js/dom.js: even if a
+        // value from the journal or a pattern pack were ever concatenated into markup again, the
+        // browser refuses to run it. Script is 'self' only - no 'unsafe-inline', no 'unsafe-eval' -
+        // which is why the pages carry no inline <script> and no onclick attributes. Style still
+        // allows inline: the pages hide panels with style="display: none" and the fallback page
+        // carries a <style> block, and a stylesheet cannot execute. The two cdnjs allowances are
+        // the Font Awesome stylesheet and the webfonts it pulls in.
+        const string contentSecurityPolicy =
+            "default-src 'self'; " +
+            "script-src 'self'; " +
+            "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; " +
+            "font-src 'self' https://cdnjs.cloudflare.com; " +
+            "img-src 'self' data:; " +
+            "connect-src 'self'; " +
+            "object-src 'none'; " +
+            "base-uri 'self'; " +
+            "form-action 'self'; " +
+            "frame-ancestors 'none'";
+
+        app.Use(async (context, next) =>
+        {
+            context.Response.Headers["Content-Security-Policy"] = contentSecurityPolicy;
+            await next();
+        });
+
         // Ahead of everything, including static files: a mutation that cannot prove it came from our
         // own page never reaches a handler, and a safe request leaves with the token it needs.
         app.Use(async (context, next) =>
@@ -502,36 +527,26 @@ public static class WebUiConfiguration
                     </div>
                 </div>
 
+                <!--
+                    This fallback page is served only when wwwroot/index.html is missing, so it has
+                    no data to render and no script: the Content-Security-Policy allows no inline
+                    script, and there is nothing here worth loading a file for. The endpoint list is
+                    static markup rather than something a handler writes into .innerHTML.
+                -->
                 <div class="loading">
-                    🚀 Loading configuration interface...
-                    <br><br>
-                    <small>Please wait while the advanced pattern system initializes</small>
+                    <h3>📡 Configuration Interface Ready</h3>
+                    <p>The web UI files were not found, but the API is serving requests.</p>
+                    <br>
+                    <p><strong>Available endpoints:</strong></p>
+                    <ul style="text-align: left; max-width: 600px; margin: 0 auto;">
+                        <li>GET /api/config - Current configuration</li>
+                        <li>GET /api/patterns - All haptic patterns</li>
+                        <li>GET /api/audio/devices - Available audio devices</li>
+                        <li>GET /api/journal/status - Journal monitoring status</li>
+                        <li>POST /api/patterns/{eventType}/test - Test patterns</li>
+                    </ul>
                 </div>
             </div>
-
-            <script>
-                console.log('Elite Dangerous Buttkicker Configuration Interface');
-                console.log('Web server running on localhost:8080');
-
-                // Basic status check
-                setTimeout(() => {
-                    document.querySelector('.loading').innerHTML = `
-                        <h3>📡 Configuration Interface Ready</h3>
-                        <p>API endpoints are available for pattern configuration</p>
-                        <br>
-                        <p><strong>Available endpoints:</strong></p>
-                        <ul style="text-align: left; max-width: 600px; margin: 0 auto;">
-                            <li>GET /api/config - Current configuration</li>
-                            <li>GET /api/patterns - All haptic patterns</li>
-                            <li>GET /api/audio/devices - Available audio devices</li>
-                            <li>GET /api/journal/status - Journal monitoring status</li>
-                            <li>POST /api/patterns/{eventType}/test - Test patterns</li>
-                        </ul>
-                        <br>
-                        <p><em>Advanced web UI will load here automatically...</em></p>
-                    `;
-                }, 2000);
-            </script>
         </body>
         </html>
         """;

--- a/src/EDButtkicker/wwwroot/index.html
+++ b/src/EDButtkicker/wwwroot/index.html
@@ -50,10 +50,10 @@
                 <div class="panel-header">
                     <h2><i class="fas fa-tachometer-alt"></i> System Dashboard</h2>
                     <div class="header-actions">
-                        <button class="btn btn-secondary" onclick="openSetupWizard()">
+                        <button class="btn btn-secondary" data-bind="openSetupWizard">
                             <i class="fas fa-magic"></i> Setup Wizard
                         </button>
-                        <button class="btn btn-primary" onclick="refreshDashboard()">
+                        <button class="btn btn-primary" data-bind="refreshDashboard">
                             <i class="fas fa-sync-alt"></i> Refresh
                         </button>
                     </div>
@@ -63,7 +63,7 @@
                     <div class="stats-card">
                         <div class="card-header">
                             <h3><i class="fas fa-heartbeat"></i> System Health</h3>
-                            <button class="btn btn-sm" onclick="refreshHealth()">
+                            <button class="btn btn-sm" data-bind="refreshHealth">
                                 <i class="fas fa-sync-alt"></i>
                             </button>
                         </div>
@@ -99,7 +99,7 @@
                     <div class="stats-card full-width">
                         <div class="card-header">
                             <h3><i class="fas fa-history"></i> Recent Events</h3>
-                            <button class="btn btn-sm" onclick="loadRecentEvents()">
+                            <button class="btn btn-sm" data-bind="loadRecentEvents">
                                 <i class="fas fa-refresh"></i>
                             </button>
                         </div>
@@ -117,16 +117,16 @@
                 <div class="panel-header">
                     <h2><i class="fas fa-wave-square"></i> Haptic Patterns</h2>
                     <div class="header-actions">
-                        <button class="btn btn-secondary" onclick="refreshPatterns()">
+                        <button class="btn btn-secondary" data-bind="refreshPatterns">
                             <i class="fas fa-sync-alt"></i> Refresh
                         </button>
-                        <button class="btn btn-secondary" onclick="showPatternTester()">
+                        <button class="btn btn-secondary" data-bind="showPatternTester">
                             <i class="fas fa-vial"></i> Pattern Tester
                         </button>
                         <a href="pattern-editor.html" class="btn btn-primary">
                             <i class="fas fa-edit"></i> Pattern Editor
                         </a>
-                        <button class="btn btn-primary" onclick="createNewPattern()">
+                        <button class="btn btn-primary" data-bind="createNewPattern">
                             <i class="fas fa-plus"></i> New Pattern
                         </button>
                     </div>
@@ -141,7 +141,7 @@
                     <div class="pattern-tester" id="patternTester" style="display: none;">
                         <div class="tester-header">
                             <h3><i class="fas fa-vial"></i> Pattern Tester</h3>
-                            <button class="btn-close" onclick="hidePatternTester()">&times;</button>
+                            <button class="btn-close" data-bind="hidePatternTester">&times;</button>
                         </div>
                         
                         <div class="tester-content">
@@ -224,16 +224,16 @@
                                         <div class="layer-controls" id="layerControls">
                                             <!-- Dynamic layer controls will be added here -->
                                         </div>
-                                        <button type="button" class="btn btn-sm btn-secondary" onclick="addLayer()">
+                                        <button type="button" class="btn btn-sm btn-secondary" data-bind="addLayer">
                                             <i class="fas fa-plus"></i> Add Layer
                                         </button>
                                     </div>
 
                                     <div class="pattern-actions">
-                                        <button class="btn btn-accent" onclick="testCustomPattern()">
+                                        <button class="btn btn-accent" data-bind="testCustomPattern">
                                             <i class="fas fa-play"></i> Test Pattern
                                         </button>
-                                        <button class="btn btn-secondary" onclick="resetPatternTester()">
+                                        <button class="btn btn-secondary" data-bind="resetPatternTester">
                                             <i class="fas fa-undo"></i> Reset
                                         </button>
                                     </div>
@@ -248,7 +248,7 @@
             <div class="tab-panel" id="audio">
                 <div class="panel-header">
                     <h2><i class="fas fa-volume-up"></i> Audio Configuration</h2>
-                    <button class="btn btn-primary" onclick="testAudio()">
+                    <button class="btn btn-primary" data-bind="testAudio">
                         <i class="fas fa-play"></i> Test Audio
                     </button>
                 </div>
@@ -283,7 +283,7 @@
             <div class="tab-panel" id="journal">
                 <div class="panel-header">
                     <h2><i class="fas fa-file-alt"></i> Journal Monitoring</h2>
-                    <button class="btn btn-primary" onclick="refreshJournalStatus()">
+                    <button class="btn btn-primary" data-bind="refreshJournalStatus">
                         <i class="fas fa-sync-alt"></i> Refresh
                     </button>
                 </div>
@@ -293,7 +293,7 @@
                         <h3>Journal Path Configuration</h3>
                         <div class="path-config">
                             <input type="text" id="journalPath" placeholder="Enter Elite Dangerous journal path..." class="path-input">
-                            <button class="btn btn-secondary" onclick="setJournalPath()">
+                            <button class="btn btn-secondary" data-bind="setJournalPath">
                                 <i class="fas fa-folder"></i> Set Path
                             </button>
                         </div>
@@ -321,7 +321,7 @@
                                         <select id="journalFileSelect" class="journal-select">
                                             <option value="">Loading journal files...</option>
                                         </select>
-                                        <button class="btn btn-sm btn-secondary" onclick="refreshJournalFiles()">
+                                        <button class="btn btn-sm btn-secondary" data-bind="refreshJournalFiles">
                                             <i class="fas fa-sync-alt"></i>
                                         </button>
                                     </div>
@@ -342,13 +342,13 @@
                                 </div>
                             </div>
                             <div class="replay-actions">
-                                <button class="btn btn-primary" id="startReplayBtn" onclick="startJournalReplay()">
+                                <button class="btn btn-primary" id="startReplayBtn" data-bind="startJournalReplay">
                                     <i class="fas fa-play"></i> Start Replay
                                 </button>
-                                <button class="btn btn-secondary" id="stopReplayBtn" onclick="stopJournalReplay()" disabled>
+                                <button class="btn btn-secondary" id="stopReplayBtn" data-bind="stopJournalReplay" disabled>
                                     <i class="fas fa-stop"></i> Stop Replay
                                 </button>
-                                <button class="btn btn-accent" onclick="refreshReplayStatus()">
+                                <button class="btn btn-accent" data-bind="refreshReplayStatus">
                                     <i class="fas fa-sync-alt"></i> Refresh Status
                                 </button>
                             </div>
@@ -362,7 +362,7 @@
                 <div class="panel-header">
                     <h2><i class="fas fa-brain"></i> Contextual Intelligence</h2>
                     <div class="header-actions">
-                        <button class="btn btn-primary" onclick="refreshContextStatus()">
+                        <button class="btn btn-primary" data-bind="refreshContextStatus">
                             <i class="fas fa-sync-alt"></i> Refresh
                         </button>
                     </div>
@@ -415,7 +415,7 @@
                                     </label>
                                 </div>
                                 
-                                <button class="btn btn-primary" onclick="saveContextConfiguration()">
+                                <button class="btn btn-primary" data-bind="saveContextConfiguration">
                                     <i class="fas fa-save"></i> Save Configuration
                                 </button>
                             </div>
@@ -450,10 +450,10 @@
                 <div class="panel-header">
                     <h2><i class="fas fa-cog"></i> Configuration Settings</h2>
                     <div class="header-actions">
-                        <button class="btn btn-secondary" onclick="exportConfiguration()">
+                        <button class="btn btn-secondary" data-bind="exportConfiguration">
                             <i class="fas fa-download"></i> Export
                         </button>
-                        <button class="btn btn-secondary" onclick="importConfiguration()">
+                        <button class="btn btn-secondary" data-bind="importConfiguration">
                             <i class="fas fa-upload"></i> Import
                         </button>
                     </div>
@@ -518,7 +518,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3><i class="fas fa-magic"></i> First-Run Setup</h3>
-                <button class="modal-close" onclick="closeSetupWizard()">&times;</button>
+                <button class="modal-close" data-bind="closeSetupWizard">&times;</button>
             </div>
             <div class="modal-body">
                 <ol class="setup-steps" id="setupSteps"></ol>
@@ -528,7 +528,7 @@
             </div>
             <div class="modal-footer">
                 <span class="setup-note" id="setupNote"></span>
-                <button class="btn btn-secondary" onclick="closeSetupWizard()">Close</button>
+                <button class="btn btn-secondary" data-bind="closeSetupWizard">Close</button>
             </div>
         </div>
     </div>
@@ -538,7 +538,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3 id="patternModalTitle">Edit Pattern</h3>
-                <button class="modal-close" onclick="closePatternModal()">&times;</button>
+                <button class="modal-close" data-bind="closePatternModal">&times;</button>
             </div>
             <div class="modal-body">
                 <div class="pattern-editor" id="patternEditor">
@@ -546,9 +546,9 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn btn-secondary" onclick="closePatternModal()">Cancel</button>
-                <button class="btn btn-primary" onclick="savePattern()">Save Pattern</button>
-                <button class="btn btn-accent" onclick="testCurrentPattern()">Test Pattern</button>
+                <button class="btn btn-secondary" data-bind="closePatternModal">Cancel</button>
+                <button class="btn btn-primary" data-bind="savePattern">Save Pattern</button>
+                <button class="btn btn-accent" data-bind="testCurrentPattern">Test Pattern</button>
             </div>
         </div>
     </div>
@@ -556,6 +556,7 @@
     <!-- Toast Notifications -->
     <div class="toast-container" id="toastContainer"></div>
 
+    <script src="js/dom.js"></script>
     <script src="js/csrf.js"></script>
     <script src="js/app.js"></script>
 </body>

--- a/src/EDButtkicker/wwwroot/js/app.js
+++ b/src/EDButtkicker/wwwroot/js/app.js
@@ -77,7 +77,10 @@ class ButtkickerApp {
 
             const list = document.getElementById('systemHealthList');
             if (list) {
-                list.innerHTML = '<div class="loading">Could not read system health from the local service.</div>';
+                dom.replace(list, dom.el('div', {
+                    className: 'loading',
+                    text: 'Could not read system health from the local service.'
+                }));
             }
         }
     }
@@ -90,22 +93,24 @@ class ButtkickerApp {
         const list = document.getElementById('systemHealthList');
         if (!list) return;
 
-        list.innerHTML = (report.components || []).map(component => `
-            <div class="health-item">
-                <div class="health-summary">
-                    <span class="status-indicator ${ButtkickerApp.statusDotClass(component.status)}"></span>
-                    <div class="health-text">
-                        <div class="health-name">${component.name}</div>
-                        <div class="health-reason">${component.reason || ''}</div>
-                        ${component.detail ? `<div class="health-detail">${component.detail}</div>` : ''}
-                    </div>
-                </div>
-                ${component.retry ? `
-                    <button class="btn btn-sm" onclick="retryHealthComponent('${component.id}')">
-                        <i class="fas fa-redo"></i> ${component.retry.label}
-                    </button>` : ''}
-            </div>
-        `).join('');
+        const { el, replace, icon } = dom;
+
+        replace(list, (report.components || []).map(component => el('div', { className: 'health-item' }, [
+            el('div', { className: 'health-summary' }, [
+                el('span', { className: `status-indicator ${ButtkickerApp.statusDotClass(component.status)}` }),
+                el('div', { className: 'health-text' }, [
+                    el('div', { className: 'health-name', text: component.name }),
+                    el('div', { className: 'health-reason', text: component.reason || '' }),
+                    component.detail ? el('div', { className: 'health-detail', text: component.detail }) : null
+                ])
+            ]),
+            component.retry
+                ? el('button', {
+                    className: 'btn btn-sm',
+                    on: { click: () => retryHealthComponent(component.id) }
+                }, [icon('fa-redo'), ' ', component.retry.label])
+                : null
+        ])));
     }
 
     setHeaderStatus(iconClass, text) {
@@ -203,16 +208,22 @@ class ButtkickerApp {
             this.activeStep = this.setup.current_step;
         }
 
-        stepsList.innerHTML = steps.map(step => `
-            <li class="setup-step ${step.complete ? 'complete' : ''} ${step.id === this.activeStep ? 'active' : ''}"
-                onclick="showSetupStep('${step.id}')">
-                <i class="fas ${step.complete ? 'fa-check-circle' : 'fa-circle-notch'}"></i>
-                <div>
-                    <div class="setup-step-title">${step.title}</div>
-                    <div class="setup-step-summary">${step.summary || ''}</div>
-                </div>
-            </li>
-        `).join('');
+        const { el, replace, icon } = dom;
+
+        replace(stepsList, steps.map(step => el('li', {
+            className: [
+                'setup-step',
+                step.complete ? 'complete' : '',
+                step.id === this.activeStep ? 'active' : ''
+            ].filter(Boolean).join(' '),
+            on: { click: () => showSetupStep(step.id) }
+        }, [
+            icon(step.complete ? 'fa-check-circle' : 'fa-circle-notch'),
+            el('div', {}, [
+                el('div', { className: 'setup-step-title', text: step.title }),
+                el('div', { className: 'setup-step-summary', text: step.summary || '' })
+            ])
+        ])));
 
         if (note) {
             note.textContent = this.setup.completed
@@ -237,112 +248,150 @@ class ButtkickerApp {
     }
 
     async renderJournalStep(panel) {
-        panel.innerHTML = '<div class="loading">Looking for your Elite Dangerous journal folder...</div>';
+        const { el, replace } = dom;
+
+        replace(panel, el('div', { className: 'loading', text: 'Looking for your Elite Dangerous journal folder...' }));
 
         try {
             const response = await fetch('/api/setup/journal/candidates');
             const data = await response.json();
             const candidates = data.candidates || [];
 
-            panel.innerHTML = `
-                <h4>1. Find your Elite Dangerous journal</h4>
-                <p class="setup-help">Elite Dangerous writes a <code>Journal.*.log</code> file every session.
-                   These are the folders found on this machine.</p>
-                <div class="setup-candidates">
-                    ${candidates.length === 0 ? '<div class="loading">No candidate folders found - enter the path below.</div>' : ''}
-                    ${candidates.map(candidate => `
-                        <div class="setup-candidate ${candidate.is_configured ? 'active' : ''}">
-                            <div>
-                                <div class="setup-candidate-path">${candidate.path}</div>
-                                <div class="setup-candidate-detail">
-                                    ${candidate.exists ? `${candidate.journal_files_found} journal file(s)` : 'Folder does not exist'}
-                                    ${candidate.is_recommended ? ' &middot; recommended' : ''}
-                                </div>
-                            </div>
-                            <button class="btn btn-sm btn-primary" ${candidate.exists ? '' : 'disabled'}
-                                    onclick="confirmJournalPath(${JSON.stringify(candidate.path).replace(/"/g, '&quot;')})">
-                                Use this folder
-                            </button>
-                        </div>
-                    `).join('')}
-                </div>
-                <div class="form-group">
-                    <label for="setupJournalPath">Or enter the folder yourself</label>
-                    <input type="text" id="setupJournalPath" value="${data.configured_path || ''}">
-                </div>
-                <button class="btn btn-primary" onclick="confirmJournalPath()">Confirm journal folder</button>
-            `;
+            replace(panel, [
+                el('h4', { text: '1. Find your Elite Dangerous journal' }),
+                el('p', { className: 'setup-help' }, [
+                    'Elite Dangerous writes a ',
+                    el('code', { text: 'Journal.*.log' }),
+                    ' file every session. These are the folders found on this machine.'
+                ]),
+                el('div', { className: 'setup-candidates' }, [
+                    candidates.length === 0
+                        ? el('div', { className: 'loading', text: 'No candidate folders found - enter the path below.' })
+                        : null,
+                    ...candidates.map(candidate => el('div', {
+                        className: `setup-candidate ${candidate.is_configured ? 'active' : ''}`.trim()
+                    }, [
+                        el('div', {}, [
+                            el('div', { className: 'setup-candidate-path', text: candidate.path }),
+                            el('div', { className: 'setup-candidate-detail' }, [
+                                candidate.exists
+                                    ? `${dom.num(candidate.journal_files_found)} journal file(s)`
+                                    : 'Folder does not exist',
+                                candidate.is_recommended ? ' · recommended' : ''
+                            ])
+                        ]),
+                        el('button', {
+                            className: 'btn btn-sm btn-primary',
+                            disabled: !candidate.exists,
+                            text: 'Use this folder',
+                            on: { click: () => confirmJournalPath(candidate.path) }
+                        })
+                    ]))
+                ]),
+                el('div', { className: 'form-group' }, [
+                    el('label', { attrs: { for: 'setupJournalPath' }, text: 'Or enter the folder yourself' }),
+                    el('input', { id: 'setupJournalPath', attrs: { type: 'text' }, value: data.configured_path || '' })
+                ]),
+                el('button', {
+                    className: 'btn btn-primary',
+                    text: 'Confirm journal folder',
+                    on: { click: () => confirmJournalPath() }
+                })
+            ]);
         } catch (error) {
             console.error('Error loading journal candidates:', error);
-            panel.innerHTML = '<div class="loading">Could not search for journal folders.</div>';
+            replace(panel, el('div', { className: 'loading', text: 'Could not search for journal folders.' }));
         }
     }
 
     async renderAudioDeviceStep(panel) {
-        panel.innerHTML = '<div class="loading">Reading output devices...</div>';
+        const { el, replace } = dom;
+
+        replace(panel, el('div', { className: 'loading', text: 'Reading output devices...' }));
 
         try {
             const response = await fetch('/api/audio/devices');
             const data = await response.json();
             const devices = data.devices || [];
 
-            panel.innerHTML = `
-                <h4>2. Choose your output device</h4>
-                <p class="setup-help">Pick the device your buttkicker amplifier is connected to. The device
-                   endpoint id is saved, so the choice survives devices being plugged in or removed.</p>
-                <div class="setup-candidates">
-                    ${devices.length === 0 ? '<div class="loading">No output devices reported.</div>' : ''}
-                    ${devices.map(device => `
-                        <div class="setup-candidate ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}">
-                            <div>
-                                <div class="setup-candidate-path">${device.name}</div>
-                                <div class="setup-candidate-detail">
-                                    ${device.driver}${device.isDefault ? ' &middot; system default' : ''}
-                                    ${device.isAvailable ? '' : ' &middot; not active'}
-                                </div>
-                            </div>
-                            <button class="btn btn-sm btn-primary" ${device.isAvailable ? '' : 'disabled'}
-                                    onclick="selectSetupAudioDevice(${audioDeviceArgs(device)})">
-                                Use this device
-                            </button>
-                        </div>
-                    `).join('')}
-                </div>
-            `;
+            replace(panel, [
+                el('h4', { text: '2. Choose your output device' }),
+                el('p', {
+                    className: 'setup-help',
+                    text: 'Pick the device your buttkicker amplifier is connected to. The device endpoint id '
+                        + 'is saved, so the choice survives devices being plugged in or removed.'
+                }),
+                el('div', { className: 'setup-candidates' }, [
+                    devices.length === 0
+                        ? el('div', { className: 'loading', text: 'No output devices reported.' })
+                        : null,
+                    ...devices.map(device => el('div', {
+                        className: `setup-candidate ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}`.trim()
+                    }, [
+                        el('div', {}, [
+                            el('div', { className: 'setup-candidate-path', text: device.name }),
+                            el('div', { className: 'setup-candidate-detail' }, [
+                                device.driver,
+                                device.isDefault ? ' · system default' : '',
+                                device.isAvailable ? '' : ' · not active'
+                            ])
+                        ]),
+                        el('button', {
+                            className: 'btn btn-sm btn-primary',
+                            disabled: !device.isAvailable,
+                            text: 'Use this device',
+                            on: { click: () => selectSetupAudioDevice(device.endpointId || '', Number(device.id)) }
+                        })
+                    ]))
+                ])
+            ]);
         } catch (error) {
             console.error('Error loading audio devices:', error);
-            panel.innerHTML = '<div class="loading">Could not read the output devices.</div>';
+            replace(panel, el('div', { className: 'loading', text: 'Could not read the output devices.' }));
         }
     }
 
     renderAudioTestStep(panel) {
+        const { el, replace, icon } = dom;
         const step = (this.setup.steps || []).find(s => s.id === 'audio-test');
 
-        panel.innerHTML = `
-            <h4>3. Run a quiet test</h4>
-            <p class="setup-help">This plays a short, deliberately quiet low-frequency tone so you can set
-               your amplifier gain from silence upwards rather than being surprised at full intensity.</p>
-            <div class="setup-result" id="setupTestResult">${step && step.complete ? step.summary : 'No test has been run yet.'}</div>
-            <button class="btn btn-primary" onclick="runSetupAudioTest()">
-                <i class="fas fa-volume-down"></i> Play test tone
-            </button>
-        `;
+        replace(panel, [
+            el('h4', { text: '3. Run a quiet test' }),
+            el('p', {
+                className: 'setup-help',
+                text: 'This plays a short, deliberately quiet low-frequency tone so you can set your '
+                    + 'amplifier gain from silence upwards rather than being surprised at full intensity.'
+            }),
+            el('div', {
+                className: 'setup-result',
+                id: 'setupTestResult',
+                text: step && step.complete ? step.summary : 'No test has been run yet.'
+            }),
+            el('button', {
+                className: 'btn btn-primary',
+                on: { click: () => runSetupAudioTest() }
+            }, [icon('fa-volume-down'), ' Play test tone'])
+        ]);
     }
 
     renderFinishStep(panel) {
+        const { el, replace, icon } = dom;
         const incomplete = this.setup.incomplete_steps || [];
         const remaining = incomplete.filter(id => id !== 'finish');
 
-        panel.innerHTML = `
-            <h4>4. Finish setup</h4>
-            ${remaining.length > 0 ? `
-                <p class="setup-help">These steps have not been confirmed yet: ${remaining.join(', ')}.
-                   You can still finish - the dashboard will keep showing what is missing.</p>` : `
-                <p class="setup-help">Every step has been confirmed.</p>`}
-            <button class="btn btn-primary" onclick="completeSetup()">
-                <i class="fas fa-check"></i> ${this.setup.completed ? 'Save and close' : 'Finish setup'}
-            </button>
-        `;
+        replace(panel, [
+            el('h4', { text: '4. Finish setup' }),
+            remaining.length > 0
+                ? el('p', { className: 'setup-help' }, [
+                    `These steps have not been confirmed yet: ${remaining.join(', ')}. `,
+                    'You can still finish - the dashboard will keep showing what is missing.'
+                ])
+                : el('p', { className: 'setup-help', text: 'Every step has been confirmed.' }),
+            el('button', {
+                className: 'btn btn-primary',
+                on: { click: () => completeSetup() }
+            }, [icon('fa-check'), ' ', this.setup.completed ? 'Save and close' : 'Finish setup'])
+        ]);
     }
 
     async loadDashboard() {
@@ -405,30 +454,30 @@ class ButtkickerApp {
             const eventsList = document.getElementById('recentEventsList');
             if (!eventsList) return;
 
+            const { el, replace } = dom;
+
             if (!data.events || data.events.length === 0) {
-                eventsList.innerHTML = '<div class="loading">No recent events found</div>';
+                replace(eventsList, el('div', { className: 'loading', text: 'No recent events found' }));
                 return;
             }
 
-            eventsList.innerHTML = data.events.map(event => `
-                <div class="event-item">
-                    <div class="event-info">
-                        <div class="event-type">${event.event}</div>
-                        <div class="event-details">
-                            ${event.star_system ? `System: ${event.star_system}` : ''}
-                            ${event.station_name ? ` | Station: ${event.station_name}` : ''}
-                            ${event.health ? ` | Health: ${Math.round(event.health * 100)}%` : ''}
-                        </div>
-                    </div>
-                    <div class="event-time">${this.formatDateTime(event.timestamp)}</div>
-                </div>
-            `).join('');
+            replace(eventsList, data.events.map(event => el('div', { className: 'event-item' }, [
+                el('div', { className: 'event-info' }, [
+                    el('div', { className: 'event-type', text: event.event }),
+                    el('div', { className: 'event-details' }, [
+                        event.star_system ? `System: ${event.star_system}` : '',
+                        event.station_name ? ` | Station: ${event.station_name}` : '',
+                        event.health ? ` | Health: ${Math.round(dom.num(event.health) * 100)}%` : ''
+                    ])
+                ]),
+                el('div', { className: 'event-time', text: this.formatDateTime(event.timestamp) })
+            ])));
 
         } catch (error) {
             console.error('Error loading recent events:', error);
             const eventsList = document.getElementById('recentEventsList');
             if (eventsList) {
-                eventsList.innerHTML = '<div class="loading">Error loading events</div>';
+                dom.replace(eventsList, dom.el('div', { className: 'loading', text: 'Error loading events' }));
             }
         }
     }
@@ -441,54 +490,45 @@ class ButtkickerApp {
             const patternsGrid = document.getElementById('patternsGrid');
             if (!patternsGrid) return;
 
+            const { el, replace, icon } = dom;
+
             if (!data.patterns) {
-                patternsGrid.innerHTML = '<div class="loading">No patterns found</div>';
+                replace(patternsGrid, el('div', { className: 'loading', text: 'No patterns found' }));
                 return;
             }
 
-            patternsGrid.innerHTML = Object.entries(data.patterns).map(([eventType, pattern]) => `
-                <div class="pattern-card">
-                    <div class="pattern-header">
-                        <div class="pattern-name">${pattern.Pattern.Name}</div>
-                        <div class="pattern-enabled ${pattern.Enabled ? 'active' : ''}" 
-                             onclick="togglePattern('${eventType}')"></div>
-                    </div>
-                    <div class="pattern-details">
-                        <div class="pattern-detail">
-                            <span class="label">Event:</span>
-                            <span>${eventType}</span>
-                        </div>
-                        <div class="pattern-detail">
-                            <span class="label">Type:</span>
-                            <span>${pattern.Pattern.PatternType}</span>
-                        </div>
-                        <div class="pattern-detail">
-                            <span class="label">Frequency:</span>
-                            <span>${pattern.Pattern.Frequency} Hz</span>
-                        </div>
-                        <div class="pattern-detail">
-                            <span class="label">Duration:</span>
-                            <span>${pattern.Pattern.Duration} ms</span>
-                        </div>
-                        <div class="pattern-detail">
-                            <span class="label">Intensity:</span>
-                            <span>${pattern.Pattern.Intensity}%</span>
-                        </div>
-                        <div class="pattern-detail">
-                            <span class="label">Curve:</span>
-                            <span>${pattern.Pattern.IntensityCurve}</span>
-                        </div>
-                    </div>
-                    <div class="pattern-actions">
-                        <button class="btn btn-sm" onclick="testPattern('${eventType}')">
-                            <i class="fas fa-play"></i> Test
-                        </button>
-                        <button class="btn btn-sm btn-secondary" onclick="editPattern('${eventType}')">
-                            <i class="fas fa-edit"></i> Edit
-                        </button>
-                    </div>
-                </div>
-            `).join('');
+            const detail = (label, value) => el('div', { className: 'pattern-detail' }, [
+                el('span', { className: 'label', text: label }),
+                el('span', { text: value })
+            ]);
+
+            replace(patternsGrid, Object.entries(data.patterns).map(([eventType, pattern]) => el('div', { className: 'pattern-card' }, [
+                el('div', { className: 'pattern-header' }, [
+                    el('div', { className: 'pattern-name', text: pattern.Pattern.Name }),
+                    el('div', {
+                        className: `pattern-enabled ${pattern.Enabled ? 'active' : ''}`.trim(),
+                        on: { click: () => togglePattern(eventType) }
+                    })
+                ]),
+                el('div', { className: 'pattern-details' }, [
+                    detail('Event:', eventType),
+                    detail('Type:', pattern.Pattern.PatternType),
+                    detail('Frequency:', `${pattern.Pattern.Frequency} Hz`),
+                    detail('Duration:', `${pattern.Pattern.Duration} ms`),
+                    detail('Intensity:', `${pattern.Pattern.Intensity}%`),
+                    detail('Curve:', pattern.Pattern.IntensityCurve)
+                ]),
+                el('div', { className: 'pattern-actions' }, [
+                    el('button', {
+                        className: 'btn btn-sm',
+                        on: { click: () => testPattern(eventType) }
+                    }, [icon('fa-play'), ' Test']),
+                    el('button', {
+                        className: 'btn btn-sm btn-secondary',
+                        on: { click: () => editPattern(eventType) }
+                    }, [icon('fa-edit'), ' Edit'])
+                ])
+            ])));
 
             // Also update quick test grid if pattern tester is open
             this.updateQuickTestGrid(data.patterns);
@@ -497,17 +537,22 @@ class ButtkickerApp {
             console.error('Error loading patterns:', error);
             const patternsGrid = document.getElementById('patternsGrid');
             if (patternsGrid) {
-                patternsGrid.innerHTML = '<div class="loading">Error loading patterns</div>';
+                dom.replace(patternsGrid, dom.el('div', { className: 'loading', text: 'Error loading patterns' }));
             }
         }
     }
 
     async refreshPatterns() {
+        const { el, replace, icon } = dom;
+
         try {
             // Show loading state
             const patternsGrid = document.getElementById('patternsGrid');
             if (patternsGrid) {
-                patternsGrid.innerHTML = '<div class="loading"><i class="fas fa-sync-alt fa-spin"></i> Refreshing patterns...</div>';
+                replace(patternsGrid, el('div', { className: 'loading' }, [
+                    el('i', { className: 'fas fa-sync-alt fa-spin', attrs: { 'aria-hidden': 'true' } }),
+                    ' Refreshing patterns...'
+                ]));
             }
 
             // Call the reload endpoint first
@@ -523,16 +568,16 @@ class ButtkickerApp {
             
             // Show success message temporarily
             if (patternsGrid) {
-                patternsGrid.innerHTML = `
-                    <div class="refresh-success">
-                        <i class="fas fa-check-circle"></i>
-                        <div>Patterns refreshed successfully!</div>
-                        <div class="refresh-stats">
-                            ${reloadData.totalPacks} total packs loaded
-                            ${reloadData.newPacks > 0 ? `(${reloadData.newPacks} new)` : ''}
-                        </div>
-                    </div>
-                `;
+                const newPacks = dom.num(reloadData.newPacks);
+
+                replace(patternsGrid, el('div', { className: 'refresh-success' }, [
+                    icon('fa-check-circle'),
+                    el('div', { text: 'Patterns refreshed successfully!' }),
+                    el('div', { className: 'refresh-stats' }, [
+                        `${dom.num(reloadData.totalPacks)} total packs loaded`,
+                        newPacks > 0 ? ` (${newPacks} new)` : ''
+                    ])
+                ]));
             }
 
             // Wait a moment to show the success message
@@ -545,14 +590,16 @@ class ButtkickerApp {
             console.error('Error refreshing patterns:', error);
             const patternsGrid = document.getElementById('patternsGrid');
             if (patternsGrid) {
-                patternsGrid.innerHTML = `
-                    <div class="error-message">
-                        <i class="fas fa-exclamation-triangle"></i>
-                        <div>Failed to refresh patterns</div>
-                        <div class="error-details">${error.message}</div>
-                        <button class="btn btn-sm" onclick="app.loadPatterns()">Try Again</button>
-                    </div>
-                `;
+                replace(patternsGrid, el('div', { className: 'error-message' }, [
+                    icon('fa-exclamation-triangle'),
+                    el('div', { text: 'Failed to refresh patterns' }),
+                    el('div', { className: 'error-details', text: error.message }),
+                    el('button', {
+                        className: 'btn btn-sm',
+                        text: 'Try Again',
+                        on: { click: () => app.loadPatterns() }
+                    })
+                ]));
             }
         }
     }
@@ -561,22 +608,23 @@ class ButtkickerApp {
         const quickTestGrid = document.getElementById('quickTestGrid');
         if (!quickTestGrid || !patterns) return;
 
-        quickTestGrid.innerHTML = Object.entries(patterns).map(([eventType, pattern]) => `
-            <div class="quick-test-item">
-                <div class="test-item-header">
-                    <span class="test-item-name">${pattern.Pattern.Name}</span>
-                    <span class="test-item-event">${eventType}</span>
-                </div>
-                <div class="test-item-details">
-                    <span>${pattern.Pattern.Frequency}Hz</span>
-                    <span>${pattern.Pattern.Duration}ms</span>
-                    <span>${pattern.Pattern.Intensity}%</span>
-                </div>
-                <button class="btn btn-sm btn-accent" onclick="testPattern('${eventType}')">
-                    <i class="fas fa-play"></i> Test
-                </button>
-            </div>
-        `).join('');
+        const { el, replace, icon } = dom;
+
+        replace(quickTestGrid, Object.entries(patterns).map(([eventType, pattern]) => el('div', { className: 'quick-test-item' }, [
+            el('div', { className: 'test-item-header' }, [
+                el('span', { className: 'test-item-name', text: pattern.Pattern.Name }),
+                el('span', { className: 'test-item-event', text: eventType })
+            ]),
+            el('div', { className: 'test-item-details' }, [
+                el('span', { text: `${pattern.Pattern.Frequency}Hz` }),
+                el('span', { text: `${pattern.Pattern.Duration}ms` }),
+                el('span', { text: `${pattern.Pattern.Intensity}%` })
+            ]),
+            el('button', {
+                className: 'btn btn-sm btn-accent',
+                on: { click: () => testPattern(eventType) }
+            }, [icon('fa-play'), ' Test'])
+        ])));
     }
 
     async loadAudioConfig() {
@@ -587,33 +635,39 @@ class ButtkickerApp {
             const deviceList = document.getElementById('audioDeviceList');
             if (!deviceList) return;
 
+            const { el, replace } = dom;
+
             if (!data.devices) {
-                deviceList.innerHTML = '<div class="loading">No audio devices found</div>';
+                replace(deviceList, el('div', { className: 'loading', text: 'No audio devices found' }));
                 return;
             }
 
-            deviceList.innerHTML = data.devices.map(device => `
-                <div class="device-item ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}"
-                     onclick="selectAudioDevice(${audioDeviceArgs(device)})">
-                    <div class="device-info">
-                        <div class="device-name">
-                            ${device.name}
-                            ${device.isDefault ? ' (Default)' : ''}
-                        </div>
-                        <div class="device-driver">${device.driver} | ${device.channels} channels</div>
-                    </div>
-                    ${device.isAvailable ? 
-                        '<i class="fas fa-check-circle" style="color: var(--success-color);"></i>' : 
-                        '<i class="fas fa-exclamation-circle" style="color: var(--warning-color);"></i>'
-                    }
-                </div>
-            `).join('');
+            replace(deviceList, data.devices.map(device => el('div', {
+                className: `device-item ${isSelectedAudioDevice(device, data.current) ? 'active' : ''}`.trim(),
+                on: { click: () => selectAudioDevice(device.endpointId || '', Number(device.id)) }
+            }, [
+                el('div', { className: 'device-info' }, [
+                    el('div', { className: 'device-name' }, [
+                        device.name,
+                        device.isDefault ? ' (Default)' : ''
+                    ]),
+                    el('div', { className: 'device-driver' }, [
+                        device.driver,
+                        ` | ${dom.num(device.channels)} channels`
+                    ])
+                ]),
+                el('i', {
+                    className: device.isAvailable ? 'fas fa-check-circle' : 'fas fa-exclamation-circle',
+                    style: { color: device.isAvailable ? 'var(--success-color)' : 'var(--warning-color)' },
+                    attrs: { 'aria-hidden': 'true' }
+                })
+            ])));
 
         } catch (error) {
             console.error('Error loading audio config:', error);
             const deviceList = document.getElementById('audioDeviceList');
             if (deviceList) {
-                deviceList.innerHTML = '<div class="loading">Error loading audio devices</div>';
+                dom.replace(deviceList, dom.el('div', { className: 'loading', text: 'Error loading audio devices' }));
             }
         }
     }
@@ -631,46 +685,40 @@ class ButtkickerApp {
                 journalPathInput.value = data.journal_path || '';
             }
 
+            const { el, replace } = dom;
+            const infoItem = (label, value, valueClass) => el('div', { className: 'info-item' }, [
+                el('span', { className: 'label', text: label }),
+                el('span', { className: valueClass || 'value', text: value })
+            ]);
+
             if (pathInfo) {
-                pathInfo.innerHTML = `
-                    <div class="info-item">
-                        <span class="label">Path Status:</span>
-                        <span class="value ${data.path_exists ? 'online' : ''}">${data.path_exists ? 'Valid' : 'Not Found'}</span>
-                    </div>
-                    <div class="info-item">
-                        <span class="label">Journal Files:</span>
-                        <span class="value">${data.recent_files ? data.recent_files.length : 0} found</span>
-                    </div>
-                    ${data.recent_files && data.recent_files.length > 0 ? `
-                        <div style="margin-top: 1rem;">
-                            <strong>Recent Files:</strong>
-                            <ul style="margin-top: 0.5rem; padding-left: 1rem;">
-                                ${data.recent_files.slice(0, 3).map(file => `<li>${file}</li>`).join('')}
-                            </ul>
-                        </div>
-                    ` : ''}
-                `;
+                const files = data.recent_files || [];
+
+                replace(pathInfo, [
+                    infoItem(
+                        'Path Status:',
+                        data.path_exists ? 'Valid' : 'Not Found',
+                        data.path_exists ? 'value online' : 'value'),
+                    infoItem('Journal Files:', `${files.length} found`),
+                    files.length > 0
+                        ? el('div', { style: { marginTop: '1rem' } }, [
+                            el('strong', { text: 'Recent Files:' }),
+                            el('ul', { style: { marginTop: '0.5rem', paddingLeft: '1rem' } },
+                                files.slice(0, 3).map(file => el('li', { text: file })))
+                        ])
+                        : null
+                ]);
             }
 
             if (monitoringStatus) {
-                monitoringStatus.innerHTML = `
-                    <div class="info-item">
-                        <span class="label">Status:</span>
-                        <span class="value ${data.monitoring ? 'online' : ''}">${data.status}</span>
-                    </div>
-                    <div class="info-item">
-                        <span class="label">Health:</span>
-                        <span class="value">${data.health}</span>
-                    </div>
-                    <div class="info-item">
-                        <span class="label">Events Processed:</span>
-                        <span class="value">${data.events_processed}</span>
-                    </div>
-                    <div class="info-item">
-                        <span class="label">Last Event:</span>
-                        <span class="value">${data.last_event_time ? this.formatDateTime(data.last_event_time) : 'Never'}</span>
-                    </div>
-                `;
+                replace(monitoringStatus, [
+                    infoItem('Status:', data.status, data.monitoring ? 'value online' : 'value'),
+                    infoItem('Health:', data.health),
+                    infoItem('Events Processed:', data.events_processed),
+                    infoItem(
+                        'Last Event:',
+                        data.last_event_time ? this.formatDateTime(data.last_event_time) : 'Never')
+                ]);
             }
             
             // Load initial replay status and journal files
@@ -732,7 +780,7 @@ class ButtkickerApp {
             console.error('Error loading contextual intelligence:', error);
             const contextStatus = document.getElementById('contextStatus');
             if (contextStatus) {
-                contextStatus.innerHTML = '<div class="loading">Error loading context status</div>';
+                dom.replace(contextStatus, dom.el('div', { className: 'loading', text: 'Error loading context status' }));
             }
         }
     }
@@ -741,130 +789,100 @@ class ButtkickerApp {
         const contextStatus = document.getElementById('contextStatus');
         if (!contextStatus) return;
 
-        contextStatus.innerHTML = `
-            <div class="context-grid">
-                <div class="context-item">
-                    <span class="context-label">Game State:</span>
-                    <span class="context-value ${context.game_state.toLowerCase()}">${context.game_state}</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Current System:</span>
-                    <span class="context-value">${context.current_system || 'Unknown'}</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Threat Level:</span>
-                    <span class="context-value threat-${context.threat_level.toLowerCase()}">${context.threat_level}</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Hull Integrity:</span>
-                    <span class="context-value ${context.hull_integrity < 0.5 ? 'warning' : ''}">${Math.round(context.hull_integrity * 100)}%</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Shield Strength:</span>
-                    <span class="context-value">${Math.round(context.shield_strength * 100)}%</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Combat Intensity:</span>
-                    <span class="context-value">${Math.round(context.combat_intensity * 100)}%</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Exploration Mode:</span>
-                    <span class="context-value">${context.exploration_mode}</span>
-                </div>
-                <div class="context-item">
-                    <span class="context-label">Intensity Multiplier:</span>
-                    <span class="context-value">${context.intensity_multiplier.toFixed(2)}x</span>
-                </div>
-            </div>
-        `;
+        const { el, replace, num, slug } = dom;
+
+        // The state words also drive CSS classes, so they go through slug() - the visible copy is
+        // still whatever the API said, as text.
+        const item = (label, value, valueClass) => el('div', { className: 'context-item' }, [
+            el('span', { className: 'context-label', text: label }),
+            el('span', { className: valueClass || 'context-value', text: value })
+        ]);
+
+        replace(contextStatus, el('div', { className: 'context-grid' }, [
+            item('Game State:', context.game_state, `context-value ${slug(context.game_state)}`.trim()),
+            item('Current System:', context.current_system || 'Unknown'),
+            item('Threat Level:', context.threat_level, `context-value threat-${slug(context.threat_level)}`),
+            item(
+                'Hull Integrity:',
+                `${Math.round(num(context.hull_integrity) * 100)}%`,
+                num(context.hull_integrity) < 0.5 ? 'context-value warning' : 'context-value'),
+            item('Shield Strength:', `${Math.round(num(context.shield_strength) * 100)}%`),
+            item('Combat Intensity:', `${Math.round(num(context.combat_intensity) * 100)}%`),
+            item('Exploration Mode:', context.exploration_mode),
+            item('Intensity Multiplier:', `${num(context.intensity_multiplier).toFixed(2)}x`)
+        ]));
     }
 
     updateBehaviorAnalysis(context, statistics) {
         const behaviorAnalysis = document.getElementById('behaviorAnalysis');
         if (!behaviorAnalysis) return;
 
-        behaviorAnalysis.innerHTML = `
-            <div class="behavior-grid">
-                <div class="behavior-section">
-                    <h4>Player Traits</h4>
-                    <div class="trait-item">
-                        <span class="trait-label">Aggressiveness:</span>
-                        <div class="trait-bar">
-                            <div class="trait-fill" style="width: ${context.player_aggressiveness * 100}%"></div>
-                        </div>
-                        <span class="trait-value">${Math.round(context.player_aggressiveness * 100)}%</span>
-                    </div>
-                    <div class="trait-item">
-                        <span class="trait-label">Cautiousness:</span>
-                        <div class="trait-bar">
-                            <div class="trait-fill cautious" style="width: ${context.player_cautiousness * 100}%"></div>
-                        </div>
-                        <span class="trait-value">${Math.round(context.player_cautiousness * 100)}%</span>
-                    </div>
-                </div>
-                
-                <div class="behavior-section">
-                    <h4>Activity Statistics</h4>
-                    <div class="stat-item">
-                        <span class="stat-label">Systems Visited:</span>
-                        <span class="stat-value">${statistics.systems_visited}</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-label">Bodies Scanned:</span>
-                        <span class="stat-value">${statistics.bodies_scanned}</span>
-                    </div>
-                    <div class="stat-item">
-                        <span class="stat-label">Recent Events:</span>
-                        <span class="stat-value">${statistics.recent_event_types.join(', ')}</span>
-                    </div>
-                </div>
+        const { el, replace, num } = dom;
 
-                <div class="behavior-section">
-                    <h4>Time Distribution</h4>
-                    <div class="time-distribution">
-                        ${statistics.state_time_spent.map(state => `
-                            <div class="time-item">
-                                <span class="time-label">${state.state}:</span>
-                                <span class="time-value">${Math.round(state.time_minutes)} min</span>
-                            </div>
-                        `).join('')}
-                    </div>
-                </div>
-            </div>
-        `;
+        // Percentages are the only values that reach a style, so they are clamped to a number - a
+        // string payload can never land inside the width declaration.
+        const trait = (label, value, fillClass) => el('div', { className: 'trait-item' }, [
+            el('span', { className: 'trait-label', text: label }),
+            el('div', { className: 'trait-bar' }, [
+                el('div', { className: fillClass, style: { width: `${num(value) * 100}%` } })
+            ]),
+            el('span', { className: 'trait-value', text: `${Math.round(num(value) * 100)}%` })
+        ]);
+
+        const stat = (label, value) => el('div', { className: 'stat-item' }, [
+            el('span', { className: 'stat-label', text: label }),
+            el('span', { className: 'stat-value', text: value })
+        ]);
+
+        replace(behaviorAnalysis, el('div', { className: 'behavior-grid' }, [
+            el('div', { className: 'behavior-section' }, [
+                el('h4', { text: 'Player Traits' }),
+                trait('Aggressiveness:', context.player_aggressiveness, 'trait-fill'),
+                trait('Cautiousness:', context.player_cautiousness, 'trait-fill cautious')
+            ]),
+            el('div', { className: 'behavior-section' }, [
+                el('h4', { text: 'Activity Statistics' }),
+                stat('Systems Visited:', statistics.systems_visited),
+                stat('Bodies Scanned:', statistics.bodies_scanned),
+                stat('Recent Events:', (statistics.recent_event_types || []).join(', '))
+            ]),
+            el('div', { className: 'behavior-section' }, [
+                el('h4', { text: 'Time Distribution' }),
+                el('div', { className: 'time-distribution' },
+                    (statistics.state_time_spent || []).map(state => el('div', { className: 'time-item' }, [
+                        el('span', { className: 'time-label', text: `${state.state}:` }),
+                        el('span', { className: 'time-value', text: `${Math.round(num(state.time_minutes))} min` })
+                    ])))
+            ])
+        ]));
     }
 
     updatePredictions(predictions) {
         const predictionsDiv = document.getElementById('predictions');
         if (!predictionsDiv) return;
 
-        predictionsDiv.innerHTML = `
-            <div class="predictions-grid">
-                <div class="prediction-section">
-                    <h4>Next State Prediction</h4>
-                    <div class="prediction-item">
-                        <span class="prediction-label">Predicted State:</span>
-                        <span class="prediction-value">${predictions.predicted_next_state || 'None'}</span>
-                    </div>
-                    <div class="prediction-item">
-                        <span class="prediction-label">Confidence:</span>
-                        <span class="prediction-value">${Math.round(predictions.prediction_confidence * 100)}%</span>
-                    </div>
-                </div>
+        const { el, replace, num } = dom;
+        const upcoming = predictions.likely_upcoming_events || [];
 
-                <div class="prediction-section">
-                    <h4>Likely Upcoming Events</h4>
-                    <div class="events-list">
-                        ${predictions.likely_upcoming_events && predictions.likely_upcoming_events.length > 0 
-                            ? predictions.likely_upcoming_events.map(event => `
-                                <div class="event-prediction">${event}</div>
-                            `).join('')
-                            : '<div class="no-predictions">No predictions available</div>'
-                        }
-                    </div>
-                </div>
-            </div>
-        `;
+        const item = (label, value) => el('div', { className: 'prediction-item' }, [
+            el('span', { className: 'prediction-label', text: label }),
+            el('span', { className: 'prediction-value', text: value })
+        ]);
+
+        replace(predictionsDiv, el('div', { className: 'predictions-grid' }, [
+            el('div', { className: 'prediction-section' }, [
+                el('h4', { text: 'Next State Prediction' }),
+                item('Predicted State:', predictions.predicted_next_state || 'None'),
+                item('Confidence:', `${Math.round(num(predictions.prediction_confidence) * 100)}%`)
+            ]),
+            el('div', { className: 'prediction-section' }, [
+                el('h4', { text: 'Likely Upcoming Events' }),
+                el('div', { className: 'events-list' },
+                    upcoming.length > 0
+                        ? upcoming.map(event => el('div', { className: 'event-prediction', text: event }))
+                        : el('div', { className: 'no-predictions', text: 'No predictions available' }))
+            ])
+        ]));
     }
 
     async loadSettings() {
@@ -890,12 +908,13 @@ class ButtkickerApp {
         const toastContainer = document.getElementById('toastContainer');
         const toast = document.createElement('div');
         toast.className = `toast ${type}`;
-        toast.innerHTML = `
-            <div style="display: flex; align-items: center; gap: 0.5rem;">
-                <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}"></i>
-                ${message}
-            </div>
-        `;
+        // Toast text is frequently an error string straight off the API - shown, never parsed.
+        dom.append(toast, dom.el('div', {
+            style: { display: 'flex', alignItems: 'center', gap: '0.5rem' }
+        }, [
+            dom.icon(type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'),
+            message
+        ]));
 
         toastContainer.appendChild(toast);
 
@@ -1250,39 +1269,48 @@ window.updatePatternTypeOptions = () => {
 window.addLayer = () => {
     const layerControls = document.getElementById('layerControls');
     if (!layerControls) return;
-    
+
+    const { el } = dom;
     const layerIndex = layerControls.children.length;
-    const layerDiv = document.createElement('div');
-    layerDiv.className = 'layer-control';
-    layerDiv.innerHTML = `
-        <div class="layer-header">
-            <h6>Layer ${layerIndex + 1}</h6>
-            <button type="button" class="btn-remove" onclick="removeLayer(this)">&times;</button>
-        </div>
-        <div class="layer-params">
-            <div class="form-group">
-                <label>Waveform</label>
-                <select class="layer-waveform">
-                    <option value="Sine">Sine</option>
-                    <option value="Square">Square</option>
-                    <option value="Triangle">Triangle</option>
-                    <option value="Sawtooth">Sawtooth</option>
-                    <option value="Noise">Noise</option>
-                </select>
-            </div>
-            <div class="form-group">
-                <label>Frequency (Hz)</label>
-                <input type="range" class="layer-frequency" min="20" max="80" value="40" oninput="updateRangeDisplay(this)">
-                <span class="range-value">40</span>
-            </div>
-            <div class="form-group">
-                <label>Amplitude</label>
-                <input type="range" class="layer-amplitude" min="0.1" max="1.0" step="0.1" value="0.8" oninput="updateRangeDisplay(this)">
-                <span class="range-value">0.8</span>
-            </div>
-        </div>
-    `;
-    
+
+    // The range inputs are wired here rather than through an inline oninput, which the CSP blocks.
+    const range = (className, attrs, initial) => {
+        const input = el('input', { className, attrs: { type: 'range', ...attrs }, value: initial });
+        const display = el('span', { className: 'range-value', text: initial });
+
+        input.addEventListener('input', () => { display.textContent = input.value; });
+
+        return [input, display];
+    };
+
+    const layerDiv = el('div', { className: 'layer-control' }, [
+        el('div', { className: 'layer-header' }, [
+            el('h6', { text: `Layer ${layerIndex + 1}` }),
+            el('button', {
+                className: 'btn-remove',
+                attrs: { type: 'button' },
+                text: '\u00d7',
+                on: { click: (event) => removeLayer(event.currentTarget) }
+            })
+        ]),
+        el('div', { className: 'layer-params' }, [
+            el('div', { className: 'form-group' }, [
+                el('label', { text: 'Waveform' }),
+                el('select', { className: 'layer-waveform' },
+                    ['Sine', 'Square', 'Triangle', 'Sawtooth', 'Noise']
+                        .map(waveform => el('option', { attrs: { value: waveform }, text: waveform })))
+            ]),
+            el('div', { className: 'form-group' }, [
+                el('label', { text: 'Frequency (Hz)' }),
+                ...range('layer-frequency', { min: '20', max: '80' }, '40')
+            ]),
+            el('div', { className: 'form-group' }, [
+                el('label', { text: 'Amplitude' }),
+                ...range('layer-amplitude', { min: '0.1', max: '1.0', step: '0.1' }, '0.8')
+            ])
+        ])
+    ]);
+
     layerControls.appendChild(layerDiv);
 };
 
@@ -1374,7 +1402,7 @@ window.resetPatternTester = () => {
     // Clear multi-layer controls
     const layerControls = document.getElementById('layerControls');
     if (layerControls) {
-        layerControls.innerHTML = '';
+        dom.clear(layerControls);
     }
     
     // Hide multi-layer controls
@@ -1484,7 +1512,7 @@ function updateReplayUI(isReplaying) {
     
     if (startBtn) {
         startBtn.disabled = isReplaying;
-        startBtn.innerHTML = isReplaying ? '<i class="fas fa-play"></i> Running...' : '<i class="fas fa-play"></i> Start Replay';
+        dom.replace(startBtn, [dom.icon('fa-play'), isReplaying ? ' Running...' : ' Start Replay']);
     }
     
     if (stopBtn) {
@@ -1517,7 +1545,7 @@ window.refreshJournalFiles = async () => {
             
             if (journalFileSelect && status.recent_files) {
                 // Clear existing options
-                journalFileSelect.innerHTML = '';
+                dom.clear(journalFileSelect);
                 
                 // Add default option
                 const defaultOption = document.createElement('option');
@@ -1546,7 +1574,10 @@ window.refreshJournalFiles = async () => {
         console.error('Error refreshing journal files:', error);
         const journalFileSelect = document.getElementById('journalFileSelect');
         if (journalFileSelect) {
-            journalFileSelect.innerHTML = '<option value="">Error loading journal files</option>';
+            dom.replace(journalFileSelect, dom.el('option', {
+                attrs: { value: '' },
+                text: 'Error loading journal files'
+            }));
         }
     }
 };

--- a/src/EDButtkicker/wwwroot/js/dom.js
+++ b/src/EDButtkicker/wwwroot/js/dom.js
@@ -1,0 +1,133 @@
+// Shared DOM construction helpers.
+//
+// Everything the local API hands back - journal event fields, pattern and pack metadata, audio
+// device names, folder paths, context strings, error messages - is data this application does not
+// author. None of it is concatenated into markup: it is written as text nodes and attribute values
+// so that a value like `<img src=x onerror=alert(1)>` stays a visible string instead of becoming an
+// element. Markup is only ever built from literals in this file's callers, via el()/append().
+//
+// The page's Content-Security-Policy allows no inline script, so handlers are attached with
+// addEventListener - either directly by a renderer, or by bindActions() for the static markup.
+(function (global) {
+    'use strict';
+
+    /// A child may be a node, or any value to be shown verbatim as text. null/undefined/false are
+    /// skipped so callers can write `condition && node` inline.
+    function append(parent, children) {
+        if (children === null || children === undefined || children === false) return parent;
+
+        const list = Array.isArray(children) ? children : [children];
+        list.forEach(child => {
+            if (child === null || child === undefined || child === false || child === '') return;
+            parent.appendChild(child.nodeType ? child : document.createTextNode(String(child)));
+        });
+
+        return parent;
+    }
+
+    /// el('div', { className, id, text, title, value, disabled, attrs, dataset, style, on }, children)
+    /// `text` and every child are set as text, never parsed; `attrs`/`dataset` go through
+    /// setAttribute, so a payload cannot break out into a new attribute either.
+    function el(tag, options, children) {
+        const node = document.createElement(tag);
+        const opts = options || {};
+
+        if (opts.className) node.className = opts.className;
+        if (opts.id) node.id = opts.id;
+        if (opts.title !== undefined && opts.title !== null) node.title = String(opts.title);
+        if (opts.text !== undefined && opts.text !== null) node.textContent = String(opts.text);
+        if (opts.value !== undefined && opts.value !== null) node.value = String(opts.value);
+        if (opts.disabled) node.disabled = true;
+
+        if (opts.attrs) {
+            Object.keys(opts.attrs).forEach(name => {
+                const value = opts.attrs[name];
+                if (value === null || value === undefined || value === false) return;
+                node.setAttribute(name, String(value));
+            });
+        }
+
+        if (opts.dataset) {
+            Object.keys(opts.dataset).forEach(name => {
+                const value = opts.dataset[name];
+                if (value === null || value === undefined || value === false) return;
+                node.setAttribute('data-' + name, String(value));
+            });
+        }
+
+        if (opts.style) {
+            Object.keys(opts.style).forEach(name => { node.style[name] = opts.style[name]; });
+        }
+
+        if (opts.on) {
+            Object.keys(opts.on).forEach(name => node.addEventListener(name, opts.on[name]));
+        }
+
+        return append(node, children);
+    }
+
+    function clear(node) {
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+        return node;
+    }
+
+    /// The one safe equivalent of `node.innerHTML = ...`: drop what is there, append new nodes.
+    function replace(node, children) {
+        return append(clear(node), children);
+    }
+
+    /// Decorative Font Awesome glyph. The class always comes from a literal at the call site.
+    function icon(className) {
+        return el('i', { className: 'fas ' + className, attrs: { 'aria-hidden': 'true' } });
+    }
+
+    /// Status words from the API also drive CSS class names. Reduce them to a harmless slug so an
+    /// unexpected value cannot smuggle extra classes - or anything else - into the attribute.
+    function slug(value) {
+        return String(value === null || value === undefined ? '' : value)
+            .toLowerCase()
+            .replace(/[^a-z0-9_-]/g, '');
+    }
+
+    /// Numbers from the API are shown as numbers; a non-numeric payload becomes the fallback.
+    function num(value, fallback) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : (fallback === undefined ? 0 : fallback);
+    }
+
+    /// Static markup declares `data-bind="someGlobalFunction"` (optionally `data-bind-args` as a
+    /// JSON array and `data-bind-event`) instead of an inline `onclick`, which the CSP blocks. The
+    /// name is looked up on `window` when the event fires, never evaluated as code.
+    function bindActions(root) {
+        (root || document).querySelectorAll('[data-bind]').forEach(node => {
+            const eventName = node.getAttribute('data-bind-event') || 'click';
+            node.addEventListener(eventName, () => invokeBinding(node));
+        });
+    }
+
+    function invokeBinding(node) {
+        const path = node.getAttribute('data-bind').split('.');
+        let owner = global;
+        let target = global;
+
+        for (const part of path) {
+            if (target === null || target === undefined) break;
+            owner = target;
+            target = target[part];
+        }
+
+        if (typeof target !== 'function') {
+            console.error('No handler named', node.getAttribute('data-bind'));
+            return;
+        }
+
+        const raw = node.getAttribute('data-bind-args');
+        target.apply(owner, raw ? JSON.parse(raw) : []);
+    }
+
+    global.dom = { el, append, clear, replace, icon, slug, num, bindActions };
+
+    document.addEventListener('DOMContentLoaded', () => bindActions(document));
+})(window);

--- a/src/EDButtkicker/wwwroot/js/pattern-conflicts.js
+++ b/src/EDButtkicker/wwwroot/js/pattern-conflicts.js
@@ -1,3 +1,8 @@
+// Pattern source names, pack names and authors come from files this application did not write, so
+// every one of them is rendered as a text node via dom.el/dom.replace rather than concatenated into
+// markup. See js/dom.js.
+const { el, replace, icon, slug, num } = window.dom;
+
 class PatternConflictsManager {
     constructor() {
         this.conflictData = null;
@@ -56,121 +61,103 @@ class PatternConflictsManager {
     renderStats() {
         if (!this.stats) return;
 
-        const statsCard = document.getElementById('statsCard');
-        statsCard.innerHTML = `
-            <div class="stat-item">
-                <span class="stat-label">Total Ship/Event Combinations</span>
-                <span class="stat-value">${this.stats.totalShipEventCombinations}</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-label">Available Patterns</span>
-                <span class="stat-value">${this.stats.totalAvailablePatterns}</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-label">Conflicting Combinations</span>
-                <span class="stat-value">${this.stats.conflictingCombinations}</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-label">File System Patterns</span>
-                <span class="stat-value">${this.stats.fileSystemPatterns}</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-label">User Custom Patterns</span>
-                <span class="stat-value">${this.stats.userCustomPatterns}</span>
-            </div>
-            <div class="stat-item">
-                <span class="stat-label">Default Patterns</span>
-                <span class="stat-value">${this.stats.defaultPatterns}</span>
-            </div>
-        `;
+        const rows = [
+            ['Total Ship/Event Combinations', this.stats.totalShipEventCombinations],
+            ['Available Patterns', this.stats.totalAvailablePatterns],
+            ['Conflicting Combinations', this.stats.conflictingCombinations],
+            ['File System Patterns', this.stats.fileSystemPatterns],
+            ['User Custom Patterns', this.stats.userCustomPatterns],
+            ['Default Patterns', this.stats.defaultPatterns]
+        ];
+
+        replace(document.getElementById('statsCard'), rows.map(([label, value]) => el('div', { className: 'stat-item' }, [
+            el('span', { className: 'stat-label', text: label }),
+            el('span', { className: 'stat-value', text: num(value) })
+        ])));
     }
 
     renderConflicts() {
         const conflictsList = document.getElementById('conflictsList');
         
         if (!this.conflictData || this.conflictData.conflicts.length === 0) {
-            conflictsList.innerHTML = `
-                <div class="no-conflicts">
-                    <i class="fas fa-check-circle"></i>
-                    <h3>No Pattern Conflicts</h3>
-                    <p>All ship/event combinations have been resolved or only have one pattern available.</p>
-                </div>
-            `;
+            replace(conflictsList, el('div', { className: 'no-conflicts' }, [
+                icon('fa-check-circle'),
+                el('h3', { text: 'No Pattern Conflicts' }),
+                el('p', { text: 'All ship/event combinations have been resolved or only have one pattern available.' })
+            ]));
             return;
         }
 
-        const conflictsHtml = this.conflictData.conflicts.map(conflict => 
-            this.renderConflictCard(conflict)
-        ).join('');
-        
-        conflictsList.innerHTML = conflictsHtml;
-        this.attachConflictHandlers();
+        replace(conflictsList, this.conflictData.conflicts.map(conflict => this.renderConflictCard(conflict)));
     }
 
     renderConflictCard(conflict) {
         const activePatternId = conflict.activePattern?.sourceId || '';
-        
-        return `
-            <div class="conflict-card has-conflicts" data-ship-type="${conflict.shipType}" data-event="${conflict.eventName}">
-                <div class="conflict-header">
-                    <div class="conflict-title">${conflict.shipType} - ${conflict.eventName}</div>
-                    <div class="conflict-subtitle">
-                        <span class="conflict-badge">${conflict.conflictCount} patterns available</span>
-                    </div>
-                </div>
-                <div class="conflict-body">
-                    <div class="pattern-options">
-                        ${conflict.availablePatterns.map(pattern => `
-                            <div class="pattern-option ${pattern.sourceId === activePatternId ? 'active' : ''}" 
-                                 data-source-id="${pattern.sourceId}">
-                                <input type="radio" name="pattern_${conflict.shipType}_${conflict.eventName}" 
-                                       value="${pattern.sourceId}" ${pattern.sourceId === activePatternId ? 'checked' : ''}>
-                                <div class="pattern-info">
-                                    <div class="pattern-name">${pattern.sourceName}</div>
-                                    <div class="pattern-details">
-                                        <span>Type: ${pattern.patternType}</span>
-                                        <span>Freq: ${pattern.frequency}Hz</span>
-                                        <span>Int: ${pattern.intensity}%</span>
-                                        <span>Dur: ${pattern.duration}ms</span>
-                                    </div>
-                                    <div class="pattern-meta">
-                                        <span class="source-type-badge source-type-${pattern.sourceType.toLowerCase()}">${pattern.sourceType}</span>
-                                        ${pattern.packName ? `<span>Pack: ${pattern.packName}</span>` : ''}
-                                        ${pattern.author ? `<span>Author: ${pattern.author}</span>` : ''}
-                                        ${pattern.version ? `<span>v${pattern.version}</span>` : ''}
-                                    </div>
-                                </div>
-                            </div>
-                        `).join('')}
-                    </div>
-                </div>
-            </div>
-        `;
+        const groupName = `pattern_${conflict.shipType}_${conflict.eventName}`;
+
+        const card = el('div', {
+            className: 'conflict-card has-conflicts',
+            dataset: { 'ship-type': conflict.shipType, event: conflict.eventName }
+        }, [
+            el('div', { className: 'conflict-header' }, [
+                el('div', { className: 'conflict-title' }, [conflict.shipType, ' - ', conflict.eventName]),
+                el('div', { className: 'conflict-subtitle' },
+                    el('span', { className: 'conflict-badge' }, [num(conflict.conflictCount), ' patterns available']))
+            ]),
+            el('div', { className: 'conflict-body' },
+                el('div', { className: 'pattern-options' },
+                    (conflict.availablePatterns || []).map(pattern =>
+                        this.renderPatternOption(pattern, groupName, activePatternId))))
+        ]);
+
+        return card;
     }
 
-    attachConflictHandlers() {
-        // Attach click handlers to pattern options
-        document.querySelectorAll('.pattern-option').forEach(option => {
-            option.addEventListener('click', (e) => {
-                if (e.target.type === 'radio') return; // Let radio handle itself
-                
-                const radio = option.querySelector('input[type="radio"]');
-                if (radio) {
-                    radio.checked = true;
-                    this.selectPattern(option);
-                }
-            });
+    renderPatternOption(pattern, groupName, activePatternId) {
+        const isActive = pattern.sourceId === activePatternId;
+
+        const radio = el('input', {
+            className: 'pattern-radio',
+            attrs: { type: 'radio', name: groupName, value: pattern.sourceId }
+        });
+        radio.checked = isActive;
+
+        const option = el('div', {
+            className: 'pattern-option' + (isActive ? ' active' : ''),
+            dataset: { 'source-id': pattern.sourceId }
+        }, [
+            radio,
+            el('div', { className: 'pattern-info' }, [
+                el('div', { className: 'pattern-name', text: pattern.sourceName }),
+                el('div', { className: 'pattern-details' }, [
+                    el('span', {}, ['Type: ', pattern.patternType]),
+                    el('span', {}, ['Freq: ', num(pattern.frequency), 'Hz']),
+                    el('span', {}, ['Int: ', num(pattern.intensity), '%']),
+                    el('span', {}, ['Dur: ', num(pattern.duration), 'ms'])
+                ]),
+                el('div', { className: 'pattern-meta' }, [
+                    el('span', {
+                        className: 'source-type-badge source-type-' + slug(pattern.sourceType),
+                        text: pattern.sourceType
+                    }),
+                    pattern.packName && el('span', {}, ['Pack: ', pattern.packName]),
+                    pattern.author && el('span', {}, ['Author: ', pattern.author]),
+                    pattern.version && el('span', {}, ['v', pattern.version])
+                ])
+            ])
+        ]);
+
+        option.addEventListener('click', e => {
+            if (e.target === radio) return; // Let the radio's own change event handle it.
+            radio.checked = true;
+            this.selectPattern(option);
         });
 
-        // Attach change handlers to radio buttons
-        document.querySelectorAll('input[type="radio"]').forEach(radio => {
-            radio.addEventListener('change', (e) => {
-                if (e.target.checked) {
-                    const option = e.target.closest('.pattern-option');
-                    this.selectPattern(option);
-                }
-            });
+        radio.addEventListener('change', () => {
+            if (radio.checked) this.selectPattern(option);
         });
+
+        return option;
     }
 
     async selectPattern(optionElement) {
@@ -245,7 +232,7 @@ class PatternConflictsManager {
         try {
             const autoResolveBtn = document.getElementById('autoResolveBtn');
             autoResolveBtn.disabled = true;
-            autoResolveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Resolving...';
+            replace(autoResolveBtn, [icon('fa-spinner fa-spin'), ' Resolving...']);
 
             const response = await fetch('/api/patternselection/auto-resolve', {
                 method: 'POST',
@@ -306,14 +293,11 @@ class PatternConflictsManager {
 
     showNotification(message, type) {
         // Create notification element
-        const notification = document.createElement('div');
-        notification.className = `notification notification-${type}`;
-        notification.innerHTML = `
-            <div class="notification-content">
-                <i class="fas ${type === 'success' ? 'fa-check-circle' : 'fa-exclamation-circle'}"></i>
-                <span>${message}</span>
-            </div>
-        `;
+        const notification = el('div', { className: `notification notification-${slug(type)}` },
+            el('div', { className: 'notification-content' }, [
+                icon(type === 'success' ? 'fa-check-circle' : 'fa-exclamation-circle'),
+                el('span', { text: message })
+            ]));
 
         // Add to page
         document.body.appendChild(notification);

--- a/src/EDButtkicker/wwwroot/js/pattern-editor.js
+++ b/src/EDButtkicker/wwwroot/js/pattern-editor.js
@@ -1,4 +1,10 @@
 // Pattern Editor Wizard JavaScript
+//
+// Ship names, event types, template names and pattern pack metadata all arrive from the API, which
+// reads them off disk. None of them is concatenated into markup: nodes are built with dom.el and
+// handlers are attached with addEventListener, since the page's CSP allows no inline script. See
+// js/dom.js.
+const { el, replace, clear, icon, num } = window.dom;
 
 // Helper function for formatting server errors
 async function formatServerError(response) {
@@ -568,24 +574,26 @@ class PatternWizard {
 
     displayValidationResults(container, errors) {
         if (errors.length === 0) {
-            container.innerHTML = `
-                <div class="validation-success">
-                    <i class="fas fa-check-circle"></i>
-                    All advanced patterns are valid and ready to save.
-                </div>
-            `;
-            container.style.display = 'block';
+            replace(container, el('div', { className: 'validation-success' }, [
+                icon('fa-check-circle'),
+                ' All advanced patterns are valid and ready to save.'
+            ]));
         } else {
-            container.innerHTML = `
-                <h4>Pattern Validation Errors:</h4>
-                ${errors.map(error => `<div class="validation-error"><i class="fas fa-exclamation-triangle"></i> ${error}</div>`).join('')}
-                <div class="validation-help">
-                    <i class="fas fa-info-circle"></i>
-                    Please fix these issues before proceeding. Switch between events using the dropdown above to edit each pattern.
-                </div>
-            `;
-            container.style.display = 'block';
+            replace(container, [
+                el('h4', { text: 'Pattern Validation Errors:' }),
+                ...errors.map(error => el('div', { className: 'validation-error' }, [
+                    icon('fa-exclamation-triangle'),
+                    ' ',
+                    error
+                ])),
+                el('div', { className: 'validation-help' }, [
+                    icon('fa-info-circle'),
+                    ' Please fix these issues before proceeding. Switch between events using the dropdown above to edit each pattern.'
+                ])
+            ]);
         }
+
+        container.style.display = 'block';
     }
 
     // Mode toggle functionality
@@ -617,7 +625,7 @@ class PatternWizard {
     hideFileSelection() {
         document.getElementById('fileSelectionSection').style.display = 'none';
         document.getElementById('fileListContainer').style.display = 'none';
-        document.getElementById('userFilesList').innerHTML = '';
+        clear(document.getElementById('userFilesList'));
     }
 
     showShipSelection() {
@@ -660,11 +668,14 @@ class PatternWizard {
         const container = document.getElementById('userFilesList');
 
         if (!files || files.length === 0) {
-            container.innerHTML = '<div style="padding: 1rem; text-align: center; color: var(--text-secondary);">No pattern files found for this user.</div>';
+            replace(container, el('div', {
+                style: { padding: '1rem', textAlign: 'center', color: 'var(--text-secondary)' },
+                text: 'No pattern files found for this user.'
+            }));
             return;
         }
 
-        container.innerHTML = files.map(file => this.renderFileItem(file)).join('');
+        replace(container, files.map(file => this.renderFileItem(file)));
     }
 
     // Render individual file item
@@ -673,15 +684,16 @@ class PatternWizard {
         const shipCount = file.shipCount || 'Unknown';
         const title = file.packName || file.fileName;
 
-        return `
-            <div class="file-item" onclick="wizard.selectPatternFile('${file.fileName}')">
-                <div class="file-name">${title}</div>
-                <div class="file-details">
-                    Ships: ${shipCount} | Modified: ${lastModified}
-                    ${file.description ? ` | ${file.description}` : ''}
-                </div>
-            </div>
-        `;
+        return el('div', {
+            className: 'file-item',
+            on: { click: () => this.selectPatternFile(file.fileName) }
+        }, [
+            el('div', { className: 'file-name', text: title }),
+            el('div', { className: 'file-details' }, [
+                'Ships: ', shipCount, ' | Modified: ', lastModified,
+                file.description ? ` | ${file.description}` : ''
+            ])
+        ]);
     }
 
     // Load selected pattern file
@@ -800,13 +812,13 @@ class PatternWizard {
                 return a.name.localeCompare(b.name);
             });
 
-            grid.innerHTML = ships.map(ship => `
-                <div class="ship-card ${this.selectedShip === ship.type ? 'selected' : ''}"
-                     onclick="wizard.selectShip('${ship.type}')">
-                    <div class="ship-name">${ship.name}</div>
-                    <div class="ship-class">${ship.class.charAt(0).toUpperCase() + ship.class.slice(1)} Ship</div>
-                </div>
-            `).join('');
+            replace(grid, ships.map(ship => el('div', {
+                className: 'ship-card' + (this.selectedShip === ship.type ? ' selected' : ''),
+                on: { click: () => this.selectShip(ship.type) }
+            }, [
+                el('div', { className: 'ship-name', text: ship.name }),
+                el('div', { className: 'ship-class' }, [ship.class.charAt(0).toUpperCase() + ship.class.slice(1), ' Ship'])
+            ])));
         }
 
         this.updateStep1NextButton();
@@ -885,16 +897,16 @@ class PatternWizard {
                 ...this.eventDefinitions[eventType]
             }));
 
-        container.innerHTML = events.map(event => `
-            <div class="event-card ${this.selectedEvents.includes(event.type) ? 'selected' : ''}" 
-                 onclick="wizard.toggleEvent('${event.type}')">
-                <div class="event-title">
-                    <span>${event.icon}</span>
-                    <span>${event.title}</span>
-                </div>
-                <div class="event-description">${event.description}</div>
-            </div>
-        `).join('');
+        replace(container, events.map(event => el('div', {
+            className: 'event-card' + (this.selectedEvents.includes(event.type) ? ' selected' : ''),
+            on: { click: () => this.toggleEvent(event.type) }
+        }, [
+            el('div', { className: 'event-title' }, [
+                el('span', { text: event.icon }),
+                el('span', { text: event.title })
+            ]),
+            el('div', { className: 'event-description', text: event.description })
+        ])));
     }
 
     toggleEvent(eventType) {
@@ -917,36 +929,37 @@ class PatternWizard {
     renderStep3() {
         const container = document.getElementById('selectedEventsList');
         
-        container.innerHTML = this.selectedEvents.map(eventType => {
+        replace(container, this.selectedEvents.map(eventType => {
             const event = this.eventDefinitions[eventType];
-            return `
-                <div class="event-pattern-section">
-                    <div class="event-pattern-header">
-                        <div class="event-pattern-title">
-                            ${event.icon} ${event.title}
-                        </div>
-                    </div>
-                    <div class="pattern-templates">
-                        ${this.renderPatternTemplates(eventType)}
-                    </div>
-                </div>
-            `;
-        }).join('');
+            return el('div', { className: 'event-pattern-section' }, [
+                el('div', { className: 'event-pattern-header' }, [
+                    el('div', { className: 'event-pattern-title' }, `${event.icon} ${event.title}`)
+                ]),
+                el('div', { className: 'pattern-templates' }, this.renderPatternTemplates(eventType))
+            ]);
+        }));
 
         this.updateStep3NextButton();
     }
 
     renderPatternTemplates(eventType) {
-        return this.templates.map(template => `
-            <div class="pattern-template ${this.eventPatterns[eventType] === template.pattern ? 'selected' : ''}" 
-                 onclick="wizard.selectPattern('${eventType}', '${template.pattern}')">
-                <div class="template-name">${template.name}</div>
-                <div class="template-description">${template.description}</div>
-                <button class="template-test" onclick="event.stopPropagation(); wizard.testTemplate('${template.pattern}')">
-                    ▶️ Try This
-                </button>
-            </div>
-        `).join('');
+        return this.templates.map(template => el('div', {
+            className: 'pattern-template' + (this.eventPatterns[eventType] === template.pattern ? ' selected' : ''),
+            on: { click: () => this.selectPattern(eventType, template.pattern) }
+        }, [
+            el('div', { className: 'template-name', text: template.name }),
+            el('div', { className: 'template-description', text: template.description }),
+            el('button', {
+                className: 'template-test',
+                text: '▶️ Try This',
+                on: {
+                    click: event => {
+                        event.stopPropagation();
+                        this.testTemplate(template.pattern);
+                    }
+                }
+            })
+        ]));
     }
 
     selectPattern(eventType, patternType) {
@@ -994,59 +1007,49 @@ class PatternWizard {
 
         const container = document.getElementById('tuningPanel');
 
-        container.innerHTML = this.selectedEvents.map(eventType => {
+        replace(container, this.selectedEvents.map(eventType => {
             const event = this.eventDefinitions[eventType];
             const patternType = this.eventPatterns[eventType];
             const template = this.templates.find(t => t.pattern === patternType);
             const settings = (this.eventSettings && this.eventSettings[eventType]) || (template ? template.defaultSettings : this.getDefaultSettings());
 
-            return `
-                <div class="tuning-event">
-                    <div class="tuning-header">
-                        <div class="tuning-title">${event.icon} ${event.title}</div>
-                        <button class="test-button" onclick="wizard.testEventPattern('${eventType}')">
-                            🎧 Test Pattern
-                        </button>
-                    </div>
-                    <div class="tuning-controls">
-                        ${this.renderTuningControls(eventType, settings)}
-                    </div>
-                </div>
-            `;
-        }).join('');
+            return el('div', { className: 'tuning-event' }, [
+                el('div', { className: 'tuning-header' }, [
+                    el('div', { className: 'tuning-title' }, `${event.icon} ${event.title}`),
+                    el('button', {
+                        className: 'test-button',
+                        text: '🎧 Test Pattern',
+                        on: { click: () => this.testEventPattern(eventType) }
+                    })
+                ]),
+                el('div', { className: 'tuning-controls' }, this.renderTuningControls(eventType, settings))
+            ]);
+        }));
     }
 
     renderTuningControls(eventType, settings) {
-        return `
-            <div class="control-group">
-                <label class="control-label">Intensity</label>
-                <input type="range" class="control-slider" min="10" max="100" 
-                       value="${settings.intensity}" 
-                       oninput="wizard.updateSetting('${eventType}', 'intensity', this.value)">
-                <div class="control-value" id="${eventType}_intensity">${settings.intensity}%</div>
-            </div>
-            <div class="control-group">
-                <label class="control-label">Frequency</label>
-                <input type="range" class="control-slider" min="10" max="100" 
-                       value="${settings.frequency}" 
-                       oninput="wizard.updateSetting('${eventType}', 'frequency', this.value)">
-                <div class="control-value" id="${eventType}_frequency">${settings.frequency}Hz</div>
-            </div>
-            <div class="control-group">
-                <label class="control-label">Duration</label>
-                <input type="range" class="control-slider" min="100" max="10000" step="100"
-                       value="${settings.duration}"
-                       oninput="wizard.updateSetting('${eventType}', 'duration', this.value)">
-                <div class="control-value" id="${eventType}_duration">${settings.duration}ms</div>
-            </div>
-            <div class="control-group">
-                <label class="control-label">Fade In</label>
-                <input type="range" class="control-slider" min="0" max="500" 
-                       value="${settings.fadeIn || 0}" 
-                       oninput="wizard.updateSetting('${eventType}', 'fadeIn', this.value)">
-                <div class="control-value" id="${eventType}_fadeIn">${settings.fadeIn || 0}ms</div>
-            </div>
-        `;
+        const control = (label, setting, unit, value, attrs) => el('div', { className: 'control-group' }, [
+            el('label', { className: 'control-label', text: label }),
+            el('input', {
+                className: 'control-slider',
+                // type and the bounds go on first: a range input clamps its value to whatever
+                // min/max are set at the time the value lands.
+                attrs: { type: 'range', ...attrs, value: num(value) },
+                on: { input: e => this.updateSetting(eventType, setting, e.target.value) }
+            }),
+            el('div', {
+                className: 'control-value',
+                id: `${eventType}_${setting}`,
+                text: `${num(value)}${unit}`
+            })
+        ]);
+
+        return [
+            control('Intensity', 'intensity', '%', settings.intensity, { min: 10, max: 100 }),
+            control('Frequency', 'frequency', 'Hz', settings.frequency, { min: 10, max: 100 }),
+            control('Duration', 'duration', 'ms', settings.duration, { min: 100, max: 10000, step: 100 }),
+            control('Fade In', 'fadeIn', 'ms', settings.fadeIn || 0, { min: 0, max: 500 })
+        ];
     }
 
     updateSetting(eventType, setting, value) {
@@ -1140,19 +1143,17 @@ class PatternWizard {
         const container = document.getElementById('timelineEditorContainer');
 
         // Clear container and create event-specific editors
-        container.innerHTML = `
-            <div class="timeline-event-selector">
-                <label>Edit Pattern For:</label>
-                <select id="eventSelector">
-                    ${this.selectedEvents.map(eventType => `
-                        <option value="${eventType}">${this.eventDefinitions[eventType]?.title || eventType}</option>
-                    `).join('')}
-                </select>
-            </div>
-            <div id="currentTimelineEditor" class="timeline-editor-main">
-                <!-- Current event's timeline editor will be initialized here -->
-            </div>
-        `;
+        replace(container, [
+            el('div', { className: 'timeline-event-selector' }, [
+                el('label', { text: 'Edit Pattern For:' }),
+                el('select', { id: 'eventSelector' }, this.selectedEvents.map(eventType => el('option', {
+                    value: eventType,
+                    text: this.eventDefinitions[eventType]?.title || eventType
+                })))
+            ]),
+            // Current event's timeline editor is initialized into this container below.
+            el('div', { id: 'currentTimelineEditor', className: 'timeline-editor-main' })
+        ]);
 
         // Set up event selector
         const eventSelector = container.querySelector('#eventSelector');
@@ -1337,21 +1338,17 @@ class PatternWizard {
         const eventCount = this.selectedEvents.length;
         const shipName = this.formatShipName(this.selectedShip);
         
-        container.innerHTML = `
-            <div class="summary-title">Pattern Pack Summary</div>
-            <div class="summary-item">
-                <span>Ship:</span>
-                <span>${shipName}</span>
-            </div>
-            <div class="summary-item">
-                <span>Events:</span>
-                <span>${eventCount} custom patterns</span>
-            </div>
-            <div class="summary-item">
-                <span>Selected Events:</span>
-                <span>${this.selectedEvents.map(e => this.eventDefinitions[e].title).join(', ')}</span>
-            </div>
-        `;
+        const summaryItem = (label, value) => el('div', { className: 'summary-item' }, [
+            el('span', { text: label }),
+            el('span', { text: value })
+        ]);
+
+        replace(container, [
+            el('div', { className: 'summary-title', text: 'Pattern Pack Summary' }),
+            summaryItem('Ship:', shipName),
+            summaryItem('Events:', `${eventCount} custom patterns`),
+            summaryItem('Selected Events:', this.selectedEvents.map(e => this.eventDefinitions[e].title).join(', '))
+        ]);
     }
 
     async saveWizardPattern() {
@@ -1617,7 +1614,8 @@ class PatternWizard {
     }
 }
 
-// Global functions for HTML onclick handlers
+// Global functions named by the markup's data-bind attributes. `wizard` is declared with var so it
+// lands on window, where dom.js looks up `data-bind="wizard.something"`.
 function nextStep() { wizard.nextStep(); }
 function previousStep() { wizard.previousStep(); }
 function saveWizardPattern() { wizard.saveWizardPattern(); }
@@ -1625,7 +1623,7 @@ function startOver() { wizard.startOver(); }
 function testAllPatterns() { wizard.testAllPatterns(); }
 
 // Initialize the wizard when page loads
-let wizard;
+var wizard;
 document.addEventListener('DOMContentLoaded', () => {
     wizard = new PatternWizard();
 

--- a/src/EDButtkicker/wwwroot/js/timeline-editor.js
+++ b/src/EDButtkicker/wwwroot/js/timeline-editor.js
@@ -61,110 +61,130 @@ class TimelineEditor {
     }
 
     createUI() {
-        this.container.innerHTML = `
-            <div class="timeline-editor-main">
-                <div class="timeline-toolbar" role="toolbar" aria-label="Timeline Editor Controls">
-                    <div class="timeline-controls" role="group" aria-label="Playback Controls">
-                        <button id="playBtn" class="control-btn" aria-label="Play timeline">▶️</button>
-                        <button id="pauseBtn" class="control-btn" style="display: none;" aria-label="Pause timeline">⏸️</button>
-                        <button id="stopBtn" class="control-btn" aria-label="Stop timeline">⏹️</button>
-                        <span class="time-display" aria-live="polite" aria-label="Current time">0.0s / ${(this.duration / 1000).toFixed(1)}s</span>
-                    </div>
-                    <div class="duration-controls" role="group" aria-label="Pattern Duration Controls">
-                        <label for="durationInput">Duration:</label>
-                        <input type="number" id="durationInput" min="100" max="30000" step="100" value="${this.duration}"
-                               aria-label="Pattern duration in milliseconds" style="width: 80px;">
-                        <span>ms</span>
-                    </div>
-                    <div class="zoom-controls" role="group" aria-label="Zoom Controls">
-                        <button id="zoomInBtn" class="control-btn" aria-label="Zoom in">🔍+</button>
-                        <button id="zoomOutBtn" class="control-btn" aria-label="Zoom out">🔍-</button>
-                        <button id="resetZoomBtn" class="control-btn" aria-label="Reset zoom">↻</button>
-                    </div>
-                    <div class="curve-tools" role="group" aria-label="Curve Tools">
-                        <label for="curveTypeSelect">Curve Type:</label>
-                        <select id="curveTypeSelect" aria-label="Select curve type">
-                            ${this.curveTypes.map(type => `<option value="${type}">${type}</option>`).join('')}
-                        </select>
-                        <button id="addPointBtn" class="control-btn" aria-label="Add control point">+ Point</button>
-                    </div>
-                </div>
+        const { el, replace } = window.dom;
 
-                <div class="timeline-content">
-                    <div class="timeline-canvas-wrapper">
-                        <canvas id="timelineCanvas" class="timeline-canvas"
-                                role="img"
-                                aria-label="Timeline visualization canvas. Use arrow keys to navigate, Space to pan, mouse to add control points"
-                                tabindex="0"></canvas>
-                    </div>
+        const button = (id, label, text, extra) => el('button', {
+            id,
+            className: 'control-btn' + (extra && extra.className ? ' ' + extra.className : ''),
+            text,
+            attrs: { 'aria-label': label },
+            style: extra && extra.style
+        });
 
-                    <div class="layer-panel" role="complementary" aria-label="Layer Management Panel">
-                        <div class="layer-panel-header">
-                            <h3>Layers</h3>
-                            <button id="addLayerBtn" class="control-btn" aria-label="Add new layer">+ Add Layer</button>
-                        </div>
-                        <div id="layerList" class="layer-list" role="list" aria-label="Timeline layers"></div>
+        const options = values => values.map(type => el('option', { value: type, text: type }));
 
-                        <div class="layer-controls" id="layerControls" style="display: none;" role="region" aria-label="Layer Properties">
-                            <h4>Layer Properties</h4>
-                            <div class="control-group">
-                                <label for="layerWaveform">Waveform:</label>
-                                <select id="layerWaveform" aria-label="Select waveform type">
-                                    ${this.waveformTypes.map(type => `<option value="${type}">${type}</option>`).join('')}
-                                </select>
-                            </div>
-                            <div class="control-group">
-                                <label for="frequencySlider">Frequency: <span id="frequencyValue" aria-live="polite">40</span>Hz</label>
-                                <input type="range" id="frequencySlider" min="20" max="120" value="40" step="1"
-                                       aria-label="Frequency slider" aria-describedby="frequencyValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="amplitudeSlider">Amplitude: <span id="amplitudeValue" aria-live="polite">100</span>%</label>
-                                <input type="range" id="amplitudeSlider" min="0" max="100" value="100" step="1"
-                                       aria-label="Amplitude slider" aria-describedby="amplitudeValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="phaseSlider">Phase: <span id="phaseValue" aria-live="polite">0</span>°</label>
-                                <input type="range" id="phaseSlider" min="0" max="360" value="0" step="1"
-                                       aria-label="Phase slider" aria-describedby="phaseValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="startTimeSlider">Start Time: <span id="startTimeValue" aria-live="polite">0</span>ms</label>
-                                <input type="range" id="startTimeSlider" min="0" max="${this.duration}" value="0" step="10"
-                                       aria-label="Start time slider" aria-describedby="startTimeValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="layerDurationSlider">Duration: <span id="layerDurationValue" aria-live="polite">${this.duration}</span>ms</label>
-                                <input type="range" id="layerDurationSlider" min="100" max="${this.duration}" value="${this.duration}" step="10"
-                                       aria-label="Duration slider" aria-describedby="layerDurationValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="fadeInSlider">Fade In: <span id="fadeInValue" aria-live="polite">0</span>ms</label>
-                                <input type="range" id="fadeInSlider" min="0" max="1000" value="0" step="10"
-                                       aria-label="Fade in slider" aria-describedby="fadeInValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="fadeOutSlider">Fade Out: <span id="fadeOutValue" aria-live="polite">0</span>ms</label>
-                                <input type="range" id="fadeOutSlider" min="0" max="1000" value="0" step="10"
-                                       aria-label="Fade out slider" aria-describedby="fadeOutValue">
-                            </div>
-                            <div class="control-group">
-                                <label for="layerCurve">Curve Type:</label>
-                                <select id="layerCurve" aria-label="Select layer curve type">
-                                    ${this.curveTypes.map(type => `<option value="${type}">${type}</option>`).join('')}
-                                </select>
-                            </div>
-                            <div class="layer-actions" role="group" aria-label="Layer Actions">
-                                <button id="duplicateLayerBtn" class="control-btn" aria-label="Duplicate current layer">Duplicate</button>
-                                <button id="removeLayerBtn" class="control-btn danger" aria-label="Remove current layer">Remove</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Offscreen aria-live element for control point selection announcements -->
-                <div class="sr-only-announce" role="status" aria-live="polite" style="position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden;"></div>
-            </div>
-        `;
+        /// Slider whose label carries a live-updating value readout.
+        const slider = (id, valueId, label, unit, initial, attrs) => el('div', { className: 'control-group' }, [
+            el('label', { attrs: { for: id } }, [
+                label + ': ',
+                el('span', { id: valueId, text: initial, attrs: { 'aria-live': 'polite' } }),
+                unit
+            ]),
+            el('input', {
+                id,
+                // Bounds land before the value: a range input clamps whatever it is given to the
+                // min/max in force at the time.
+                attrs: { type: 'range', step: 10, ...attrs, value: initial, 'aria-label': label + ' slider', 'aria-describedby': valueId }
+            })
+        ]);
+
+        replace(this.container, el('div', { className: 'timeline-editor-main' }, [
+            el('div', { className: 'timeline-toolbar', attrs: { role: 'toolbar', 'aria-label': 'Timeline Editor Controls' } }, [
+                el('div', { className: 'timeline-controls', attrs: { role: 'group', 'aria-label': 'Playback Controls' } }, [
+                    button('playBtn', 'Play timeline', '▶️'),
+                    button('pauseBtn', 'Pause timeline', '⏸️', { style: { display: 'none' } }),
+                    button('stopBtn', 'Stop timeline', '⏹️'),
+                    el('span', {
+                        className: 'time-display',
+                        text: `0.0s / ${(this.duration / 1000).toFixed(1)}s`,
+                        attrs: { 'aria-live': 'polite', 'aria-label': 'Current time' }
+                    })
+                ]),
+                el('div', { className: 'duration-controls', attrs: { role: 'group', 'aria-label': 'Pattern Duration Controls' } }, [
+                    el('label', { text: 'Duration:', attrs: { for: 'durationInput' } }),
+                    el('input', {
+                        id: 'durationInput',
+                        style: { width: '80px' },
+                        attrs: {
+                            type: 'number', min: 100, max: 30000, step: 100, value: this.duration,
+                            'aria-label': 'Pattern duration in milliseconds'
+                        }
+                    }),
+                    el('span', { text: 'ms' })
+                ]),
+                el('div', { className: 'zoom-controls', attrs: { role: 'group', 'aria-label': 'Zoom Controls' } }, [
+                    button('zoomInBtn', 'Zoom in', '🔍+'),
+                    button('zoomOutBtn', 'Zoom out', '🔍-'),
+                    button('resetZoomBtn', 'Reset zoom', '↻')
+                ]),
+                el('div', { className: 'curve-tools', attrs: { role: 'group', 'aria-label': 'Curve Tools' } }, [
+                    el('label', { text: 'Curve Type:', attrs: { for: 'curveTypeSelect' } }),
+                    el('select', { id: 'curveTypeSelect', attrs: { 'aria-label': 'Select curve type' } }, options(this.curveTypes)),
+                    button('addPointBtn', 'Add control point', '+ Point')
+                ])
+            ]),
+
+            el('div', { className: 'timeline-content' }, [
+                el('div', { className: 'timeline-canvas-wrapper' }, [
+                    el('canvas', {
+                        id: 'timelineCanvas',
+                        className: 'timeline-canvas',
+                        attrs: {
+                            role: 'img',
+                            tabindex: '0',
+                            'aria-label': 'Timeline visualization canvas. Use arrow keys to navigate, Space to pan, mouse to add control points'
+                        }
+                    })
+                ]),
+
+                el('div', { className: 'layer-panel', attrs: { role: 'complementary', 'aria-label': 'Layer Management Panel' } }, [
+                    el('div', { className: 'layer-panel-header' }, [
+                        el('h3', { text: 'Layers' }),
+                        button('addLayerBtn', 'Add new layer', '+ Add Layer')
+                    ]),
+                    el('div', {
+                        id: 'layerList',
+                        className: 'layer-list',
+                        attrs: { role: 'list', 'aria-label': 'Timeline layers' }
+                    }),
+
+                    el('div', {
+                        id: 'layerControls',
+                        className: 'layer-controls',
+                        style: { display: 'none' },
+                        attrs: { role: 'region', 'aria-label': 'Layer Properties' }
+                    }, [
+                        el('h4', { text: 'Layer Properties' }),
+                        el('div', { className: 'control-group' }, [
+                            el('label', { text: 'Waveform:', attrs: { for: 'layerWaveform' } }),
+                            el('select', { id: 'layerWaveform', attrs: { 'aria-label': 'Select waveform type' } }, options(this.waveformTypes))
+                        ]),
+                        slider('frequencySlider', 'frequencyValue', 'Frequency', 'Hz', 40, { min: 20, max: 120, step: 1 }),
+                        slider('amplitudeSlider', 'amplitudeValue', 'Amplitude', '%', 100, { min: 0, max: 100, step: 1 }),
+                        slider('phaseSlider', 'phaseValue', 'Phase', '°', 0, { min: 0, max: 360, step: 1 }),
+                        slider('startTimeSlider', 'startTimeValue', 'Start Time', 'ms', 0, { min: 0, max: this.duration }),
+                        slider('layerDurationSlider', 'layerDurationValue', 'Duration', 'ms', this.duration, { min: 100, max: this.duration }),
+                        slider('fadeInSlider', 'fadeInValue', 'Fade In', 'ms', 0, { min: 0, max: 1000 }),
+                        slider('fadeOutSlider', 'fadeOutValue', 'Fade Out', 'ms', 0, { min: 0, max: 1000 }),
+                        el('div', { className: 'control-group' }, [
+                            el('label', { text: 'Curve Type:', attrs: { for: 'layerCurve' } }),
+                            el('select', { id: 'layerCurve', attrs: { 'aria-label': 'Select layer curve type' } }, options(this.curveTypes))
+                        ]),
+                        el('div', { className: 'layer-actions', attrs: { role: 'group', 'aria-label': 'Layer Actions' } }, [
+                            button('duplicateLayerBtn', 'Duplicate current layer', 'Duplicate'),
+                            button('removeLayerBtn', 'Remove current layer', 'Remove', { className: 'danger' })
+                        ])
+                    ])
+                ])
+            ]),
+
+            // Offscreen aria-live element for control point selection announcements.
+            el('div', {
+                className: 'sr-only-announce',
+                attrs: { role: 'status', 'aria-live': 'polite' },
+                style: { position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }
+            })
+        ]));
     }
 
     setupCanvas() {
@@ -410,34 +430,62 @@ class TimelineEditor {
             return;
         }
 
-        layerList.innerHTML = this.layers.map((layer, index) => `
-            <div class="layer-item ${this.selectedLayer?.id === layer.id ? 'selected' : ''}"
-                 data-layer-id="${layer.id}"
-                 role="listitem"
-                 tabindex="0"
-                 aria-label="Layer ${index + 1}: ${layer.waveform} waveform, ${layer.visible ? 'visible' : 'hidden'}, ${layer.muted ? 'muted' : 'unmuted'}"
-                 ${this.selectedLayer?.id === layer.id ? 'aria-selected="true"' : 'aria-selected="false"'}>
-                <div class="layer-header">
-                    <div class="layer-color" style="background-color: ${layer.color}" aria-hidden="true"></div>
-                    <span class="layer-name">Layer ${index + 1} (${layer.waveform})</span>
-                    <div class="layer-toggles" role="group" aria-label="Layer visibility controls">
-                        <button class="toggle-btn ${layer.visible ? 'active' : ''}"
-                                data-action="toggle-visible"
-                                aria-label="${layer.visible ? 'Hide layer' : 'Show layer'}"
-                                aria-pressed="${layer.visible}">👁️</button>
-                        <button class="toggle-btn ${layer.muted ? 'active' : ''}"
-                                data-action="toggle-muted"
-                                aria-label="${layer.muted ? 'Unmute layer' : 'Mute layer'}"
-                                aria-pressed="${layer.muted}">🔇</button>
-                    </div>
-                </div>
-                <div class="layer-preview">
-                    <canvas class="layer-waveform" width="200" height="30"
-                            role="img"
-                            aria-label="Waveform preview for layer ${index + 1}"></canvas>
-                </div>
-            </div>
-        `).join('');
+        const { el, replace } = window.dom;
+
+        replace(layerList, this.layers.map((layer, index) => {
+            const selected = this.selectedLayer?.id === layer.id;
+
+            return el('div', {
+                className: 'layer-item' + (selected ? ' selected' : ''),
+                dataset: { 'layer-id': layer.id },
+                attrs: {
+                    role: 'listitem',
+                    tabindex: '0',
+                    'aria-label': `Layer ${index + 1}: ${layer.waveform} waveform, ${layer.visible ? 'visible' : 'hidden'}, ${layer.muted ? 'muted' : 'unmuted'}`,
+                    'aria-selected': selected ? 'true' : 'false'
+                }
+            }, [
+                el('div', { className: 'layer-header' }, [
+                    el('div', {
+                        className: 'layer-color',
+                        style: { backgroundColor: layer.color },
+                        attrs: { 'aria-hidden': 'true' }
+                    }),
+                    el('span', { className: 'layer-name', text: `Layer ${index + 1} (${layer.waveform})` }),
+                    el('div', { className: 'layer-toggles', attrs: { role: 'group', 'aria-label': 'Layer visibility controls' } }, [
+                        el('button', {
+                            className: 'toggle-btn' + (layer.visible ? ' active' : ''),
+                            text: '👁️',
+                            dataset: { action: 'toggle-visible' },
+                            attrs: {
+                                'aria-label': layer.visible ? 'Hide layer' : 'Show layer',
+                                'aria-pressed': String(!!layer.visible)
+                            }
+                        }),
+                        el('button', {
+                            className: 'toggle-btn' + (layer.muted ? ' active' : ''),
+                            text: '🔇',
+                            dataset: { action: 'toggle-muted' },
+                            attrs: {
+                                'aria-label': layer.muted ? 'Unmute layer' : 'Mute layer',
+                                'aria-pressed': String(!!layer.muted)
+                            }
+                        })
+                    ])
+                ]),
+                el('div', { className: 'layer-preview' }, [
+                    el('canvas', {
+                        className: 'layer-waveform',
+                        attrs: {
+                            width: 200,
+                            height: 30,
+                            role: 'img',
+                            'aria-label': `Waveform preview for layer ${index + 1}`
+                        }
+                    })
+                ])
+            ]);
+        }));
 
         // Add layer selection event listeners
         layerList.querySelectorAll('.layer-item').forEach(item => {

--- a/src/EDButtkicker/wwwroot/pattern-conflicts.html
+++ b/src/EDButtkicker/wwwroot/pattern-conflicts.html
@@ -297,10 +297,10 @@
 
                 <div class="section">
                     <h3>🔄 Actions</h3>
-                    <button onclick="refreshConflicts()" class="btn btn-secondary full-width">
+                    <button data-bind="refreshConflicts" class="btn btn-secondary full-width">
                         <i class="fas fa-sync-alt"></i> Refresh
                     </button>
-                    <button onclick="refreshSources()" class="btn btn-primary full-width">
+                    <button data-bind="refreshSources" class="btn btn-primary full-width">
                         <i class="fas fa-database"></i> Refresh Sources
                     </button>
                 </div>
@@ -322,6 +322,7 @@
         </main>
     </div>
 
+    <script src="js/dom.js"></script>
     <script src="js/csrf.js"></script>
     <script src="js/pattern-conflicts.js"></script>
 </body>

--- a/src/EDButtkicker/wwwroot/pattern-editor.html
+++ b/src/EDButtkicker/wwwroot/pattern-editor.html
@@ -962,11 +962,11 @@
                     <div class="form-group">
                         <div style="display: flex; gap: 1rem; justify-content: center; margin-bottom: 1.5rem;">
                             <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
-                                <input type="radio" name="editorMode" value="create" checked onclick="wizard.toggleMode('create')">
+                                <input type="radio" name="editorMode" value="create" checked data-bind="wizard.toggleMode" data-bind-args='["create"]'>
                                 <span>Create New Pattern</span>
                             </label>
                             <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
-                                <input type="radio" name="editorMode" value="edit" onclick="wizard.toggleMode('edit')">
+                                <input type="radio" name="editorMode" value="edit" data-bind="wizard.toggleMode" data-bind-args='["edit"]'>
                                 <span>Edit Existing Pattern</span>
                             </label>
                         </div>
@@ -979,7 +979,7 @@
                     <div class="form-group">
                         <label for="authorInput">Your Username</label>
                         <input type="text" id="authorInput" placeholder="CMDR YourName" style="margin-bottom: 0.75rem;">
-                        <button onclick="wizard.loadUserFiles()" class="btn btn-primary" id="loadFilesBtn">Load My Files</button>
+                        <button data-bind="wizard.loadUserFiles" class="btn btn-primary" id="loadFilesBtn">Load My Files</button>
                     </div>
 
                     <div class="form-group" id="fileListContainer" style="display: none;">
@@ -1003,7 +1003,7 @@
                 </div>
 
                 <div class="step-actions">
-                    <button onclick="nextStep()" class="btn btn-primary" id="step1Next" disabled>Next: Select Events →</button>
+                    <button data-bind="nextStep" class="btn btn-primary" id="step1Next" disabled>Next: Select Events →</button>
                 </div>
             </div>
 
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button onclick="previousStep()" class="btn btn-secondary">← Back</button>
-                    <button onclick="nextStep()" class="btn btn-primary" id="step2Next" disabled>Next: Choose Patterns →</button>
+                    <button data-bind="previousStep" class="btn btn-secondary">← Back</button>
+                    <button data-bind="nextStep" class="btn btn-primary" id="step2Next" disabled>Next: Choose Patterns →</button>
                 </div>
             </div>
 
@@ -1073,8 +1073,8 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button onclick="previousStep()" class="btn btn-secondary">← Back</button>
-                    <button onclick="nextStep()" class="btn btn-primary" id="step3Next" disabled>Next: Fine-tune →</button>
+                    <button data-bind="previousStep" class="btn btn-secondary">← Back</button>
+                    <button data-bind="nextStep" class="btn btn-primary" id="step3Next" disabled>Next: Fine-tune →</button>
                 </div>
             </div>
 
@@ -1109,8 +1109,8 @@
                 </div>
 
                 <div class="step-actions">
-                    <button onclick="previousStep()" class="btn btn-secondary">← Back</button>
-                    <button onclick="nextStep()" class="btn btn-primary">Next: Save →</button>
+                    <button data-bind="previousStep" class="btn btn-secondary">← Back</button>
+                    <button data-bind="nextStep" class="btn btn-primary">Next: Save →</button>
                 </div>
             </div>
 
@@ -1143,8 +1143,8 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button onclick="previousStep()" class="btn btn-secondary">← Back</button>
-                    <button onclick="saveWizardPattern()" class="btn btn-success">💾 Save Pattern Pack</button>
+                    <button data-bind="previousStep" class="btn btn-secondary">← Back</button>
+                    <button data-bind="saveWizardPattern" class="btn btn-success">💾 Save Pattern Pack</button>
                 </div>
             </div>
 
@@ -1156,8 +1156,8 @@
                     <p>Your custom haptic patterns have been saved and are ready to use.</p>
                     
                     <div class="success-actions">
-                        <button onclick="startOver()" class="btn btn-primary">Create Another Pack</button>
-                        <button onclick="testAllPatterns()" class="btn btn-secondary">Test All Patterns</button>
+                        <button data-bind="startOver" class="btn btn-primary">Create Another Pack</button>
+                        <button data-bind="testAllPatterns" class="btn btn-secondary">Test All Patterns</button>
                         <a href="index.html" class="btn btn-secondary">← Back to Main</a>
                     </div>
                 </div>
@@ -1168,7 +1168,7 @@
     <!-- Add Ship Modal -->
     <div id="addShipModal" class="modal">
         <div class="modal-content">
-            <span class="close" onclick="closeModal('addShipModal')">&times;</span>
+            <span class="close" data-bind="closeModal" data-bind-args='["addShipModal"]'>&times;</span>
             <h3>Add Ship to Pattern Pack</h3>
             <div class="form-group">
                 <label for="shipType">Ship Type</label>
@@ -1181,8 +1181,8 @@
                 <input type="text" id="shipDisplayName" placeholder="Custom display name">
             </div>
             <div class="action-buttons">
-                <button onclick="confirmAddShip()" class="btn btn-primary">Add Ship</button>
-                <button onclick="closeModal('addShipModal')" class="btn btn-secondary">Cancel</button>
+                <button data-bind="confirmAddShip" class="btn btn-primary">Add Ship</button>
+                <button data-bind="closeModal" data-bind-args='["addShipModal"]' class="btn btn-secondary">Cancel</button>
             </div>
         </div>
     </div>
@@ -1190,7 +1190,7 @@
     <!-- Add Event Modal -->
     <div id="addEventModal" class="modal">
         <div class="modal-content">
-            <span class="close" onclick="closeModal('addEventModal')">&times;</span>
+            <span class="close" data-bind="closeModal" data-bind-args='["addEventModal"]'>&times;</span>
             <h3>Add Event Pattern</h3>
             <div class="form-group">
                 <label for="eventType">Event Type</label>
@@ -1205,12 +1205,13 @@
                 </select>
             </div>
             <div class="action-buttons">
-                <button onclick="confirmAddEvent()" class="btn btn-primary">Add Event</button>
-                <button onclick="closeModal('addEventModal')" class="btn btn-secondary">Cancel</button>
+                <button data-bind="confirmAddEvent" class="btn btn-primary">Add Event</button>
+                <button data-bind="closeModal" data-bind-args='["addEventModal"]' class="btn btn-secondary">Cancel</button>
             </div>
         </div>
     </div>
 
+    <script src="js/dom.js"></script>
     <script src="js/csrf.js"></script>
     <script src="js/timeline-editor.js"></script>
     <script src="js/pattern-editor.js"></script>

--- a/tests/EDButtkicker.Tests/ContentSecurityPolicyTests.cs
+++ b/tests/EDButtkicker.Tests/ContentSecurityPolicyTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The UI's defence against a hostile string that reaches the page - a ship name, a journal event,
+/// a folder path - is that markup is never built by concatenation and no inline script may run.
+/// The second half of that is the Content-Security-Policy header, so pin it on a real response:
+/// scripts come from this origin's own files, and neither inline nor eval'd code is allowed.
+/// </summary>
+public class ContentSecurityPolicyTests : IClassFixture<WebUiTestServerFixture>
+{
+    private readonly WebUiTestServerFixture _fixture;
+
+    public ContentSecurityPolicyTests(WebUiTestServerFixture fixture) => _fixture = fixture;
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/api/csrf")]
+    public async Task Response_CarriesAScriptSrcSelfPolicy(string path)
+    {
+        // The same loopback Host, Origin and token the application's own page sends.
+        var response = await _fixture.Client.GetAsync(path);
+
+        Assert.True(
+            response.Headers.TryGetValues("Content-Security-Policy", out var values),
+            $"GET {path} returned no Content-Security-Policy header");
+
+        var policy = string.Join(' ', values!);
+
+        Assert.Contains("script-src 'self'", policy);
+        Assert.DoesNotContain("unsafe-eval", policy);
+
+        // Only script-src has to be free of 'unsafe-inline'; style-src keeps it, because the pages
+        // hide panels with a style attribute and a stylesheet cannot execute.
+        Assert.DoesNotContain("unsafe-inline", ScriptSrc(policy));
+    }
+
+    private static string ScriptSrc(string policy)
+    {
+        var directive = policy
+            .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .SingleOrDefault(part => part.StartsWith("script-src", StringComparison.Ordinal));
+
+        Assert.NotNull(directive);
+        return directive!;
+    }
+}

--- a/tests/EDButtkicker.Tests/DomXssRenderingTests.cs
+++ b/tests/EDButtkicker.Tests/DomXssRenderingTests.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The browser half of the escaping story cannot be exercised from .NET, so it lives in
+/// js/dom_xss_test.js: it loads the real js/dom.js into a DOM and feeds markup payloads through the
+/// helpers every renderer uses. This runs that script under node and fails with its output.
+/// </summary>
+public class DomXssRenderingTests
+{
+    private const string ScriptName = "dom_xss_test.js";
+
+    [Fact]
+    public void UntrustedText_IsNeverParsedAsMarkup()
+    {
+        var scriptDirectory = LocateScriptDirectory();
+        EnsureDependenciesInstalled(scriptDirectory);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "node",
+            WorkingDirectory = scriptDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(ScriptName);
+
+        using var process = Start(startInfo);
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, $"{ScriptName} failed:\n{output}\n{error}");
+    }
+
+    /// <summary>
+    /// node_modules is not in the repository, so on a clean checkout - CI's, most of the time - the
+    /// packages the script needs have to be fetched first.
+    /// </summary>
+    private static void EnsureDependenciesInstalled(string scriptDirectory)
+    {
+        if (Directory.Exists(Path.Combine(scriptDirectory, "node_modules", "jsdom")))
+        {
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "npm",
+            WorkingDirectory = scriptDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("install");
+
+        using var install = Start(startInfo, "npm");
+
+        var output = install.StandardOutput.ReadToEnd();
+        var error = install.StandardError.ReadToEnd();
+        install.WaitForExit();
+
+        Assert.True(install.ExitCode == 0, $"npm install in {scriptDirectory} failed:\n{output}\n{error}");
+    }
+
+    private static Process Start(ProcessStartInfo startInfo, string executable = "node")
+    {
+        try
+        {
+            return Process.Start(startInfo)!;
+        }
+        catch (Win32Exception)
+        {
+            Assert.Fail($"{executable} is required to run the DOM escaping tests but was not found on PATH.");
+            throw;
+        }
+    }
+
+    /// <summary>Walks out of bin/Debug/net8.0 to the test project's own js directory.</summary>
+    private static string LocateScriptDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "js");
+            if (File.Exists(Path.Combine(candidate, ScriptName)))
+            {
+                return candidate;
+            }
+        }
+
+        Assert.Fail($"Could not find js/{ScriptName} above {AppContext.BaseDirectory}");
+        throw new InvalidOperationException();
+    }
+}

--- a/tests/EDButtkicker.Tests/js/dom_xss_test.js
+++ b/tests/EDButtkicker.Tests/js/dom_xss_test.js
@@ -1,0 +1,55 @@
+// Every string the UI shows - journal event names, pattern names, context strings, toast messages,
+// audio device names - comes from data this application does not author. This runs the real
+// js/dom.js in a DOM and pins that a markup payload in any of those places stays a visible string:
+// no element is created from it, and the page still shows it verbatim.
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+const wwwroot = path.resolve(__dirname, '../../../src/EDButtkicker/wwwroot/js');
+
+const { window } = new JSDOM('<!doctype html><html><body></body></html>', { runScripts: 'dangerously' });
+const script = window.document.createElement('script');
+script.textContent = fs.readFileSync(path.join(wwwroot, 'dom.js'), 'utf8');
+window.document.head.appendChild(script);
+
+const payloads = ['<img src=x onerror=alert(1)>', '<script>window.__xss=1</script>', '"><svg/onload=alert(1)>'];
+
+// The five kinds of untrusted text the renderers put on the page.
+const kinds = ['event-type', 'pattern-name', 'context', 'toast-message', 'device-name'];
+
+for (const payload of payloads) {
+    for (const kind of kinds) {
+        const root = window.document.createElement('div');
+        window.document.body.appendChild(root);
+
+        window.dom.replace(root, window.dom.el('div', { className: kind, text: payload }));
+
+        if (root.querySelector('img, script, svg')) {
+            console.error('payload was parsed as markup:', kind, payload);
+            process.exit(1);
+        }
+
+        if (!root.textContent.includes(payload)) {
+            console.error('payload did not survive as text:', kind, payload);
+            process.exit(1);
+        }
+
+        root.remove();
+    }
+}
+
+if (window.__xss !== undefined) {
+    console.error('a payload executed');
+    process.exit(1);
+}
+
+// The dashboard renders the same five kinds, so it must not have an innerHTML assignment left.
+const appJs = fs.readFileSync(path.join(wwwroot, 'app.js'), 'utf8');
+if (/innerHTML\s*=/.test(appJs)) {
+    console.error('app.js still assigns innerHTML');
+    process.exit(1);
+}
+
+console.log('ok');
+process.exit(0);

--- a/tests/EDButtkicker.Tests/js/package-lock.json
+++ b/tests/EDButtkicker.Tests/js/package-lock.json
@@ -1,0 +1,513 @@
+{
+  "name": "js",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "jsdom": "^30.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/EDButtkicker.Tests/js/package.json
+++ b/tests/EDButtkicker.Tests/js/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsdom": "^30.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
Closes #17.

Journal fields, pattern metadata, device names, context strings, and toast text are no longer concatenated into `innerHTML`. Shared `wwwroot/js/dom.js` helpers write them as text nodes and attach listeners with `addEventListener`. Static `onclick` attributes become `data-bind` so the page runs under a CSP that forbids inline script and eval.

## Test Plan
- [x] `dotnet test` on Linux: 477 passed, 0 failed
- [x] CSP tests: GET `/` and `/api/csrf` carry `script-src 'self'` without `unsafe-inline`/`unsafe-eval` in script-src
- [x] jsdom XSS tests: HTML/script payloads in journal, pattern, context, toast, and device fields stay text
- [ ] Windows WASAPI / physical Buttkicker not required for this ticket

## Out
Does not broaden the listener beyond loopback. Does not add cloud accounts.
