### PR TITLE
fix(audio): make test playback health truthful and recoverable

### DIFF
--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -184,31 +184,67 @@ public class AudioApiController
         }
     }
 
+    /// <summary>
+    /// What the output is actually doing: the selected endpoint, the backend carrying audio, whether
+    /// a device is open, and why the last playback failed. Reading this never opens a device, so the
+    /// UI can show "not opened yet" without provoking hardware.
+    /// </summary>
+    public async Task GetAudioStatus(HttpContext context)
+    {
+        try
+        {
+            await WriteJsonAsync(context, BuildStatusPayload());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading audio status");
+            context.Response.StatusCode = 500;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+        }
+    }
+
+    /// <summary>
+    /// Plays the shared, deliberately quiet test tone. The request fails unless the tone actually
+    /// reached an open output: a scheduled effect on a device that was never opened is not a
+    /// successful test, and reporting it as one is what let a silent rig look healthy.
+    /// </summary>
     public async Task TestAudio(HttpContext context)
     {
         try
         {
             _logger.LogInformation("Testing audio output");
 
-            // Create a test haptic pattern
-            var testPattern = new HapticPattern
+            var testPattern = AudioTestPattern.Create(_settings.Audio, "Audio Test");
+
+            // Forget any earlier failure first: a user pressing Test after reconnecting their amp
+            // is asking for another attempt, not for the old verdict.
+            var opened = _audioEngine.RetryInitialization();
+            var playback = opened
+                ? await _audioEngine.TryPlayHapticPattern(testPattern)
+                : AudioPlaybackResult.Failed(DescribeUnavailableOutput());
+
+            if (!playback.Played)
             {
-                Name = "Audio Test",
-                Pattern = PatternType.SharpPulse,
-                Frequency = 40,
-                Duration = 1000,
-                Intensity = 60,
-                FadeIn = 100,
-                FadeOut = 200
-            };
+                _logger.LogWarning("Audio test failed: {Error}", playback.Error);
 
-            await _audioEngine.PlayHapticPattern(testPattern);
+                // 503 when there is no output to reach, 500 when an open output refused the tone.
+                context.Response.StatusCode = opened ? 500 : 503;
+                await WriteJsonAsync(context, new
+                {
+                    success = false,
+                    played = false,
+                    error = playback.Error,
+                    audio = BuildStatusPayload()
+                });
+                return;
+            }
 
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                success = true, 
-                message = "Audio test completed successfully",
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                played = true,
+                message = $"Played a {testPattern.Duration} ms tone at {testPattern.Frequency} Hz and " +
+                    $"{testPattern.Intensity}% intensity.",
                 pattern = new
                 {
                     name = testPattern.Name,
@@ -216,13 +252,9 @@ public class AudioApiController
                     duration = testPattern.Duration,
                     intensity = testPattern.Intensity
                 },
-                device = new
-                {
-                    id = _settings.Audio.AudioDeviceId,
-                    endpointId = _settings.Audio.AudioDeviceEndpointId,
-                    name = _settings.Audio.AudioDeviceName
-                }
-            }));
+                stop = "/api/audio/stop",
+                audio = BuildStatusPayload()
+            });
         }
         catch (Exception ex)
         {
@@ -230,6 +262,104 @@ public class AudioApiController
             context.Response.StatusCode = 500;
             await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
         }
