### PR TITLE
fix(journal): rebind watcher on path change and report read offset

### DIFF
--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -75,6 +75,7 @@ public class JournalApiController
                 monitor_state = monitor.State.ToString(),
                 monitor_reason = monitor.Reason,
                 monitor_active_file = monitor.ActiveFile,
+                monitor_offset = monitor.Offset,
                 monitor_latest_only = _settings.EliteDangerous.MonitorLatestOnly,
                 recent_files = journalFiles,
                 events_processed = GetRecentEventsCount(),
@@ -159,7 +160,11 @@ public class JournalApiController
             }
 
             _settings.EliteDangerous.JournalPath = journalPath;
-            
+
+            // The live watcher is still attached to the old folder; ask it to re-check now so the
+            // new path takes effect without a restart, the same way the setup wizard does.
+            _monitorStatus.RequestRecheck();
+
             _logger.LogInformation("Journal path updated to: {JournalPath}", journalPath);
 
             context.Response.ContentType = "application/json";
@@ -213,8 +218,9 @@ public class JournalApiController
                 {
                     total_events = events.Count,
                     limit_applied = limit,
-                    monitoring = !string.IsNullOrEmpty(_settings.EliteDangerous.JournalPath) && 
-                                Directory.Exists(_settings.EliteDangerous.JournalPath)
+                    // Same meaning as the journal status endpoint: a watcher is attached, not just
+                    // that the configured folder happens to exist.
+                    monitoring = _monitorStatus.Current.State == JournalWatchState.Watching
                 }
             };
 

--- a/src/EDButtkicker/Services/JournalMonitorService.cs
+++ b/src/EDButtkicker/Services/JournalMonitorService.cs
@@ -237,11 +237,13 @@ public class JournalMonitorService : BackgroundService
         var lines = await reader.ReadNewLinesAsync(cancellationToken).ConfigureAwait(false);
 
         // Which file the watcher is on is part of the health story: "attached, no journal file yet"
-        // and "reading Journal.2026-08-28.log" are different states.
+        // and "reading Journal.2026-08-28.log" are different states. The cursor goes with it, so
+        // status shows how far into that file the reader has committed after every drain.
         var currentFile = reader.CurrentFile;
         _status.ReportWatching(
             _settings.EliteDangerous.JournalPath,
-            currentFile == null ? null : Path.GetFileName(currentFile));
+            currentFile == null ? null : Path.GetFileName(currentFile),
+            currentFile == null ? null : reader.Cursor);
 
         foreach (var line in lines)
         {

--- a/src/EDButtkicker/Services/JournalMonitorStatus.cs
+++ b/src/EDButtkicker/Services/JournalMonitorStatus.cs
@@ -26,7 +26,9 @@ public sealed record JournalMonitorSnapshot(
     string Reason,
     string? ActiveFile,
     DateTime? SinceUtc,
-    DateTime? LastLineUtc);
+    DateTime? LastLineUtc,
+    /// <summary>Byte offset the reader has committed in <see cref="ActiveFile"/>, when one is open.</summary>
+    long? Offset = null);
 
 /// <summary>
 /// The journal watcher's real state, published by <see cref="JournalMonitorService"/> and read by
@@ -47,7 +49,8 @@ public sealed class JournalMonitorStatus
         Reason: "Journal monitoring has not started yet.",
         ActiveFile: null,
         SinceUtc: null,
-        LastLineUtc: null);
+        LastLineUtc: null,
+        Offset: null);
 
     public JournalMonitorStatus(TimeProvider timeProvider)
     {
@@ -77,12 +80,17 @@ public sealed class JournalMonitorStatus
                 Path = path,
                 Reason = reason,
                 ActiveFile = null,
+                Offset = null,
                 SinceUtc = unchanged ? _snapshot.SinceUtc : UtcNow
             };
         }
     }
 