+    }
+
+    /// <summary>
+    /// Silences everything playing right now. This is the way out of a tone that is too strong, so
+    /// it takes effect immediately rather than waiting for the effect's own cleanup.
+    /// </summary>
+    public async Task StopAudio(HttpContext context)
+    {
+        try
+        {
+            var stopped = _audioEngine.StopAllEffects();
+            _logger.LogInformation("Stopped {Count} active audio effect(s) on request", stopped);
+
+            await WriteJsonAsync(context, new
+            {
+                success = true,
+                stopped,
+                message = stopped == 0
+                    ? "Nothing was playing."
+                    : $"Stopped {stopped} active effect(s).",
+                audio = BuildStatusPayload()
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error stopping audio playback");
+            context.Response.StatusCode = 500;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+        }
+    }
+
+    /// <summary>
+    /// The health contract behind every audio response: selection, backend, initialization state and
+    /// the last playback error, all read from the engine rather than inferred from a 200.
+    /// </summary>
+    private object BuildStatusPayload()
+    {
+        var status = _audioEngine.GetStatus();
+        var devices = GetAvailableAudioDevices();
+        var resolution = ResolveConfiguredDevice(devices);
+
+        return new
+        {
+            initialized = status.Initialized,
+            initializationFailed = status.InitializationFailed,
+            // Null until a device has been opened - naming a backend before then would be a guess.
+            backend = status.Backend,
+            openedAtUtc = status.OpenedAtUtc,
+            lastError = status.LastError,
+            lastPlaybackError = status.LastPlaybackError,
+            lastPlaybackAtUtc = status.LastPlaybackAtUtc,
+            activeEffects = status.ActiveEffects,
+            selectedDevice = new
+            {
+                id = _settings.Audio.AudioDeviceId,
+                endpointId = _settings.Audio.AudioDeviceEndpointId,
+                name = _settings.Audio.AudioDeviceName,
+                resolved = resolution.Status.ToString(),
+                resolvedEndpointId = resolution.EndpointId,
+                resolvedName = resolution.Name,
+                usesSystemDefault = resolution.UsesSystemDefault,
+                reason = resolution.Reason
+            },
+            // What is carrying audio, which is not always what was selected: the engine falls back
+            // to the default output when the saved endpoint cannot be opened.
+            activeDevice = new
+            {
+                endpointId = status.ActiveEndpointId,
+                name = status.ActiveDeviceName
+            },
+            test = new
+            {
+                endpoint = "/api/audio/test",
+                stopEndpoint = "/api/audio/stop",
+                intensity = AudioTestPattern.IntensityFor(_settings.Audio),
+                maxIntensity = _settings.Audio.MaxIntensity,
+                durationMs = AudioTestPattern.DurationMs
+            }
+        };
+    }
+
+    private string DescribeUnavailableOutput()
+    {
+        var status = _audioEngine.GetStatus();
+
+        return string.IsNullOrWhiteSpace(status.LastError)
+            ? "No audio output device could be opened, so nothing was played."
+            : $"No audio output device could be opened, so nothing was played: {status.LastError}";
+    }
+
+    private static Task WriteJsonAsync(HttpContext context, object payload)
+    {
+        context.Response.ContentType = "application/json";
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        }));
     }
 
     // One enumeration for the whole app: the setup wizard, the health checks and this API all read

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -16,14 +16,15 @@ public class SetupApiController
 {
     /// <summary>
     /// The test tone is deliberately gentle: a buttkicker is a physical actuator and the user has
-    /// not set their amplifier gain yet when they reach this step.
+    /// not set their amplifier gain yet when they reach this step. The wizard and the audio tab
+    /// play the same capped tone, so the shape lives in <see cref="AudioTestPattern"/>.
     /// </summary>
-    public const int TestIntensityPercent = 30;
-    public const int TestDurationMs = 800;
-    public const int TestFadeInMs = 200;
-    public const int TestFadeOutMs = 300;
-    public const int MinTestFrequency = 20;
-    public const int MaxTestFrequency = 50;
+    public const int TestIntensityPercent = AudioTestPattern.IntensityPercent;
+    public const int TestDurationMs = AudioTestPattern.DurationMs;
+    public const int TestFadeInMs = AudioTestPattern.FadeInMs;
+    public const int TestFadeOutMs = AudioTestPattern.FadeOutMs;
+    public const int MinTestFrequency = AudioTestPattern.MinFrequency;
+    public const int MaxTestFrequency = AudioTestPattern.MaxFrequency;
 
     private readonly ILogger<SetupApiController> _logger;
     private readonly AppSettings _settings;
@@ -275,33 +276,36 @@ public class SetupApiController
             var pattern = BuildTestPattern();
             var opened = _audioEngine.RetryInitialization();
 
-            if (opened)
-            {
-                await _audioEngine.PlayHapticPattern(pattern);
-            }
+            // A device that opens can still refuse the tone, so the wizard reports the playback
+            // result rather than treating "the device opened" as "the user felt something".
+            var playback = opened
+                ? await _audioEngine.TryPlayHapticPattern(pattern)
+                : AudioPlaybackResult.Failed("No audio output device could be opened.");
 
             var status = _audioEngine.GetStatus();
-            var reason = opened
+            var reason = playback.Played
                 ? $"Played a {pattern.Duration} ms tone at {pattern.Frequency} Hz and {pattern.Intensity}% intensity."
-                : string.IsNullOrWhiteSpace(status.LastError)
-                    ? "No audio output device could be opened, so nothing was played."
-                    : $"No audio output device could be opened, so nothing was played: {status.LastError}";
+                : opened
+                    ? $"The audio device is open but the test tone could not be played: {playback.Error}"
+                    : string.IsNullOrWhiteSpace(status.LastError)
+                        ? "No audio output device could be opened, so nothing was played."
+                        : $"No audio output device could be opened, so nothing was played: {status.LastError}";
 
             var testedAt = _timeProvider.GetUtcNow().UtcDateTime;
             await _setupState.UpdateAsync(state =>
             {
                 state.AudioTestedAtUtc = testedAt;
-                state.AudioTestPlayed = opened;
+                state.AudioTestPlayed = playback.Played;
                 state.AudioTestReason = reason;
             });
 
-            _logger.LogInformation("Setup audio test ran, played: {Played}", opened);
+            _logger.LogInformation("Setup audio test ran, played: {Played}", playback.Played);
 
             await WriteJsonAsync(context, new
             {
-                // Truthfully false when no device could be opened - the request succeeded, the
+                // Truthfully false when nothing reached the output - the request succeeded, the
                 // playback did not.
-                played = opened,
+                played = playback.Played,
                 reason,
                 pattern = new
                 {
@@ -369,16 +373,7 @@ public class SetupApiController
         }
     }
 
-    private HapticPattern BuildTestPattern() => new()
-    {
-        Name = "Setup Audio Test",
-        Pattern = PatternType.SustainedRumble,
-        Frequency = Math.Clamp(_settings.Audio.DefaultFrequency, MinTestFrequency, MaxTestFrequency),
-        Duration = TestDurationMs,
-        Intensity = Math.Min(TestIntensityPercent, Math.Max(1, _settings.Audio.MaxIntensity)),
-        FadeIn = TestFadeInMs,
-        FadeOut = TestFadeOutMs
-    };
+    private HapticPattern BuildTestPattern() => AudioTestPattern.Create(_settings.Audio, "Setup Audio Test");
 
     private async Task<object> BuildStatusAsync()
     {

--- a/src/EDButtkicker/Hosting/WebUiConfiguration.cs
+++ b/src/EDButtkicker/Hosting/WebUiConfiguration.cs
@@ -186,10 +186,22 @@ public static class WebUiConfiguration
                     await controller!.SetAudioDevice(context);
                     return;
                 }
+                else if (path == "/api/audio/status" && method == "GET")
+                {
+                    var controller = context.RequestServices.GetService<AudioApiController>();
+                    await controller!.GetAudioStatus(context);
+                    return;
+                }
                 else if (path == "/api/audio/test" && method == "POST")
                 {
                     var controller = context.RequestServices.GetService<AudioApiController>();
                     await controller!.TestAudio(context);
+                    return;
+                }
+                else if (path == "/api/audio/stop" && method == "POST")
+                {
+                    var controller = context.RequestServices.GetService<AudioApiController>();
+                    await controller!.StopAudio(context);
                     return;
                 }
                 // Journal API

--- a/src/EDButtkicker/Services/AudioEngineService.cs
+++ b/src/EDButtkicker/Services/AudioEngineService.cs
@@ -21,6 +21,13 @@ public class AudioEngineService : IDisposable
     private bool _initializationFailed = false;
     private string? _lastInitializationError;
     private DateTime? _openedAtUtc;
+    // What was actually opened, as opposed to what the settings asked for: the fallback path can
+    // land on a different backend and a different endpoint than the saved selection.
+    private string? _backend;
+    private string? _activeEndpointId;
+    private string? _activeDeviceName;
+    private string? _lastPlaybackError;
+    private DateTime? _lastPlaybackAtUtc;
     private readonly Dictionary<string, SignalGenerator> _activeGenerators = new();
     private readonly Dictionary<string, CancellationTokenSource> _activeCancellations = new();
 
@@ -129,7 +136,13 @@ public class AudioEngineService : IDisposable
                 _initializationFailed,
                 _lastInitializationError,
                 _settings.Audio.AudioDeviceName,
-                _openedAtUtc);
+                _openedAtUtc,
+                _backend,
+                _activeDeviceName,
+                _activeEndpointId,
+                _lastPlaybackError,
+                _lastPlaybackAtUtc,
+                _activeGenerators.Count);
         }
     }
 
@@ -149,28 +162,35 @@ public class AudioEngineService : IDisposable
     }
 
     /// <summary>
-    /// Plays one pattern. Virtual so tests can observe what would be played without opening a device;
-    /// when no audio device is available this degrades to a no-op instead of throwing.
+    /// Plays one pattern and reports whether it actually reached an open output. Virtual so tests
+    /// can observe what would be played without opening a device. Nothing throws: a caller that
+    /// only wants haptics-if-available can ignore the result, while the test endpoints turn a
+    /// failure into an HTTP failure rather than reporting a success that never made a sound.
     /// </summary>
-    public virtual Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
+    public virtual Task<AudioPlaybackResult> TryPlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
     {
         if (!EnsureInitialized())
         {
             _logger.LogWarning("⚠ Audio engine not initialized, skipping playback for pattern: {PatternName}", pattern.Name);
-            return Task.CompletedTask;
+
+            var reason = string.IsNullOrWhiteSpace(_lastInitializationError)
+                ? "No audio output device could be opened."
+                : $"No audio output device could be opened: {_lastInitializationError}";
+
+            return Task.FromResult(RecordPlaybackFailure(reason));
         }
 
         // Check if wave output is still valid
         if (_waveOut == null)
         {
             _logger.LogError("❌ Wave output is null, cannot play pattern: {PatternName}", pattern.Name);
-            return Task.CompletedTask;
+            return Task.FromResult(RecordPlaybackFailure("The audio output was closed, so nothing could be played."));
         }
 
         var playbackState = _waveOut.PlaybackState;
         if (playbackState != PlaybackState.Playing)
         {
-            _logger.LogWarning("⚠ Wave output not in playing state ({PlaybackState}), attempting to restart for pattern: {PatternName}", 
+            _logger.LogWarning("⚠ Wave output not in playing state ({PlaybackState}), attempting to restart for pattern: {PatternName}",
                 playbackState, pattern.Name);
             try
             {
@@ -180,7 +200,7 @@ public class AudioEngineService : IDisposable
             catch (Exception ex)
             {
                 _logger.LogError(ex, "❌ Failed to restart wave output");
-                return Task.CompletedTask;
+                return Task.FromResult(RecordPlaybackFailure($"The audio output could not be restarted: {ex.Message}"));
             }
         }
 
@@ -260,9 +280,35 @@ public class AudioEngineService : IDisposable
         {
             _logger.LogError(ex, "❌ Error playing haptic pattern '{PatternName}': {ErrorMessage}", pattern.Name, ex.Message);
             LogDetailedAudioError(ex);
+
+            return Task.FromResult(RecordPlaybackFailure($"Playback failed: {ex.Message}"));
         }
-        
-        return Task.CompletedTask;
+
+        lock (_lock)
+        {
+            _lastPlaybackError = null;
+            _lastPlaybackAtUtc = DateTime.UtcNow;
+        }
+
+        return Task.FromResult(AudioPlaybackResult.Success);
+    }
+
+    /// <summary>
+    /// Plays one pattern for callers that want haptics if a device is available and nothing at all
+    /// otherwise - the journal-driven path, where a missing device must not break event handling.
+    /// </summary>
+    public virtual Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null) =>
+        TryPlayHapticPattern(pattern, journalEvent);
+
+    /// <summary>Remembers why the last playback did not reach the output, for the health payload.</summary>
+    private AudioPlaybackResult RecordPlaybackFailure(string error)
+    {
+        lock (_lock)
+        {
+            _lastPlaybackError = error;
+        }
+
+        return AudioPlaybackResult.Failed(error);
     }
 
     private int CalculateIntensity(HapticPattern pattern, JournalEvent? journalEvent)
@@ -306,12 +352,18 @@ public class AudioEngineService : IDisposable
         }
     }
 