-    public void ReportWatching(string path, string? activeFile)
+    /// <summary>
+    /// Publishes the attached folder, the file being read, and how far into it the reader has
+    /// committed, so the dashboard can show progress rather than only "attached".
+    /// </summary>
+    public void ReportWatching(string path, string? activeFile, long? offset = null)
     {
         lock (_lock)
         {
@@ -98,6 +106,7 @@ public sealed class JournalMonitorStatus
                     ? "Watching the journal folder; Elite Dangerous has not written a journal file yet."
                     : $"Reading {activeFile}.",
                 ActiveFile = activeFile,
+                Offset = activeFile == null ? null : offset,
                 SinceUtc = unchanged ? _snapshot.SinceUtc : UtcNow
             };
         }
@@ -120,6 +129,7 @@ public sealed class JournalMonitorStatus
                 State = JournalWatchState.Faulted,
                 Reason = reason,
                 ActiveFile = null,
+                Offset = null,
                 SinceUtc = UtcNow
             };
         }
@@ -134,6 +144,7 @@ public sealed class JournalMonitorStatus
                 State = JournalWatchState.Stopped,
                 Reason = reason,
                 ActiveFile = null,
+                Offset = null,
                 SinceUtc = UtcNow
             };
         }

--- a/tests/EDButtkicker.Tests/JournalMonitorApiRebindTests.cs
+++ b/tests/EDButtkicker.Tests/JournalMonitorApiRebindTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The public journal-path API used to change the settings object and nothing else, so the live
+/// watcher stayed on the old folder until something else happened to request a re-check. These run
+/// the real web pipeline next to a real monitor over temp folders - no game, no audio hardware -
+/// and pin that POST /api/journal/path rebinds the watcher in place, and that the status endpoint
+/// reports how far into the active file the reader has committed.
+/// </summary>
+public class JournalMonitorApiRebindTests : IDisposable
+{
+    private const string FsdJumpLine =
+        """{"timestamp":"2026-08-28T12:00:00Z","event":"FSDJump","StarSystem":"Shinrarta Dezhra"}""";
+
+    private readonly TempDirectory _root = new("edbk-monitor-api");
+    private readonly RecordingJournalPipeline _pipeline = new();
+    private readonly AppSettings _settings = new();
+
+    private static string WriteJournal(string directory, string name, string line)
+    {
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, line + "\n");
+        return path;
+    }
+
+    /// <summary>
+    /// The production graph on a TestServer, plus a monitor built from it with the recording
+    /// pipeline in place of audio, so the controller and the watcher share one status object.
+    /// </summary>
+    private (SetupTestHost Host, JournalMonitorService Monitor) CreateHostAndMonitor()
+    {
+        var host = new SetupTestHost(_root.Path, _settings);
+        var monitor = ActivatorUtilities.CreateInstance<JournalMonitorService>(host.Services, _pipeline);
+        return (host, monitor);
+    }
+
+    [Fact]
+    public async Task SetJournalPathApi_RebindsTheLiveWatcherWithoutRestartingTheHost()
+    {
+        var first = Path.Combine(_root.Path, "first");
+        var second = Path.Combine(_root.Path, "second");
+        Directory.CreateDirectory(first);
+        Directory.CreateDirectory(second);
+
+        _settings.EliteDangerous.JournalPath = first;
+        // Read the whole file rather than tailing, so the test does not race the writer.
+        _settings.EliteDangerous.MonitorLatestOnly = false;
+
+        var (host, monitor) = CreateHostAndMonitor();
+        var status = host.Services.GetRequiredService<JournalMonitorStatus>();
+
+        await monitor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await SetupTestExtensions.WaitForAsync(
+                () => status.Current.State == JournalWatchState.Watching && status.Current.Path == first,
+                "the monitor to attach to the first folder");
+
+            var journal = WriteJournal(second, "Journal.2026-08-28T130000.01.log", FsdJumpLine);
+
+            var response = await host.PostAsync("/api/journal/path", new { path = second });
+            Assert.True(response.IsSuccessStatusCode, $"POST /api/journal/path returned {(int)response.StatusCode}");
+
+            await SetupTestExtensions.WaitForAsync(
+                () => status.Current.Path == second && _pipeline.Processed.Count > 0,
+                "the monitor to rebind to the folder the API was pointed at");
+
+            Assert.Equal(JournalWatchState.Watching, status.Current.State);
+            Assert.Equal(Path.GetFileName(journal), status.Current.ActiveFile);
+            Assert.Equal("FSDJump", _pipeline.Processed[0].Event);
+
+            var reported = await host.GetJsonAsync("/api/journal/status");
+            Assert.True(reported.GetProperty("monitoring").GetBoolean());
+            Assert.Equal(second, reported.GetProperty("journal_path").GetString());
+            Assert.Equal(Path.GetFileName(journal), reported.GetProperty("monitor_active_file").GetString());
+        }
+        finally
+        {
+            await monitor.StopAsync(CancellationToken.None);
+            monitor.Dispose();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task StatusReportsTheReaderOffsetOnceALineHasBeenRead()
+    {
+        var journalPath = Path.Combine(_root.Path, "journals");
+        Directory.CreateDirectory(journalPath);
+
+        _settings.EliteDangerous.JournalPath = journalPath;
+        _settings.EliteDangerous.MonitorLatestOnly = false;
+
+        var (host, monitor) = CreateHostAndMonitor();
+        var status = host.Services.GetRequiredService<JournalMonitorStatus>();
+
+        var journal = WriteJournal(journalPath, "Journal.2026-08-28T120000.01.log", FsdJumpLine);
+        var length = new FileInfo(journal).Length;
+
+        await monitor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await SetupTestExtensions.WaitForAsync(
+                () => status.Current.Offset > 0 && _pipeline.Processed.Count > 0,
+                "the monitor to report the offset it has committed in the journal file");
+
+            // The cursor sits just past the newline that ended the only complete line.
+            Assert.Equal(length, status.Current.Offset);
+
+            var reported = await host.GetJsonAsync("/api/journal/status");
+            Assert.Equal(status.Current.Offset, reported.GetProperty("monitor_offset").GetInt64());
+
+            var events = await host.GetJsonAsync("/api/journal/events/recent");
+            Assert.True(
+                events.GetProperty("metadata").GetProperty("monitoring").GetBoolean(),
+                "recent-event metadata should report the watcher state, not folder existence");
+        }
+        finally
+        {
+            await monitor.StopAsync(CancellationToken.None);
+            monitor.Dispose();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RecentEventsMetadata_IsNotMonitoringWhileTheFolderIsMerelyPresent()
+    {
+        var journalPath = Path.Combine(_root.Path, "journals");
+        Directory.CreateDirectory(journalPath);
+        _settings.EliteDangerous.JournalPath = journalPath;
+
+        // No monitor is running, so the folder existing must not read as monitoring.
+        using var host = new SetupTestHost(_root.Path, _settings);
+
+        var events = await host.GetJsonAsync("/api/journal/events/recent");
+
+        Assert.False(events.GetProperty("metadata").GetProperty("monitoring").GetBoolean());
+    }
+
+    public void Dispose() => _root.Dispose();
+}


### PR DESCRIPTION
## Summary
- `POST /api/journal/path` now calls `JournalMonitorStatus.RequestRecheck()` after a validated folder change, so the live watcher rebinds without restarting the app (same signal the setup wizard already used).
- `/api/journal/status` publishes `monitor_offset` (the tail reader's committed byte offset) alongside the active file.
- `/api/journal/events/recent` metadata `monitoring` now means a watcher is attached, not that the configured folder merely exists.

## Test plan
- [x] `dotnet test` on Linux: 480 passed, 0 failed (worktree `/home/hermes/src/oss/worktrees/EBK-21-20260904150701`).
- [x] New `JournalMonitorApiRebindTests`: API path change rebinds the live watcher; status reports offset after a line is read; recent-event metadata is not "monitoring" when the folder exists but no watcher is attached.
- Existing recovery tests (missing-at-start, folder-created-later, in-memory path change, folder disappearing) and tail-reader rotation/truncation tests remain green.
- WASAPI playback and physical Buttkicker hardware were not exercised (Linux CI).

Closes #21