-    public void StopAllEffects()
+    /// <summary>
+    /// Silences everything that is playing right now and returns how many effects were stopped.
+    /// This is the panic button behind the UI's stop control, so it takes effect immediately rather
+    /// than waiting for the scheduled cleanup of each effect.
+    /// </summary>
+    public virtual int StopAllEffects()
     {
         lock (_lock)
         {
-            _logger.LogInformation("Stopping all active audio effects");
-            
+            var stopped = _activeGenerators.Count;
+            _logger.LogInformation("Stopping all active audio effects ({Count})", stopped);
+
             foreach (var cancellation in _activeCancellations.Values)
             {
                 cancellation.Cancel();
@@ -319,9 +371,11 @@ public class AudioEngineService : IDisposable
 
             _activeGenerators.Clear();
             _activeCancellations.Clear();
-            
+
             // Clear mixer
             _mixer?.RemoveAllMixerInputs();
+
+            return stopped;
         }
     }
 
@@ -344,6 +398,11 @@ public class AudioEngineService : IDisposable
             _mixer = null;
             _isInitialized = false;
             _openedAtUtc = null;
+            _backend = null;
+            _activeEndpointId = null;
+            _activeDeviceName = null;
+            _lastPlaybackError = null;
+            _lastPlaybackAtUtc = null;
             // A new device deserves a fresh attempt even if the previous one could not be opened.
             _initializationFailed = false;
             _lastInitializationError = null;
@@ -435,7 +494,7 @@ public class AudioEngineService : IDisposable
         {
             // No WASAPI here: the default output is the only thing left to try.
             _logger.LogWarning(ex, "Failed to enumerate WASAPI render endpoints, using the default output");
-            return new WaveOutEvent();
+            return OpenDefaultOutput();
         }
 
         foreach (var line in AudioDeviceDiagnostics.DescribeEnumeration(enumerated, "WASAPI render"))
@@ -459,7 +518,12 @@ public class AudioEngineService : IDisposable
                 _logger.LogInformation("✓ Using audio device: {DeviceName} (endpoint {EndpointId})",
                     endpoint.FriendlyName, resolution.EndpointId);
 
-                return new WasapiOut(endpoint, AudioClientShareMode.Shared, true, 200);
+                var output = new WasapiOut(endpoint, AudioClientShareMode.Shared, true, 200);
+                _backend = "WASAPI";
+                _activeEndpointId = resolution.EndpointId;
+                _activeDeviceName = endpoint.FriendlyName;
+
+                return output;
             }
             catch (Exception ex)
             {
@@ -472,7 +536,22 @@ public class AudioEngineService : IDisposable
             _logger.LogWarning("⚠ {Selection}", resolution.Reason);
         }
 
-        _logger.LogInformation("Using default audio device: {DefaultDevice}", GetDefaultAudioDevice() ?? "Unknown");
+        return OpenDefaultOutput();
+    }
+
+    /// <summary>
+    /// The fallback output. Recorded as its own backend so the health payload can say the saved
+    /// endpoint is not what is playing, instead of implying the selection was honoured.
+    /// </summary>
+    private IWavePlayer OpenDefaultOutput()
+    {
+        var defaultDevice = GetDefaultAudioDevice();
+        _logger.LogInformation("Using default audio device: {DefaultDevice}", defaultDevice ?? "Unknown");
+
+        _backend = "WaveOut";
+        _activeEndpointId = null;
+        _activeDeviceName = defaultDevice;
+
         return new WaveOutEvent();
     }
 
@@ -627,11 +706,29 @@ public class AudioEngineService : IDisposable
 
 /// <summary>
 /// A read of the audio output state that costs nothing: whether a device is open, whether opening
-/// one failed and why, and which device the settings ask for.
+/// one failed and why, which device the settings ask for, which output is actually carrying audio,
+/// and why the last playback did not reach it.
 /// </summary>
 public sealed record AudioEngineStatus(
     bool Initialized,
     bool InitializationFailed,
     string? LastError,
     string? ConfiguredDeviceName,
-    DateTime? OpenedAtUtc);
+    DateTime? OpenedAtUtc,
+    string? Backend = null,
+    string? ActiveDeviceName = null,
+    string? ActiveEndpointId = null,
+    string? LastPlaybackError = null,
+    DateTime? LastPlaybackAtUtc = null,
+    int ActiveEffects = 0);
+
+/// <summary>
+/// Whether one playback attempt actually reached an open output, and why not when it did not.
+/// A "test" that only scheduled work is not a success, so this is what the test endpoints report.
+/// </summary>
+public sealed record AudioPlaybackResult(bool Played, string? Error)
+{
+    public static AudioPlaybackResult Success { get; } = new(true, null);
+
+    public static AudioPlaybackResult Failed(string error) => new(false, error);
+}

--- a/src/EDButtkicker/Services/AudioTestPattern.cs
+++ b/src/EDButtkicker/Services/AudioTestPattern.cs
@@ -1,0 +1,34 @@
+using EDButtkicker.Configuration;
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// The tone every "test" button plays. A buttkicker is a physical actuator sitting under the user's
+/// seat and a test click is exactly the moment their amplifier gain is still unknown, so the level
+/// is capped here rather than at each call site: the configured maximum only ever lowers it.
+/// </summary>
+public static class AudioTestPattern
+{
+    public const int IntensityPercent = 30;
+    public const int DurationMs = 800;
+    public const int FadeInMs = 200;
+    public const int FadeOutMs = 300;
+    public const int MinFrequency = 20;
+    public const int MaxFrequency = 50;
+
+    /// <summary>The level a test tone plays at: never above the cap, never above the user's own.</summary>
+    public static int IntensityFor(AudioSettings audio) =>
+        Math.Min(IntensityPercent, Math.Max(1, audio.MaxIntensity));
+
+    public static HapticPattern Create(AudioSettings audio, string name) => new()
+    {
+        Name = name,
+        Pattern = PatternType.SustainedRumble,
+        Frequency = Math.Clamp(audio.DefaultFrequency, MinFrequency, MaxFrequency),
+        Duration = DurationMs,
+        Intensity = IntensityFor(audio),
+        FadeIn = FadeInMs,
+        FadeOut = FadeOutMs
+    };
+}

--- a/src/EDButtkicker/wwwroot/index.html
+++ b/src/EDButtkicker/wwwroot/index.html
@@ -251,6 +251,9 @@
                     <button class="btn btn-primary" data-bind="testAudio">
                         <i class="fas fa-play"></i> Test Audio
                     </button>
+                    <button class="btn btn-secondary" data-bind="stopAudio">
+                        <i class="fas fa-stop"></i> Stop
+                    </button>
                 </div>
 
                 <div class="audio-config">

--- a/src/EDButtkicker/wwwroot/js/app.js
+++ b/src/EDButtkicker/wwwroot/js/app.js
@@ -1012,20 +1012,44 @@ window.selectAudioDevice = async (endpointId, deviceId) => {
     }
 };
 
+// The server only answers 2xx when the tone actually reached an open output, so the toast repeats
+// what it said rather than claiming success because a request was accepted.
 window.testAudio = async () => {
     try {
         const response = await fetch('/api/audio/test', {
             method: 'POST'
         });
 
+        const result = await response.json().catch(() => ({}));
+
         if (response.ok) {
-            app.showToast('Audio test completed!', 'success');
+            app.showToast(result.message || 'Audio test played.', 'success');
         } else {
-            app.showToast('Error testing audio', 'error');
+            app.showToast(result.error || 'The audio test could not be played', 'error');
         }
     } catch (error) {
         console.error('Error testing audio:', error);
         app.showToast('Error testing audio', 'error');
+    }
+};
+
+// The way out of a tone that is too strong: stops everything already playing, immediately.
+window.stopAudio = async () => {
+    try {
+        const response = await fetch('/api/audio/stop', {
+            method: 'POST'
+        });
+
+        const result = await response.json().catch(() => ({}));
+
+        if (response.ok) {
+            app.showToast(result.message || 'Playback stopped.', 'success');
+        } else {
+            app.showToast(result.error || 'Error stopping playback', 'error');
+        }
+    } catch (error) {
+        console.error('Error stopping playback:', error);
+        app.showToast('Error stopping playback', 'error');
     }
 };
 

--- a/tests/EDButtkicker.Tests/AudioTestPlaybackApiTests.cs
+++ b/tests/EDButtkicker.Tests/AudioTestPlaybackApiTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// The audio tab's Test button used to answer 200 as soon as playback was scheduled, so a rig with
+/// no reachable output looked healthy. These pin the contract instead: the request only succeeds
+/// when the tone reached an open output, the failure says which of the two things went wrong, the
+/// level stays gentle, and there is a way to stop what is playing.
+/// </summary>
+public class AudioTestPlaybackApiTests : IDisposable
+{
+    private readonly TempDirectory _settingsDir = new("edbk-audio-test");
+
+    private SetupTestHost NewHost(AppSettings settings, FakeAudioEngine engine) =>
+        new(_settingsDir.Path, settings, audioEngine: engine);
+
+    [Fact]
+    public async Task Test_PlaysAQuietToneAndReportsTheOpenOutput()
+    {
+        var settings = new AppSettings();
+        settings.Audio.AudioDeviceName = "ButtKicker Amp";
+        settings.Audio.AudioDeviceEndpointId = FakeAudioDeviceCatalog.EndpointIdFor(0);
+        var engine = new FakeAudioEngine(settings);
+        using var host = NewHost(settings, engine);
+
+        var response = await host.PostAsync("/api/audio/test");
+        var body = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.True(body.GetProperty("played").GetBoolean());
+
+        var audio = body.GetProperty("audio");
+        Assert.True(audio.GetProperty("initialized").GetBoolean());
+        Assert.Equal("FakeOut", audio.GetProperty("backend").GetString());
+        Assert.Equal(
+            FakeAudioDeviceCatalog.EndpointIdFor(0),
+            audio.GetProperty("selectedDevice").GetProperty("endpointId").GetString());
+        Assert.Equal(JsonValueKind.Null, audio.GetProperty("lastPlaybackError").ValueKind);
+
+        var played = Assert.Single(engine.Played);
+        Assert.True(played.Intensity <= AudioTestPattern.IntensityPercent, "the test tone must stay quiet");
+        Assert.Equal(AudioTestPattern.DurationMs, played.Duration);
+        Assert.InRange(played.Frequency, AudioTestPattern.MinFrequency, AudioTestPattern.MaxFrequency);
+    }
+
+    [Fact]
+    public async Task Test_WithNoOutputToReach_FailsAndNamesTheReason()
+    {
+        var settings = new AppSettings();
+        var engine = new FakeAudioEngine(settings, canOpen: false);
+        engine.FailureReason = "the ButtKicker amp is not connected";
+        using var host = NewHost(settings, engine);
+
+        var response = await host.PostAsync("/api/audio/test");
+        var body = await SetupTestHost.ReadJsonAsync(response);
+
+        // Not a 200 with a "scheduled" success: nothing was played, so the request failed.
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.False(body.GetProperty("played").GetBoolean());
+        Assert.Contains("not connected", body.GetProperty("error").GetString());
+        Assert.Empty(engine.Played);
+
+        var audio = body.GetProperty("audio");
+        Assert.False(audio.GetProperty("initialized").GetBoolean());
+        Assert.True(audio.GetProperty("initializationFailed").GetBoolean());
+        // Nothing was opened, so naming a backend would be a guess.
+        Assert.Equal(JsonValueKind.Null, audio.GetProperty("backend").ValueKind);
+    }
+
+    [Fact]
+    public async Task Test_WhenAnOpenOutputRefusesTheTone_FailsAndKeepsTheError()
+    {
+        var settings = new AppSettings();
+        var engine = new FakeAudioEngine(settings) { PlaybackFailure = "Playback failed: the mixer rejected the input" };
+        using var host = NewHost(settings, engine);
+
+        var response = await host.PostAsync("/api/audio/test");
+        var body = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.False(body.GetProperty("played").GetBoolean());
+        Assert.Contains("the mixer rejected the input", body.GetProperty("error").GetString());
+        Assert.Empty(engine.Played);
+
+        // The device is open, and the failure is remembered as a playback error rather than as an
+        // initialization one - the health payload has to be able to tell those apart.
+        var audio = body.GetProperty("audio");
+        Assert.True(audio.GetProperty("initialized").GetBoolean());
+        Assert.Contains("the mixer rejected the input", audio.GetProperty("lastPlaybackError").GetString());
+
+        // And it is still readable afterwards, without playing anything.
+        var status = await host.GetJsonAsync("/api/audio/status");
+        Assert.Contains("the mixer rejected the input", status.GetProperty("lastPlaybackError").GetString());
+    }
+
+    [Fact]
+    public async Task Status_ReportsThePendingStateWithoutOpeningADevice()
+    {
+        var settings = new AppSettings();
+        var engine = new FakeAudioEngine(settings);
+        using var host = NewHost(settings, engine);
+
+        var status = await host.GetJsonAsync("/api/audio/status");
+
+        Assert.False(status.GetProperty("initialized").GetBoolean());
+        Assert.False(status.GetProperty("initializationFailed").GetBoolean());
+        Assert.Equal(0, engine.OpenAttempts);
+
+        // The advertised test level is the capped one, not the user's maximum.
+        Assert.Equal(AudioTestPattern.IntensityPercent, status.GetProperty("test").GetProperty("intensity").GetInt32());
+        Assert.Equal("/api/audio/stop", status.GetProperty("test").GetProperty("stopEndpoint").GetString());
+    }
+
+    [Fact]
+    public async Task Test_NeverExceedsTheConfiguredMaximum()
+    {
+        var settings = new AppSettings();
+        settings.Audio.MaxIntensity = 10;
+        var engine = new FakeAudioEngine(settings);
+        using var host = NewHost(settings, engine);
+
+        Assert.True((await host.PostAsync("/api/audio/test")).IsSuccessStatusCode);
+
+        Assert.Equal(10, Assert.Single(engine.Played).Intensity);
+    }
+
+    [Fact]
+    public async Task Stop_SilencesWhatIsPlaying()
+    {
+        var settings = new AppSettings();
+        var engine = new FakeAudioEngine(settings);
+        using var host = NewHost(settings, engine);
+
+        Assert.True((await host.PostAsync("/api/audio/test")).IsSuccessStatusCode);
+
+        var response = await host.PostAsync("/api/audio/stop");
+        var body = await SetupTestHost.ReadJsonAsync(response);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(1, body.GetProperty("stopped").GetInt32());
+        Assert.Equal(1, engine.StopRequests);
+        Assert.Equal(0, body.GetProperty("audio").GetProperty("activeEffects").GetInt32());
+    }
+
+    public void Dispose() => _settingsDir.Dispose();
+}

--- a/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
+++ b/tests/EDButtkicker.Tests/DependencyInjectionGraphTests.cs
@@ -109,11 +109,16 @@ public class DependencyInjectionGraphTests : IClassFixture<WebUiTestServerFixtur
 
         // 4xx is fine - these requests carry deliberately minimal bodies. 5xx means the route could
         // not be served at all, which is what a broken service graph looks like from the outside.
-        // The one documented exception is the import endpoint, which answers 501 by design.
+        // Two documented exceptions: the import endpoint answers 501 by design, and the audio test
+        // answers 503 on a machine with no output device, which is the whole point of that route -
+        // it refuses to report a success it cannot back up.
         var allowNotImplemented = path == "/api/PatternFiles/import";
+        var allowNoAudioDevice = path == "/api/audio/test";
 
         Assert.True(
-            status < 500 || (allowNotImplemented && status == (int)HttpStatusCode.NotImplemented),
+            status < 500
+                || (allowNotImplemented && status == (int)HttpStatusCode.NotImplemented)
+                || (allowNoAudioDevice && status == (int)HttpStatusCode.ServiceUnavailable),
             $"{method} {path} returned {status}: {body}");
     }
 

--- a/tests/EDButtkicker.Tests/SetupTestSupport.cs
+++ b/tests/EDButtkicker.Tests/SetupTestSupport.cs
@@ -73,13 +73,16 @@ internal sealed class FakeAudioDeviceCatalog : IAudioDeviceCatalog
 /// <summary>
 /// An audio engine that reports device state without opening one. <see cref="FailuresBeforeSuccess"/>
 /// models the machine where the device only opens on a second attempt, which is what the health
-/// retry exists for.
+/// retry exists for, and <see cref="PlaybackFailure"/> the one where the device opens but the tone
+/// never reaches it.
 /// </summary>
 internal sealed class FakeAudioEngine : AudioEngineService
 {
     private readonly AppSettings _settings;
     private bool _opened;
     private bool _attempted;
+    private string? _lastPlaybackError;
+    private DateTime? _lastPlaybackAtUtc;
 
     public FakeAudioEngine(AppSettings settings, bool canOpen = true, int failuresBeforeSuccess = 0)
         : base(NullLogger<AudioEngineService>.Instance, settings)
@@ -95,9 +98,16 @@ internal sealed class FakeAudioEngine : AudioEngineService
 
     public string FailureReason { get; set; } = "no output device is available";
 
+    /// <summary>When set, the device opens and playback still fails - with this as the reason.</summary>
+    public string? PlaybackFailure { get; set; }
+
+    public string Backend { get; set; } = "FakeOut";
+
     public List<HapticPattern> Played { get; } = new();
 
     public int OpenAttempts { get; private set; }
+
+    public int StopRequests { get; private set; }
 
     public override bool EnsureInitialized()
     {
@@ -120,13 +130,30 @@ internal sealed class FakeAudioEngine : AudioEngineService
         _attempted && !_opened,
         _opened ? null : FailureReason,
         _settings.Audio.AudioDeviceName,
-        _opened ? DateTime.UtcNow : null);
+        _opened ? DateTime.UtcNow : null,
+        _opened ? Backend : null,
+        _opened ? _settings.Audio.AudioDeviceName : null,
+        _opened ? _settings.Audio.AudioDeviceEndpointId : null,
+        _lastPlaybackError,
+        _lastPlaybackAtUtc,
+        ActiveEffects);
 
-    public override Task PlayHapticPattern(HapticPattern pattern, JournalEvent? journalEvent = null)
+    public int ActiveEffects { get; private set; }
+
+    public override Task<AudioPlaybackResult> TryPlayHapticPattern(
+        HapticPattern pattern,
+        JournalEvent? journalEvent = null)
     {
         if (!EnsureInitialized())
         {
-            return Task.CompletedTask;
+            _lastPlaybackError = $"No audio output device could be opened: {FailureReason}";
+            return Task.FromResult(AudioPlaybackResult.Failed(_lastPlaybackError));
+        }
+
+        if (PlaybackFailure != null)
+        {
+            _lastPlaybackError = PlaybackFailure;
+            return Task.FromResult(AudioPlaybackResult.Failed(PlaybackFailure));
         }
 
         lock (Played)
@@ -134,7 +161,21 @@ internal sealed class FakeAudioEngine : AudioEngineService
             Played.Add(pattern);
         }
 
-        return Task.CompletedTask;
+        ActiveEffects++;
+        _lastPlaybackError = null;
+        _lastPlaybackAtUtc = DateTime.UtcNow;
+
+        return Task.FromResult(AudioPlaybackResult.Success);
+    }
+
+    public override int StopAllEffects()
+    {
+        StopRequests++;
+
+        var stopped = ActiveEffects;
+        ActiveEffects = 0;
+
+        return stopped;
     }
 }
 


### PR DESCRIPTION
## Summary
- `/api/audio/test` now fails (503/500) unless a tone actually reaches an open output, instead of returning 200 after scheduling playback.
- `/api/audio/status` exposes selected endpoint, backend, initialization state, last playback error, and a conservative test level.
- `/api/audio/stop` cancels in-flight effects immediately; the audio tab has a Stop button.
- Shared `AudioTestPattern` caps test intensity at 30% (or the user's max if lower). Wizard and audio-tab tests use the same tone.

## Test plan
- [x] `dotnet test` on Linux: 486 passed, 0 failed (fake-audio: success, unavailable endpoint, playback failure, stop, intensity cap).
- [ ] Windows WASAPI / physical Buttkicker playback is not claimed from this host.

Closes #22
