### PR TITLE
fix(settings): persist mutations and report restart vs live apply

### DIFF
--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -13,17 +13,20 @@ public class AudioApiController
     private readonly AppSettings _settings;
     private readonly AudioEngineService _audioEngine;
     private readonly IAudioDeviceCatalog _deviceCatalog;
+    private readonly SettingsPersistenceService _settingsPersistence;
 
     public AudioApiController(
         ILogger<AudioApiController> logger,
         AppSettings settings,
         AudioEngineService audioEngine,
-        IAudioDeviceCatalog deviceCatalog)
+        IAudioDeviceCatalog deviceCatalog,
+        SettingsPersistenceService settingsPersistence)
     {
         _logger = logger;
         _settings = settings;
         _audioEngine = audioEngine;
         _deviceCatalog = deviceCatalog;
+        _settingsPersistence = settingsPersistence;
     }
 
     public async Task GetAudioDevices(HttpContext context)
@@ -140,41 +143,40 @@ public class AudioApiController
             // endpoint id and empty name the audio engine already reads as "use the default".
             var isSystemDefault = selectedDevice.DeviceId == WasapiAudioDeviceCatalog.SystemDefaultDeviceId;
 
-            _settings.Audio.AudioDeviceEndpointId = isSystemDefault ? string.Empty : selectedDevice.EndpointId;
-            _settings.Audio.AudioDeviceName = isSystemDefault ? string.Empty : selectedDevice.Name;
-            _settings.Audio.AudioDeviceId = selectedDevice.DeviceId;
-
-            _logger.LogInformation("Audio device changed to: {DeviceName} (endpoint {EndpointId}, ordinal {DeviceId})",
-                selectedDevice.Name, _settings.Audio.AudioDeviceEndpointId, selectedDevice.DeviceId);
-
-            // Reinitialize the audio engine with the new device
-            try
+            // The selection is applied, taken live (the engine releases the open output so the next
+            // pattern opens this one) and written to the settings file by the one persistence
+            // service, so the device is still selected after a restart.
+            var result = await _settingsPersistence.ApplyAsync(new SettingsUpdate
             {
-                _audioEngine.Reinitialize();
-                _logger.LogInformation("Audio engine reinitialized successfully with endpoint {EndpointId}",
-                    _settings.Audio.AudioDeviceEndpointId);
-            }
-            catch (Exception ex)
+                AudioDeviceEndpointId = isSystemDefault ? string.Empty : selectedDevice.EndpointId,
+                AudioDeviceName = isSystemDefault ? string.Empty : selectedDevice.Name,
+                AudioDeviceId = selectedDevice.DeviceId
+            });
+
+            if (!result.Valid)
             {
-                _logger.LogError(ex, "Failed to reinitialize audio engine with new device");
-                context.Response.StatusCode = 500;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Failed to initialize new audio device: " + ex.Message }));
+                context.Response.StatusCode = 400;
+                await WriteJsonAsync(context, new { error = result.Message, validation_errors = result.ValidationErrors });
                 return;
             }
 
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                success = true, 
-                message = "Audio device updated successfully",
+            _logger.LogInformation("Audio device changed to: {DeviceName} (endpoint {EndpointId}, ordinal {DeviceId}): {Message}",
+                selectedDevice.Name, _settings.Audio.AudioDeviceEndpointId, selectedDevice.DeviceId, result.Message);
+
+            context.Response.StatusCode = result.Saved ? 200 : 500;
+            await WriteJsonAsync(context, new
+            {
+                success = result.Saved,
+                message = result.Message,
                 device = new
                 {
                     id = selectedDevice.DeviceId,
                     endpointId = selectedDevice.EndpointId,
                     name = selectedDevice.Name,
                     driver = selectedDevice.Driver
-                }
-            }));
+                },
+                settings = result.ToPayload()
+            });
         }
         catch (Exception ex)
         {

--- a/src/EDButtkicker/Controllers/ConfigurationApiController.cs
+++ b/src/EDButtkicker/Controllers/ConfigurationApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
 
 namespace EDButtkicker.Controllers;
@@ -9,11 +10,16 @@ public class ConfigurationApiController
 {
     private readonly ILogger<ConfigurationApiController> _logger;
     private readonly AppSettings _settings;
+    private readonly SettingsPersistenceService _settingsPersistence;
 
-    public ConfigurationApiController(ILogger<ConfigurationApiController> logger, AppSettings settings)
+    public ConfigurationApiController(
+        ILogger<ConfigurationApiController> logger,
+        AppSettings settings,
+        SettingsPersistenceService settingsPersistence)
     {
         _logger = logger;
         _settings = settings;
+        _settingsPersistence = settingsPersistence;
     }
 
     public async Task GetConfiguration(HttpContext context)
@@ -50,71 +56,66 @@ public class ConfigurationApiController
         }
     }
 
+    /// <summary>
+    /// The settings the web UI edits. Nothing is written to the running configuration here: the
+    /// request is turned into an update and handed to the one service that validates it, applies
+    /// what can be applied now, and persists the result - so a 200 here is a change that survives a
+    /// restart, and the response says which parts are live already.
+    /// </summary>
     public async Task UpdateConfiguration(HttpContext context)
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var root = await ReadJsonAsync(context);
+            if (root == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
+                await WriteBadRequestAsync(context, "Request body is empty");
                 return;
             }
 
-            var configUpdate = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (configUpdate == null)
+            if (root.Value.ValueKind != JsonValueKind.Object)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid JSON format" }));
+                await WriteBadRequestAsync(context, "Invalid JSON format");
                 return;
             }
 
-            // Update individual settings
-            if (configUpdate.ContainsKey("audio"))
+            var update = new SettingsUpdate();
+
+            if (TryGetSection(root.Value, "audio", out var audio))
             {
-                var audioJson = configUpdate["audio"].ToString();
-                if (!string.IsNullOrEmpty(audioJson))
-                {
-                    var audioSettings = JsonSerializer.Deserialize<Dictionary<string, object>>(audioJson);
-                    if (audioSettings != null)
-                    {
-                        if (audioSettings.ContainsKey("AudioDeviceId") && int.TryParse(audioSettings["AudioDeviceId"].ToString(), out int deviceId))
-                            _settings.Audio.AudioDeviceId = deviceId;
-                        if (audioSettings.ContainsKey("AudioDeviceEndpointId"))
-                            _settings.Audio.AudioDeviceEndpointId = audioSettings["AudioDeviceEndpointId"].ToString() ?? _settings.Audio.AudioDeviceEndpointId;
-                        if (audioSettings.ContainsKey("AudioDeviceName"))
-                            _settings.Audio.AudioDeviceName = audioSettings["AudioDeviceName"].ToString() ?? _settings.Audio.AudioDeviceName;
-                        if (audioSettings.ContainsKey("MaxIntensity") && int.TryParse(audioSettings["MaxIntensity"].ToString(), out int maxIntensity))
-                            _settings.Audio.MaxIntensity = maxIntensity;
-                        if (audioSettings.ContainsKey("DefaultFrequency") && int.TryParse(audioSettings["DefaultFrequency"].ToString(), out int defaultFreq))
-                            _settings.Audio.DefaultFrequency = defaultFreq;
-                    }
-                }
+                update.AudioDeviceId = ReadInt(audio, "AudioDeviceId");
+                update.AudioDeviceEndpointId = ReadString(audio, "AudioDeviceEndpointId");
+                update.AudioDeviceName = ReadString(audio, "AudioDeviceName");
+                update.MaxIntensity = ReadInt(audio, "MaxIntensity");
+                update.DefaultFrequency = ReadInt(audio, "DefaultFrequency");
+                update.SampleRate = ReadInt(audio, "SampleRate");
+                update.BufferSize = ReadInt(audio, "BufferSize");
             }
 
-            if (configUpdate.ContainsKey("eliteDangerous"))
+            if (TryGetSection(root.Value, "eliteDangerous", out var eliteDangerous))
             {
-                var edJson = configUpdate["eliteDangerous"].ToString();
-                if (!string.IsNullOrEmpty(edJson))
-                {
-                    var edSettings = JsonSerializer.Deserialize<Dictionary<string, object>>(edJson);
-                    if (edSettings != null)
-                    {
-                        if (edSettings.ContainsKey("JournalPath"))
-                            _settings.EliteDangerous.JournalPath = edSettings["JournalPath"].ToString() ?? _settings.EliteDangerous.JournalPath;
-                        if (edSettings.ContainsKey("MonitorLatestOnly") && bool.TryParse(edSettings["MonitorLatestOnly"].ToString(), out bool monitorLatest))
-                            _settings.EliteDangerous.MonitorLatestOnly = monitorLatest;
-                    }
-                }
+                update.JournalPath = ReadString(eliteDangerous, "JournalPath");
+                update.MonitorLatestOnly = ReadBool(eliteDangerous, "MonitorLatestOnly");
             }
 
-            _logger.LogInformation("Configuration updated via web interface");
+            var result = await _settingsPersistence.ApplyAsync(update);
 
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { success = true, message = "Configuration updated successfully" }));
+            if (!result.Valid)
+            {
+                await WriteBadRequestAsync(context, result.Message, result);
+                return;
+            }
+
+            _logger.LogInformation("Configuration updated via web interface: {Message}", result.Message);
+
+            // A change that only reached memory is not a successful configuration change: say so.
+            context.Response.StatusCode = result.Saved ? 200 : 500;
+            await WriteJsonAsync(context, new
+            {
+                success = result.Saved,
+                message = result.Message,
+                settings = result.ToPayload()
+            });
         }
         catch (Exception ex)
         {
@@ -165,86 +166,55 @@ public class ConfigurationApiController
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var root = await ReadJsonAsync(context);
+            if (root == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "No configuration data provided" }));
+                await WriteBadRequestAsync(context, "No configuration data provided");
                 return;
             }
 
-            var importData = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (importData?.ContainsKey("configuration") != true)
+            if (root.Value.ValueKind != JsonValueKind.Object ||
+                !TryGetSection(root.Value, "configuration", out var configuration))
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid configuration format" }));
+                await WriteBadRequestAsync(context, "Invalid configuration format");
                 return;
             }
 
-            var configJson = importData["configuration"].ToString();
-            if (string.IsNullOrEmpty(configJson))
+            var update = new SettingsUpdate();
+
+            if (TryGetSection(configuration, "Audio", out var audio))
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Configuration data is empty" }));
+                update.MaxIntensity = ReadInt(audio, "MaxIntensity");
+                update.DefaultFrequency = ReadInt(audio, "DefaultFrequency");
+                update.SampleRate = ReadInt(audio, "SampleRate");
+                update.BufferSize = ReadInt(audio, "BufferSize");
+            }
+
+            if (TryGetSection(configuration, "EliteDangerous", out var eliteDangerous))
+            {
+                update.MonitorLatestOnly = ReadBool(eliteDangerous, "MonitorLatestOnly");
+                // The journal path is still deliberately not imported: an exported file names a
+                // folder on the machine it came from.
+            }
+
+            var result = await _settingsPersistence.ApplyAsync(update);
+
+            if (!result.Valid)
+            {
+                await WriteBadRequestAsync(context, result.Message, result);
                 return;
             }
 
-            var configData = JsonSerializer.Deserialize<Dictionary<string, object>>(configJson);
-            if (configData == null)
+            _logger.LogInformation("Configuration imported via web interface: {Message}", result.Message);
+
+            context.Response.StatusCode = result.Saved ? 200 : 500;
+            await WriteJsonAsync(context, new
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Failed to parse configuration data" }));
-                return;
-            }
-
-            // Import audio settings
-            if (configData.ContainsKey("Audio"))
-            {
-                var audioJson = configData["Audio"].ToString();
-                if (!string.IsNullOrEmpty(audioJson))
-                {
-                    var audioSettings = JsonSerializer.Deserialize<Dictionary<string, object>>(audioJson);
-                    if (audioSettings != null)
-                    {
-                        if (audioSettings.ContainsKey("MaxIntensity") && int.TryParse(audioSettings["MaxIntensity"].ToString(), out int maxIntensity))
-                            _settings.Audio.MaxIntensity = maxIntensity;
-                        if (audioSettings.ContainsKey("DefaultFrequency") && int.TryParse(audioSettings["DefaultFrequency"].ToString(), out int defaultFreq))
-                            _settings.Audio.DefaultFrequency = defaultFreq;
-                        if (audioSettings.ContainsKey("SampleRate") && int.TryParse(audioSettings["SampleRate"].ToString(), out int sampleRate))
-                            _settings.Audio.SampleRate = sampleRate;
-                        if (audioSettings.ContainsKey("BufferSize") && int.TryParse(audioSettings["BufferSize"].ToString(), out int bufferSize))
-                            _settings.Audio.BufferSize = bufferSize;
-                    }
-                }
-            }
-
-            // Import Elite Dangerous settings
-            if (configData.ContainsKey("EliteDangerous"))
-            {
-                var edJson = configData["EliteDangerous"].ToString();
-                if (!string.IsNullOrEmpty(edJson))
-                {
-                    var edSettings = JsonSerializer.Deserialize<Dictionary<string, object>>(edJson);
-                    if (edSettings != null)
-                    {
-                        if (edSettings.ContainsKey("MonitorLatestOnly") && bool.TryParse(edSettings["MonitorLatestOnly"].ToString(), out bool monitorLatest))
-                            _settings.EliteDangerous.MonitorLatestOnly = monitorLatest;
-                        // Don't auto-import journal path for security
-                    }
-                }
-            }
-
-            _logger.LogInformation("Configuration imported via web interface");
-
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                success = true, 
-                message = "Configuration imported successfully",
-                imported_at = DateTime.UtcNow
-            }));
+                success = result.Saved,
+                message = result.Message,
+                imported_at = DateTime.UtcNow,
+                settings = result.ToPayload()
+            });
         }
         catch (Exception ex)
         {
@@ -252,5 +222,113 @@ public class ConfigurationApiController
             context.Response.StatusCode = 500;
             await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
         }
+    }
+
+    private static async Task<JsonElement?> ReadJsonAsync(HttpContext context)
+    {
+        using var reader = new StreamReader(context.Request.Body);
+        var json = await reader.ReadToEndAsync();
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// A nested object by name, case-insensitively: the web UI sends camelCase and an exported
+    /// configuration file carries the PascalCase property names of the settings classes.
+    /// </summary>
+    private static bool TryGetSection(JsonElement parent, string name, out JsonElement section)
+    {
+        if (parent.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in parent.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase) &&
+                    property.Value.ValueKind == JsonValueKind.Object)
+                {
+                    section = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        section = default;
+        return false;
+    }
+
+    private static bool TryGetValue(JsonElement section, string name, out JsonElement value)
+    {
+        if (section.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in section.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static int? ReadInt(JsonElement section, string name)
+    {
+        if (!TryGetValue(section, name, out var value)) return null;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetInt32(out var number) => number,
+            JsonValueKind.String when int.TryParse(value.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static bool? ReadBool(JsonElement section, string name)
+    {
+        if (!TryGetValue(section, name, out var value)) return null;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String when bool.TryParse(value.GetString(), out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static string? ReadString(JsonElement section, string name) =>
+        TryGetValue(section, name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static Task WriteJsonAsync(HttpContext context, object payload)
+    {
+        context.Response.ContentType = "application/json";
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        }));
+    }
+
+    private static Task WriteBadRequestAsync(HttpContext context, string error, SettingsUpdateResult? result = null)
+    {
+        context.Response.StatusCode = 400;
+
+        return WriteJsonAsync(context, new
+        {
+            error,
+            // Named individually so the UI can show which value was refused, and why.
+            validation_errors = result?.ValidationErrors ?? Array.Empty<string>(),
+            settings = result?.ToPayload()
+        });
     }
 }

--- a/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
+++ b/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
@@ -12,15 +12,18 @@ public class ContextualIntelligenceApiController
 	private readonly ILogger<ContextualIntelligenceApiController> _logger;
 	private readonly AppSettings _settings;
 	private readonly ContextualIntelligenceService _contextualIntelligence;
+	private readonly SettingsPersistenceService _settingsPersistence;
 
 	public ContextualIntelligenceApiController(
 		ILogger<ContextualIntelligenceApiController> logger,
 		AppSettings settings,
-		ContextualIntelligenceService contextualIntelligence)
+		ContextualIntelligenceService contextualIntelligence,
+		SettingsPersistenceService settingsPersistence)
 	{
 		_logger = logger;
 		_settings = settings;
 		_contextualIntelligence = contextualIntelligence;
+		_settingsPersistence = settingsPersistence;
 	}
 
 	public async Task GetContextualIntelligenceStatus(HttpContext context)
@@ -122,40 +125,61 @@ public class ContextualIntelligenceApiController
 				return;
 			}
 
-			if (_settings.ContextualIntelligence == null)
-				_settings.ContextualIntelligence = new ContextualIntelligenceConfiguration();
-
-			var config = _settings.ContextualIntelligence;
+			var update = new SettingsUpdate();
 
 			if (configUpdate.ContainsKey("enabled") && bool.TryParse(configUpdate["enabled"].ToString(), out bool enabled))
-				config.Enabled = enabled;
+				update.ContextualIntelligenceEnabled = enabled;
 
+			// Both rates are clamped rather than refused, as they always were: they arrive from
+			// sliders, and a slider at its end stop is not a mistake worth an error.
 			if (configUpdate.ContainsKey("learning_rate") && double.TryParse(configUpdate["learning_rate"].ToString(), out double learningRate))
-				config.LearningRate = Math.Max(0.01, Math.Min(1.0, learningRate));
+				update.LearningRate = Math.Clamp(learningRate, 0.01, 1.0);
 
 			if (configUpdate.ContainsKey("prediction_threshold") && double.TryParse(configUpdate["prediction_threshold"].ToString(), out double predictionThreshold))
-				config.PredictionThreshold = Math.Max(0.1, Math.Min(1.0, predictionThreshold));
+				update.PredictionThreshold = Math.Clamp(predictionThreshold, 0.1, 1.0);
 
 			if (configUpdate.ContainsKey("adaptive_intensity") && bool.TryParse(configUpdate["adaptive_intensity"].ToString(), out bool adaptiveIntensity))
-				config.EnableAdaptiveIntensity = adaptiveIntensity;
+				update.EnableAdaptiveIntensity = adaptiveIntensity;
 
 			if (configUpdate.ContainsKey("predictive_patterns") && bool.TryParse(configUpdate["predictive_patterns"].ToString(), out bool predictivePatterns))
-				config.EnablePredictivePatterns = predictivePatterns;
+				update.EnablePredictivePatterns = predictivePatterns;
 
 			if (configUpdate.ContainsKey("contextual_voice") && bool.TryParse(configUpdate["contextual_voice"].ToString(), out bool contextualVoice))
-				config.EnableContextualVoice = contextualVoice;
+				update.EnableContextualVoice = contextualVoice;
 
 			if (configUpdate.ContainsKey("log_analysis") && bool.TryParse(configUpdate["log_analysis"].ToString(), out bool logAnalysis))
-				config.LogContextAnalysis = logAnalysis;
+				update.LogContextAnalysis = logAnalysis;
 
-			_logger.LogInformation("Contextual Intelligence configuration updated via web interface - Enabled: {Enabled}", config.Enabled);
+			// Same persistence path as every other settings change, so these choices are still in
+			// place after a restart instead of living only in this process.
+			var result = await _settingsPersistence.ApplyAsync(update);
 
+			if (!result.Valid)
+			{
+				context.Response.StatusCode = 400;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonSerializer.Serialize(new
+				{
+					error = result.Message,
+					validation_errors = result.ValidationErrors
+				}));
+				return;
+			}
+
+			var config = _settings.ContextualIntelligence ?? new ContextualIntelligenceConfiguration();
+
+			_logger.LogInformation(
+				"Contextual Intelligence configuration updated via web interface - Enabled: {Enabled}: {Message}",
+				config.Enabled, result.Message);
+
+			context.Response.StatusCode = result.Saved ? 200 : 500;
 			context.Response.ContentType = "application/json";
 			await context.Response.WriteAsync(JsonSerializer.Serialize(new
 			{
-				success = true,
-				message = "Contextual Intelligence configuration updated successfully",
-				enabled = config.Enabled
+				success = result.Saved,
+				message = result.Message,
+				enabled = config.Enabled,
+				settings = result.ToPayload()
 			}));
 		}
 		catch (Exception ex)

--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -14,6 +14,7 @@ public class JournalApiController
     private readonly IJournalEventStore _eventStore;
     private readonly IJournalEventPipeline _pipeline;
     private readonly JournalMonitorStatus _monitorStatus;
+    private readonly SettingsPersistenceService _settingsPersistence;
 
     // Replay functionality
     private CancellationTokenSource? _replayTokenSource;
@@ -25,13 +26,15 @@ public class JournalApiController
         AppSettings settings,
         IJournalEventStore eventStore,
         IJournalEventPipeline pipeline,
-        JournalMonitorStatus monitorStatus)
+        JournalMonitorStatus monitorStatus,
+        SettingsPersistenceService settingsPersistence)
     {
         _logger = logger;
         _settings = settings;
         _eventStore = eventStore;
         _pipeline = pipeline;
         _monitorStatus = monitorStatus;
+        _settingsPersistence = settingsPersistence;
     }
 
     public async Task GetJournalStatus(HttpContext context)
@@ -128,12 +131,9 @@ public class JournalApiController
                 return;
             }
 
-            // Expand environment variables
-            if (journalPath.Contains("%USERPROFILE%"))
-            {
-                journalPath = journalPath.Replace("%USERPROFILE%", 
-                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-            }
+            // Expand environment variables the same way the persistence service will, so the folder
+            // that is checked here is the folder that gets saved.
+            journalPath = SettingsPersistenceService.ExpandJournalPath(journalPath);
 
             if (!Directory.Exists(journalPath))
             {
@@ -159,21 +159,36 @@ public class JournalApiController
                 return;
             }
 
-            _settings.EliteDangerous.JournalPath = journalPath;
+            // One validated path for the change: it is applied to the running configuration, the
+            // live watcher is asked to re-attach, and the folder is written to the settings file -
+            // so the choice is still there after a restart.
+            var result = await _settingsPersistence.ApplyAsync(new SettingsUpdate { JournalPath = journalPath });
 
-            // The live watcher is still attached to the old folder; ask it to re-check now so the
-            // new path takes effect without a restart, the same way the setup wizard does.
-            _monitorStatus.RequestRecheck();
+            if (!result.Valid)
+            {
+                context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                {
+                    error = result.Message,
+                    path = journalPath,
+                    validation_errors = result.ValidationErrors
+                }));
+                return;
+            }
 
-            _logger.LogInformation("Journal path updated to: {JournalPath}", journalPath);
+            _logger.LogInformation("Journal path updated to {JournalPath}: {Message}", journalPath, result.Message);
 
+            // Not saved means the folder is in use for this session only; that is not a success.
+            context.Response.StatusCode = result.Saved ? 200 : 500;
             context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                success = true, 
-                message = "Journal path updated successfully",
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new
+            {
+                success = result.Saved,
+                message = result.Message,
                 path = journalPath,
-                journal_files_found = journalFiles.Length
+                journal_files_found = journalFiles.Length,
+                settings = result.ToPayload()
             }));
         }
         catch (Exception ex)

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -35,6 +35,7 @@ public class SetupApiController
     private readonly IAudioDeviceCatalog _deviceCatalog;
     private readonly AudioEngineService _audioEngine;
     private readonly SystemHealthService _health;
+    private readonly SettingsPersistenceService _settingsPersistence;
     private readonly TimeProvider _timeProvider;
 
     public SetupApiController(
@@ -47,6 +48,7 @@ public class SetupApiController
         IAudioDeviceCatalog deviceCatalog,
         AudioEngineService audioEngine,
         SystemHealthService health,
+        SettingsPersistenceService settingsPersistence,
         TimeProvider timeProvider)
     {
         _logger = logger;
@@ -58,6 +60,7 @@ public class SetupApiController
         _deviceCatalog = deviceCatalog;
         _audioEngine = audioEngine;
         _health = health;
+        _settingsPersistence = settingsPersistence;
         _timeProvider = timeProvider;
     }
 
@@ -444,19 +447,10 @@ public class SetupApiController
     /// be written: the caller must not then record the step as confirmed, because the choice would
     /// be gone on the next run while the wizard claimed it was done.
     /// </summary>
-    private async Task<bool> TryPersistUserSettingsAsync()
-    {
-        try
-        {
-            await _userSettings.SaveUserPreferencesAsync(_userSettings.CreatePreferencesFromAppSettings(_settings));
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Setup could not persist user settings to {SettingsPath}", _userSettings.GetUserSettingsPath());
-            return false;
-        }
-    }
+    private Task<bool> TryPersistUserSettingsAsync() =>
+        // Through the same atomic, backed-up write as every other settings change - the wizard has
+        // already validated and applied its own step, so it only needs the write.
+        _settingsPersistence.PersistCurrentAsync();
 
     /// <summary>
     /// Reports a choice that applied to this session but could not be saved, leaving the recorded

--- a/src/EDButtkicker/Controllers/UserSettingsApiController.cs
+++ b/src/EDButtkicker/Controllers/UserSettingsApiController.cs
@@ -12,18 +12,18 @@ public class UserSettingsController : ControllerBase
     private readonly ILogger<UserSettingsController> _logger;
     private readonly UserSettingsService _userSettingsService;
     private readonly AppSettings _appSettings;
-    private readonly AudioEngineService _audioEngineService;
+    private readonly SettingsPersistenceService _settingsPersistence;
 
     public UserSettingsController(
         ILogger<UserSettingsController> logger,
         UserSettingsService userSettingsService,
         AppSettings appSettings,
-        AudioEngineService audioEngineService)
+        SettingsPersistenceService settingsPersistence)
     {
         _logger = logger;
         _userSettingsService = userSettingsService;
         _appSettings = appSettings;
-        _audioEngineService = audioEngineService;
+        _settingsPersistence = settingsPersistence;
     }
 
     [HttpGet]
@@ -42,71 +42,57 @@ public class UserSettingsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// The settings the UI saves. This route does not touch the running configuration or the
+    /// settings file itself: the request becomes an update handed to the one service that validates
+    /// it, applies what can be applied now, and writes it atomically - so a rejected value leaves
+    /// both the running configuration and the saved one exactly as they were, and a 200 says plainly
+    /// which parts are live already and which need a restart.
+    /// </summary>
     [HttpPost("save")]
     public async Task<ActionResult> SaveUserSettings([FromBody] SaveUserSettingsRequest request)
     {
         try
         {
             _logger.LogInformation("Saving user settings");
-            
-            // Create preferences from current app settings and request
-            var preferences = new UserPreferences
-            {
-                // Audio settings
-                AudioDeviceId = request.AudioDeviceId ?? _appSettings.Audio.AudioDeviceId,
-                AudioDeviceEndpointId = request.AudioDeviceEndpointId ?? _appSettings.Audio.AudioDeviceEndpointId,
-                AudioDeviceName = request.AudioDeviceName ?? _appSettings.Audio.AudioDeviceName,
-                MaxIntensity = request.MaxIntensity ?? _appSettings.Audio.MaxIntensity,
-                DefaultFrequency = request.DefaultFrequency ?? _appSettings.Audio.DefaultFrequency,
-                
-                // Elite Dangerous settings
-                JournalPath = request.JournalPath ?? _appSettings.EliteDangerous.JournalPath,
-                MonitorLatestOnly = request.MonitorLatestOnly ?? _appSettings.EliteDangerous.MonitorLatestOnly,
-                
-                // Contextual Intelligence settings
-                ContextualIntelligence = _appSettings.ContextualIntelligence != null ? new UserContextualIntelligencePreferences
-                {
-                    Enabled = request.ContextualIntelligenceEnabled ?? _appSettings.ContextualIntelligence.Enabled,
-                    EnableAdaptiveIntensity = request.EnableAdaptiveIntensity ?? _appSettings.ContextualIntelligence.EnableAdaptiveIntensity,
-                    EnablePredictivePatterns = request.EnablePredictivePatterns ?? _appSettings.ContextualIntelligence.EnablePredictivePatterns,
-                    EnableContextualVoice = request.EnableContextualVoice ?? _appSettings.ContextualIntelligence.EnableContextualVoice
-                } : null,
-                
-                // Metadata
-                LastSaved = DateTime.UtcNow,
-                Version = "1.0.0"
-            };
 
-            // Apply changes to app settings immediately
-            _userSettingsService.ApplyUserPreferencesToAppSettings(preferences, _appSettings);
-            
-            // If audio device changed, reinitialize audio engine
-            if (request.AudioDeviceId.HasValue ||
-                request.AudioDeviceEndpointId != null ||
-                !string.IsNullOrEmpty(request.AudioDeviceName))
+            var result = await _settingsPersistence.ApplyAsync(new SettingsUpdate
             {
-                _logger.LogInformation("Audio device settings changed, reinitializing audio engine");
-                try
+                AudioDeviceId = request.AudioDeviceId,
+                AudioDeviceEndpointId = request.AudioDeviceEndpointId,
+                AudioDeviceName = request.AudioDeviceName,
+                MaxIntensity = request.MaxIntensity,
+                DefaultFrequency = request.DefaultFrequency,
+
+                JournalPath = request.JournalPath,
+                MonitorLatestOnly = request.MonitorLatestOnly,
+
+                ContextualIntelligenceEnabled = request.ContextualIntelligenceEnabled,
+                EnableAdaptiveIntensity = request.EnableAdaptiveIntensity,
+                EnablePredictivePatterns = request.EnablePredictivePatterns,
+                EnableContextualVoice = request.EnableContextualVoice
+            });
+
+            if (!result.Valid)
+            {
+                return BadRequest(new
                 {
-                    // Note: In a real implementation, you might want to add a method to reinitialize
-                    // the audio engine. For now, we'll log this and let it be handled on next restart
-                    _logger.LogInformation("Audio device change will take effect on next restart or pattern playback");
-                }
-                catch (Exception audioEx)
-                {
-                    _logger.LogWarning(audioEx, "Audio engine reinitialization failed, but settings were saved");
-                }
+                    error = "Failed to save user settings",
+                    message = result.Message,
+                    validation_errors = result.ValidationErrors,
+                    settings = result.ToPayload()
+                });
             }
 
-            // Save to disk
-            await _userSettingsService.SaveUserPreferencesAsync(preferences);
-            
-            _logger.LogInformation("User settings saved successfully");
-            
-            return Ok(new { 
-                message = "Settings saved successfully", 
-                timestamp = preferences.LastSaved,
-                settingsPath = _userSettingsService.GetUserSettingsPath()
+            _logger.LogInformation("User settings save handled: {Message}", result.Message);
+
+            // A change that only reached memory is not a saved setting: the caller has to hear that.
+            return StatusCode(result.Saved ? 200 : 500, new
+            {
+                message = result.Message,
+                timestamp = DateTime.UtcNow,
+                settingsPath = result.SettingsPath,
+                settings = result.ToPayload()
             });
         }
         catch (Exception ex)

--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -32,6 +32,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<AudioEngineService>();
         services.AddSingleton<PatternSequencer>();
         services.AddSingleton<UserSettingsService>();
+
+        // Every settings mutation is validated, applied and written through this one service, so a
+        // successful settings API call always means the same thing - and always survives a restart.
+        services.AddSingleton<SettingsPersistenceService>();
         services.AddSingleton<ContextualIntelligenceService>();
         services.AddSingleton<EventMappingService>();
         services.AddSingleton<ShipTrackingService>();

--- a/src/EDButtkicker/Services/SettingsPersistenceService.cs
+++ b/src/EDButtkicker/Services/SettingsPersistenceService.cs
@@ -1,0 +1,546 @@
+using EDButtkicker.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// A requested settings change. Every field is optional and null means "leave this one alone", so a
+/// caller that only knows about one setting can never blank out the rest of the configuration.
+/// The audio device name and endpoint id are deliberately nullable strings rather than empty-string
+/// sentinels: an empty value is a real choice - it is how "use the system default" is recorded.
+/// </summary>
+public sealed class SettingsUpdate
+{
+    public int? AudioDeviceId { get; set; }
+    public string? AudioDeviceEndpointId { get; set; }
+    public string? AudioDeviceName { get; set; }
+    public int? MaxIntensity { get; set; }
+    public int? DefaultFrequency { get; set; }
+    public int? SampleRate { get; set; }
+    public int? BufferSize { get; set; }
+
+    public string? JournalPath { get; set; }
+    public bool? MonitorLatestOnly { get; set; }
+
+    public bool? ContextualIntelligenceEnabled { get; set; }
+    public double? LearningRate { get; set; }
+    public double? PredictionThreshold { get; set; }
+    public bool? EnableAdaptiveIntensity { get; set; }
+    public bool? EnablePredictivePatterns { get; set; }
+    public bool? EnableContextualVoice { get; set; }
+    public bool? LogContextAnalysis { get; set; }
+}
+
+/// <summary>
+/// One setting that actually changed, and whether the running application is already using it.
+/// <paramref name="AppliedNow"/> is the honest answer to "do I have to restart?" - it is false only
+/// when the subsystem that reads the setting cannot pick it up without a restart.
+/// </summary>
+public sealed record SettingsChange(string Setting, string Value, bool AppliedNow, string Detail);
+
+/// <summary>
+/// What a settings mutation did: whether it was accepted, what changed, whether it reached disk, and
+/// which of the changes the running process is already honouring.
+/// </summary>
+public sealed class SettingsUpdateResult
+{
+    private SettingsUpdateResult(
+        bool valid,
+        IReadOnlyList<string> validationErrors,
+        IReadOnlyList<SettingsChange> changes,
+        bool saved,
+        string? saveError,
+        string settingsPath)
+    {
+        Valid = valid;
+        ValidationErrors = validationErrors;
+        Changes = changes;
+        Saved = saved;
+        SaveError = saveError;
+        SettingsPath = settingsPath;
+    }
+
+    /// <summary>False when nothing was applied and nothing was written: the request was rejected.</summary>
+    public bool Valid { get; }
+
+    public IReadOnlyList<string> ValidationErrors { get; }
+
+    public IReadOnlyList<SettingsChange> Changes { get; }
+
+    /// <summary>True once the settings file on disk reflects the change.</summary>
+    public bool Saved { get; }
+
+    public string? SaveError { get; }
+
+    public string SettingsPath { get; }
+
+    public bool RestartRequired => Changes.Any(c => !c.AppliedNow);
+
+    public IReadOnlyList<string> RestartRequiredSettings =>
+        Changes.Where(c => !c.AppliedNow).Select(c => c.Setting).ToList();
+
+    /// <summary>How much of this change the running process is honouring right now.</summary>
+    public string AppliedState => Changes.Count == 0
+        ? "no_changes"
+        : Changes.All(c => c.AppliedNow)
+            ? "immediately"
+            : Changes.Any(c => c.AppliedNow)
+                ? "partly"
+                : "after_restart";
+
+    /// <summary>
+    /// One sentence a user can act on. It never says "saved" unless the file was written, and never
+    /// implies a change is live when the subsystem only reads it at startup.
+    /// </summary>
+    public string Message
+    {
+        get
+        {
+            if (!Valid)
+            {
+                return $"No settings were changed: {string.Join(" ", ValidationErrors)}";
+            }
+
+            if (Changes.Count == 0)
+            {
+                return "No settings changed.";
+            }
+
+            var where = Saved
+                ? $"Saved to {SettingsPath}."
+                : $"NOT saved to {SettingsPath} ({SaveError}) - these values apply to this session only and will be gone after a restart.";
+
+            var live = Changes.Where(c => c.AppliedNow).Select(c => c.Setting).ToList();
+            var pending = RestartRequiredSettings;
+
+            return pending.Count == 0
+                ? $"{where} In effect now: {string.Join(", ", live)}."
+                : live.Count == 0
+                    ? $"{where} Restart the application to apply: {string.Join(", ", pending)}."
+                    : $"{where} In effect now: {string.Join(", ", live)}. " +
+                      $"Restart the application to apply: {string.Join(", ", pending)}.";
+        }
+    }
+
+    /// <summary>
+    /// The block every settings mutation returns, so a caller never has to guess whether a 200 means
+    /// "live", "written" or merely "accepted".
+    /// </summary>
+    public object ToPayload() => new
+    {
+        saved = Saved,
+        settings_path = SettingsPath,
+        applied = AppliedState,
+        restart_required = RestartRequired,
+        restart_required_settings = RestartRequiredSettings,
+        changes = Changes.Select(c => new
+        {
+            setting = c.Setting,
+            value = c.Value,
+            applied_now = c.AppliedNow,
+            detail = c.Detail
+        }).ToList(),
+        message = Message
+    };
+
+    internal static SettingsUpdateResult Rejected(IReadOnlyList<string> errors, string settingsPath) =>
+        new(false, errors, Array.Empty<SettingsChange>(), saved: false, saveError: null, settingsPath);
+
+    internal static SettingsUpdateResult Applied(
+        IReadOnlyList<SettingsChange> changes,
+        bool saved,
+        string? saveError,
+        string settingsPath) =>
+        new(true, Array.Empty<string>(), changes, saved, saveError, settingsPath);
+}
+
+/// <summary>
+/// The single place a settings change is validated, applied to the running configuration, handed to
+/// the subsystems that can take it live, and written to disk. Every settings route goes through here
+/// so that a successful response means the same thing everywhere: the value was checked, the file on
+/// disk holds it, and the response says plainly whether the process is already using it.
+/// </summary>
+public class SettingsPersistenceService
+{
+    /// <summary>Intensity is a percentage of the configured maximum output.</summary>
+    public const int MinIntensity = 1;
+    public const int MaxIntensity = 100;
+
+    /// <summary>A buttkicker reproduces low frequencies; anything outside this is a typo, not a choice.</summary>
+    public const int MinFrequency = 10;
+    public const int MaxFrequency = 200;
+
+    public const int MinSampleRate = 8000;
+    public const int MaxSampleRate = 192000;
+
+    public const int MinBufferSize = 64;
+    public const int MaxBufferSize = 16384;
+
+    private const string RestartAudioFormatDetail =
+        "Saved. The audio output keeps the format it was opened with, so this takes effect the next time the application starts.";
+
+    private const string RestartJournalModeDetail =
+        "Saved. The journal reader keeps the mode it attached with, so this takes effect the next time the application starts.";
+
+    private readonly ILogger<SettingsPersistenceService> _logger;
+    private readonly AppSettings _settings;
+    private readonly UserSettingsService _userSettings;
+    private readonly AudioEngineService _audioEngine;
+    private readonly JournalMonitorStatus _journalStatus;
+
+    // One writer at a time: two overlapping requests must not interleave a mutation with a write and
+    // leave the file describing a configuration that never existed.
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    public SettingsPersistenceService(
+        ILogger<SettingsPersistenceService> logger,
+        AppSettings settings,
+        UserSettingsService userSettings,
+        AudioEngineService audioEngine,
+        JournalMonitorStatus journalStatus)
+    {
+        _logger = logger;
+        _settings = settings;
+        _userSettings = userSettings;
+        _audioEngine = audioEngine;
+        _journalStatus = journalStatus;
+    }
+
+    public string SettingsPath => _userSettings.GetUserSettingsPath();
+
+    /// <summary>
+    /// Validates <paramref name="update"/>, applies what actually differs, takes live what can be
+    /// taken live, and persists the result. A rejected update changes nothing at all - neither the
+    /// running configuration nor the file - so an invalid value can never destroy a working one.
+    /// </summary>
+    public async Task<SettingsUpdateResult> ApplyAsync(SettingsUpdate update)
+    {
+        var errors = Validate(update);
+        if (errors.Count > 0)
+        {
+            _logger.LogWarning("Rejected a settings change: {Errors}", string.Join(" ", errors));
+            return SettingsUpdateResult.Rejected(errors, SettingsPath);
+        }
+
+        await _mutex.WaitAsync();
+        try
+        {
+            var changes = ApplyToRunningConfiguration(update);
+
+            if (changes.Count == 0)
+            {
+                return SettingsUpdateResult.Applied(changes, saved: true, saveError: null, SettingsPath);
+            }
+
+            try
+            {
+                await _userSettings.SaveUserPreferencesAsync(
+                    _userSettings.CreatePreferencesFromAppSettings(_settings));
+
+                _logger.LogInformation(
+                    "Persisted settings change: {Changes}",
+                    string.Join(", ", changes.Select(c => $"{c.Setting}={c.Value}")));
+
+                return SettingsUpdateResult.Applied(changes, saved: true, saveError: null, SettingsPath);
+            }
+            catch (Exception ex)
+            {
+                // The values are live for this session; only the record of them is missing, and the
+                // caller has to be able to say so rather than report a save that did not happen.
+                _logger.LogError(ex, "Settings change applied to this session but could not be saved to {SettingsPath}", SettingsPath);
+                return SettingsUpdateResult.Applied(changes, saved: false, saveError: ex.Message, SettingsPath);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <summary>
+    /// Writes the running configuration exactly as it stands. This is for callers that have already
+    /// validated and applied a change themselves - the first-run wizard - so that they still write
+    /// through the one atomic, backed-up path instead of a second one of their own.
+    /// </summary>
+    public async Task<bool> PersistCurrentAsync()
+    {
+        await _mutex.WaitAsync();
+        try
+        {
+            await _userSettings.SaveUserPreferencesAsync(
+                _userSettings.CreatePreferencesFromAppSettings(_settings));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not persist the running configuration to {SettingsPath}", SettingsPath);
+            return false;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <summary>
+    /// Every reason this update cannot be accepted, checked before anything is mutated. Journal paths
+    /// are expanded first, so a user typing %USERPROFILE% is validated on the folder they meant.
+    /// </summary>
+    public static IReadOnlyList<string> Validate(SettingsUpdate update)
+    {
+        var errors = new List<string>();
+
+        if (update.MaxIntensity is { } intensity && (intensity < MinIntensity || intensity > MaxIntensity))
+        {
+            errors.Add($"Maximum intensity must be between {MinIntensity} and {MaxIntensity} (got {intensity}).");
+        }
+
+        if (update.DefaultFrequency is { } frequency && (frequency < MinFrequency || frequency > MaxFrequency))
+        {
+            errors.Add($"Default frequency must be between {MinFrequency} and {MaxFrequency} Hz (got {frequency}).");
+        }
+
+        if (update.SampleRate is { } sampleRate && (sampleRate < MinSampleRate || sampleRate > MaxSampleRate))
+        {
+            errors.Add($"Sample rate must be between {MinSampleRate} and {MaxSampleRate} Hz (got {sampleRate}).");
+        }
+
+        if (update.BufferSize is { } bufferSize && (bufferSize < MinBufferSize || bufferSize > MaxBufferSize))
+        {
+            errors.Add($"Buffer size must be between {MinBufferSize} and {MaxBufferSize} samples (got {bufferSize}).");
+        }
+
+        if (update.AudioDeviceId is { } deviceId && deviceId < WasapiAudioDeviceCatalog.SystemDefaultDeviceId)
+        {
+            errors.Add($"Audio device id must be {WasapiAudioDeviceCatalog.SystemDefaultDeviceId} (the system default) or greater (got {deviceId}).");
+        }
+
+        if (update.JournalPath != null)
+        {
+            var journalPath = ExpandJournalPath(update.JournalPath);
+
+            if (string.IsNullOrWhiteSpace(journalPath))
+            {
+                errors.Add("The journal folder path cannot be empty.");
+            }
+            else if (!Directory.Exists(journalPath))
+            {
+                errors.Add($"The journal folder does not exist: {journalPath}");
+            }
+        }
+
+        if (update.LearningRate is { } learningRate && (learningRate < 0.01 || learningRate > 1.0))
+        {
+            errors.Add($"Learning rate must be between 0.01 and 1.0 (got {learningRate}).");
+        }
+
+        if (update.PredictionThreshold is { } threshold && (threshold < 0.1 || threshold > 1.0))
+        {
+            errors.Add($"Prediction threshold must be between 0.1 and 1.0 (got {threshold}).");
+        }
+
+        return errors;
+    }
+
+    /// <summary>The path as the user meant it: %USERPROFILE% expanded, surrounding blanks removed.</summary>
+    public static string ExpandJournalPath(string path) =>
+        JournalPathDiscovery.ExpandUserProfile(path.Trim());
+
+    /// <summary>
+    /// Applies the fields that actually differ from the running configuration and reports each one,
+    /// including whether the subsystem behind it took the new value live.
+    /// </summary>
+    private List<SettingsChange> ApplyToRunningConfiguration(SettingsUpdate update)
+    {
+        var changes = new List<SettingsChange>();
+
+        // The output device is three fields describing one choice, so they are applied together and
+        // reported against a single reinitialisation of the audio engine.
+        var deviceFields = new List<(string Setting, string Value)>();
+
+        if (update.AudioDeviceEndpointId != null &&
+            update.AudioDeviceEndpointId != _settings.Audio.AudioDeviceEndpointId)
+        {
+            _settings.Audio.AudioDeviceEndpointId = update.AudioDeviceEndpointId;
+            deviceFields.Add(("audio.audioDeviceEndpointId", update.AudioDeviceEndpointId));
+        }
+
+        if (update.AudioDeviceName != null && update.AudioDeviceName != _settings.Audio.AudioDeviceName)
+        {
+            _settings.Audio.AudioDeviceName = update.AudioDeviceName;
+            deviceFields.Add(("audio.audioDeviceName", update.AudioDeviceName));
+        }
+
+        if (update.AudioDeviceId is { } deviceId && deviceId != _settings.Audio.AudioDeviceId)
+        {
+            _settings.Audio.AudioDeviceId = deviceId;
+            deviceFields.Add(("audio.audioDeviceId", deviceId.ToString()));
+        }
+
+        if (deviceFields.Count > 0)
+        {
+            var (appliedNow, detail) = ReopenAudioOutput();
+
+            foreach (var (setting, value) in deviceFields)
+            {
+                changes.Add(new SettingsChange(setting, value, appliedNow, detail));
+            }
+        }
+
+        if (update.MaxIntensity is { } maxIntensity && maxIntensity != _settings.Audio.MaxIntensity)
+        {
+            _settings.Audio.MaxIntensity = maxIntensity;
+            changes.Add(new SettingsChange(
+                "audio.maxIntensity", maxIntensity.ToString(), true,
+                "In effect now: every pattern is scaled against this maximum when it plays."));
+        }
+
+        if (update.DefaultFrequency is { } defaultFrequency && defaultFrequency != _settings.Audio.DefaultFrequency)
+        {
+            _settings.Audio.DefaultFrequency = defaultFrequency;
+            changes.Add(new SettingsChange(
+                "audio.defaultFrequency", defaultFrequency.ToString(), true,
+                "In effect now: patterns without their own frequency use this one."));
+        }
+
+        if (update.SampleRate is { } sampleRate && sampleRate != _settings.Audio.SampleRate)
+        {
+            _settings.Audio.SampleRate = sampleRate;
+            changes.Add(new SettingsChange(
+                "audio.sampleRate", sampleRate.ToString(), false, RestartAudioFormatDetail));
+        }
+
+        if (update.BufferSize is { } bufferSize && bufferSize != _settings.Audio.BufferSize)
+        {
+            _settings.Audio.BufferSize = bufferSize;
+            changes.Add(new SettingsChange(
+                "audio.bufferSize", bufferSize.ToString(), false, RestartAudioFormatDetail));
+        }
+
+        if (update.JournalPath != null)
+        {
+            var journalPath = ExpandJournalPath(update.JournalPath);
+
+            if (journalPath != _settings.EliteDangerous.JournalPath)
+            {
+                _settings.EliteDangerous.JournalPath = journalPath;
+
+                // The watcher is still attached to the old folder, so ask it to look again now
+                // rather than at the end of its next sweep.
+                _journalStatus.RequestRecheck();
+
+                changes.Add(new SettingsChange(
+                    "eliteDangerous.journalPath", journalPath, true,
+                    "In effect now: the journal watcher was asked to attach to this folder."));
+            }
+        }
+
+        if (update.MonitorLatestOnly is { } monitorLatestOnly &&
+            monitorLatestOnly != _settings.EliteDangerous.MonitorLatestOnly)
+        {
+            _settings.EliteDangerous.MonitorLatestOnly = monitorLatestOnly;
+            changes.Add(new SettingsChange(
+                "eliteDangerous.monitorLatestOnly", monitorLatestOnly.ToString(), false, RestartJournalModeDetail));
+        }
+
+        changes.AddRange(ApplyContextualIntelligence(update));
+
+        return changes;
+    }
+
+    /// <summary>
+    /// Contextual intelligence is read from the settings object on every event, so each of these is
+    /// live the moment it is assigned.
+    /// </summary>
+    private List<SettingsChange> ApplyContextualIntelligence(SettingsUpdate update)
+    {
+        var changes = new List<SettingsChange>();
+
+        if (update.ContextualIntelligenceEnabled == null &&
+            update.LearningRate == null &&
+            update.PredictionThreshold == null &&
+            update.EnableAdaptiveIntensity == null &&
+            update.EnablePredictivePatterns == null &&
+            update.EnableContextualVoice == null &&
+            update.LogContextAnalysis == null)
+        {
+            return changes;
+        }
+
+        _settings.ContextualIntelligence ??= new ContextualIntelligenceConfiguration();
+        var config = _settings.ContextualIntelligence;
+
+        const string liveDetail = "In effect now: contextual intelligence reads this setting on every event.";
+
+        void Record(string setting, string value) =>
+            changes.Add(new SettingsChange(setting, value, true, liveDetail));
+
+        if (update.ContextualIntelligenceEnabled is { } enabled && enabled != config.Enabled)
+        {
+            config.Enabled = enabled;
+            Record("contextualIntelligence.enabled", enabled.ToString());
+        }
+
+        if (update.LearningRate is { } learningRate && Math.Abs(learningRate - config.LearningRate) > double.Epsilon)
+        {
+            config.LearningRate = learningRate;
+            Record("contextualIntelligence.learningRate", learningRate.ToString("0.###"));
+        }
+
+        if (update.PredictionThreshold is { } threshold && Math.Abs(threshold - config.PredictionThreshold) > double.Epsilon)
+        {
+            config.PredictionThreshold = threshold;
+            Record("contextualIntelligence.predictionThreshold", threshold.ToString("0.###"));
+        }
+
+        if (update.EnableAdaptiveIntensity is { } adaptive && adaptive != config.EnableAdaptiveIntensity)
+        {
+            config.EnableAdaptiveIntensity = adaptive;
+            Record("contextualIntelligence.enableAdaptiveIntensity", adaptive.ToString());
+        }
+
+        if (update.EnablePredictivePatterns is { } predictive && predictive != config.EnablePredictivePatterns)
+        {
+            config.EnablePredictivePatterns = predictive;
+            Record("contextualIntelligence.enablePredictivePatterns", predictive.ToString());
+        }
+
+        if (update.EnableContextualVoice is { } voice && voice != config.EnableContextualVoice)
+        {
+            config.EnableContextualVoice = voice;
+            Record("contextualIntelligence.enableContextualVoice", voice.ToString());
+        }
+
+        if (update.LogContextAnalysis is { } logAnalysis && logAnalysis != config.LogContextAnalysis)
+        {
+            config.LogContextAnalysis = logAnalysis;
+            Record("contextualIntelligence.logContextAnalysis", logAnalysis.ToString());
+        }
+
+        return changes;
+    }
+
+    /// <summary>
+    /// Drops the currently open output so the next pattern opens the newly selected one. Reported
+    /// honestly: if the engine refuses to let go of the old device, the change is on disk but the
+    /// running process is still on the previous output until it restarts.
+    /// </summary>
+    private (bool AppliedNow, string Detail) ReopenAudioOutput()
+    {
+        try
+        {
+            _audioEngine.Reinitialize();
+
+            return (true,
+                "In effect now: the audio output was released, so the next pattern opens this device.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not reopen the audio output after a device change");
+
+            return (false,
+                $"Saved, but the audio output could not be reopened ({ex.Message}), so this device is used " +
+                "the next time the application starts.");
+        }
+    }
+}

--- a/src/EDButtkicker/Services/UserSettingsService.cs
+++ b/src/EDButtkicker/Services/UserSettingsService.cs
@@ -9,6 +9,7 @@ public class UserSettingsService
 {
     private readonly ILogger<UserSettingsService> _logger;
     private readonly string _userSettingsPath;
+    private readonly string _userSettingsBackupPath;
     private readonly string _gameContextPath;
     private readonly JsonSerializerOptions _jsonOptions;
 
@@ -36,6 +37,7 @@ public class UserSettingsService
         Directory.CreateDirectory(settingsDir);
 
         _userSettingsPath = Path.Combine(settingsDir, "user-settings.json");
+        _userSettingsBackupPath = Path.Combine(settingsDir, "user-settings.backup.json");
         _gameContextPath = Path.Combine(settingsDir, "game-context.json");
         
         _jsonOptions = new JsonSerializerOptions
@@ -50,51 +52,125 @@ public class UserSettingsService
 
     public async Task<UserPreferences> LoadUserPreferencesAsync()
     {
-        try
+        var preferences = await TryReadPreferencesAsync(_userSettingsPath);
+
+        if (preferences != null)
         {
-            if (!File.Exists(_userSettingsPath))
-            {
-                _logger.LogInformation("No user settings file found, using defaults");
-                return new UserPreferences();
-            }
-
-            var json = await File.ReadAllTextAsync(_userSettingsPath);
-            var preferences = JsonSerializer.Deserialize<UserPreferences>(json, _jsonOptions);
-            
-            if (preferences == null)
-            {
-                _logger.LogWarning("Failed to deserialize user preferences, using defaults");
-                return new UserPreferences();
-            }
-
             _logger.LogInformation("Loaded user preferences from {SettingsPath}", _userSettingsPath);
-            _logger.LogDebug("Audio Device: {DeviceName} (ID: {DeviceId})", 
+            _logger.LogDebug("Audio Device: {DeviceName} (ID: {DeviceId})",
                 preferences.AudioDeviceName, preferences.AudioDeviceId);
-            
+
             return preferences;
         }
-        catch (Exception ex)
+
+        // A settings file that cannot be read is exactly what the backup exists for: reverting a
+        // working configuration to defaults because of one damaged file is the outcome to avoid.
+        var lastKnownGood = await TryReadPreferencesAsync(_userSettingsBackupPath);
+
+        if (lastKnownGood != null)
         {
-            _logger.LogError(ex, "Error loading user preferences, using defaults");
-            return new UserPreferences();
+            _logger.LogWarning(
+                "Settings at {SettingsPath} could not be read; using the last known good copy from {BackupPath}",
+                _userSettingsPath, _userSettingsBackupPath);
+
+            return lastKnownGood;
         }
+
+        _logger.LogInformation("No usable user settings file found, using defaults");
+        return new UserPreferences();
     }
 
+    /// <summary>
+    /// Writes the settings file atomically and keeps the copy it replaced as the last known good
+    /// one. Throws when the file could not be written: the caller has to be able to tell the user
+    /// that their change only applies to this session.
+    /// </summary>
     public async Task SaveUserPreferencesAsync(UserPreferences preferences)
     {
         try
         {
             var json = JsonSerializer.Serialize(preferences, _jsonOptions);
-            await File.WriteAllTextAsync(_userSettingsPath, json);
-            
+            await WriteAtomicallyAsync(_userSettingsPath, json, _userSettingsBackupPath);
+
             _logger.LogInformation("Saved user preferences to {SettingsPath}", _userSettingsPath);
-            _logger.LogDebug("Saved Audio Device: {DeviceName} (ID: {DeviceId})", 
+            _logger.LogDebug("Saved Audio Device: {DeviceName} (ID: {DeviceId})",
                 preferences.AudioDeviceName, preferences.AudioDeviceId);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error saving user preferences");
             throw;
+        }
+    }
+
+    private async Task<UserPreferences?> TryReadPreferencesAsync(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(path);
+            var preferences = JsonSerializer.Deserialize<UserPreferences>(json, _jsonOptions);
+
+            if (preferences == null)
+            {
+                _logger.LogWarning("Settings file {Path} deserialized to nothing", path);
+            }
+
+            return preferences;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading settings file {Path}", path);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fills a temporary file first and then replaces the target in one step, so an interrupted
+    /// write - a crash, a full disk, a process kill - can never leave half a settings file behind.
+    /// When <paramref name="backupPath"/> is given, the file being replaced is kept there.
+    /// </summary>
+    private static async Task WriteAtomicallyAsync(string path, string json, string? backupPath = null)
+    {
+        var tempPath = path + ".tmp";
+
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, json);
+
+            if (File.Exists(path))
+            {
+                if (backupPath != null)
+                {
+                    File.Replace(tempPath, path, backupPath, ignoreMetadataErrors: true);
+                }
+                else
+                {
+                    File.Move(tempPath, path, overwrite: true);
+                }
+            }
+            else
+            {
+                File.Move(tempPath, path);
+            }
+        }
+        finally
+        {
+            // Only ever reached with the temporary file still present when the replace failed, and
+            // a leftover .tmp would be read by nothing but would confuse the next look at the folder.
+            try
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+            catch (IOException) { /* best effort cleanup */ }
+            catch (UnauthorizedAccessException) { /* best effort cleanup */ }
         }
     }
 
@@ -135,6 +211,20 @@ public class UserSettingsService
                 _logger.LogDebug("Applied default frequency: {DefaultFrequency}", preferences.DefaultFrequency.Value);
             }
 
+            // The output format is only read when the device is opened, which is why a change to it
+            // is reported as needing a restart - but it still has to come back after one.
+            if (preferences.SampleRate.HasValue)
+            {
+                appSettings.Audio.SampleRate = preferences.SampleRate.Value;
+                _logger.LogDebug("Applied sample rate: {SampleRate}", preferences.SampleRate.Value);
+            }
+
+            if (preferences.BufferSize.HasValue)
+            {
+                appSettings.Audio.BufferSize = preferences.BufferSize.Value;
+                _logger.LogDebug("Applied buffer size: {BufferSize}", preferences.BufferSize.Value);
+            }
+
             // Apply journal preferences
             if (!string.IsNullOrEmpty(preferences.JournalPath))
             {
@@ -170,6 +260,21 @@ public class UserSettingsService
                 {
                     appSettings.ContextualIntelligence.EnableContextualVoice = preferences.ContextualIntelligence.EnableContextualVoice.Value;
                 }
+
+                if (preferences.ContextualIntelligence.LearningRate.HasValue)
+                {
+                    appSettings.ContextualIntelligence.LearningRate = preferences.ContextualIntelligence.LearningRate.Value;
+                }
+
+                if (preferences.ContextualIntelligence.PredictionThreshold.HasValue)
+                {
+                    appSettings.ContextualIntelligence.PredictionThreshold = preferences.ContextualIntelligence.PredictionThreshold.Value;
+                }
+
+                if (preferences.ContextualIntelligence.LogContextAnalysis.HasValue)
+                {
+                    appSettings.ContextualIntelligence.LogContextAnalysis = preferences.ContextualIntelligence.LogContextAnalysis.Value;
+                }
             }
 
             _logger.LogInformation("Applied user preferences to app settings");
@@ -191,6 +296,8 @@ public class UserSettingsService
                 AudioDeviceName = appSettings.Audio.AudioDeviceName,
                 MaxIntensity = appSettings.Audio.MaxIntensity,
                 DefaultFrequency = appSettings.Audio.DefaultFrequency,
+                SampleRate = appSettings.Audio.SampleRate,
+                BufferSize = appSettings.Audio.BufferSize,
                 JournalPath = appSettings.EliteDangerous.JournalPath,
                 MonitorLatestOnly = appSettings.EliteDangerous.MonitorLatestOnly,
                 ContextualIntelligence = appSettings.ContextualIntelligence != null ? new UserContextualIntelligencePreferences
@@ -198,7 +305,10 @@ public class UserSettingsService
                     Enabled = appSettings.ContextualIntelligence.Enabled,
                     EnableAdaptiveIntensity = appSettings.ContextualIntelligence.EnableAdaptiveIntensity,
                     EnablePredictivePatterns = appSettings.ContextualIntelligence.EnablePredictivePatterns,
-                    EnableContextualVoice = appSettings.ContextualIntelligence.EnableContextualVoice
+                    EnableContextualVoice = appSettings.ContextualIntelligence.EnableContextualVoice,
+                    LearningRate = appSettings.ContextualIntelligence.LearningRate,
+                    PredictionThreshold = appSettings.ContextualIntelligence.PredictionThreshold,
+                    LogContextAnalysis = appSettings.ContextualIntelligence.LogContextAnalysis
                 } : null,
                 LastSaved = DateTime.UtcNow
             };
@@ -214,6 +324,12 @@ public class UserSettingsService
     }
 
     public string GetUserSettingsPath() => _userSettingsPath;
+
+    /// <summary>
+    /// Where the previous settings file is kept whenever a new one replaces it. A damaged or
+    /// truncated settings file is read from here rather than silently reverting to defaults.
+    /// </summary>
+    public string GetUserSettingsBackupPath() => _userSettingsBackupPath;
 
     public bool UserSettingsExist() => File.Exists(_userSettingsPath);
 
@@ -277,6 +393,10 @@ public class UserPreferences
     public int? MaxIntensity { get; set; }
     public int? DefaultFrequency { get; set; }
 
+    /// <summary>Output format the audio device is opened with; only read when it is opened.</summary>
+    public int? SampleRate { get; set; }
+    public int? BufferSize { get; set; }
+
     // Elite Dangerous preferences
     public string? JournalPath { get; set; }
     public bool? MonitorLatestOnly { get; set; }
@@ -295,4 +415,7 @@ public class UserContextualIntelligencePreferences
     public bool? EnableAdaptiveIntensity { get; set; }
     public bool? EnablePredictivePatterns { get; set; }
     public bool? EnableContextualVoice { get; set; }
+    public double? LearningRate { get; set; }
+    public double? PredictionThreshold { get; set; }
+    public bool? LogContextAnalysis { get; set; }
 }

--- a/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
+++ b/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
@@ -120,12 +120,23 @@ public class JournalReplayPathTraversalTests
             Settings = new AppSettings();
             Settings.EliteDangerous.JournalPath = JournalDirectory;
 
+            var userSettings = new UserSettingsService(
+                NullLogger<UserSettingsService>.Instance, _root.Path);
+
+            var persistence = new SettingsPersistenceService(
+                NullLogger<SettingsPersistenceService>.Instance,
+                Settings,
+                userSettings,
+                new AudioEngineService(NullLogger<AudioEngineService>.Instance, Settings),
+                new JournalMonitorStatus(TimeProvider.System));
+
             Controller = new JournalApiController(
                 NullLogger<JournalApiController>.Instance,
                 Settings,
                 EventStore,
                 Pipeline,
-                new JournalMonitorStatus(TimeProvider.System));
+                new JournalMonitorStatus(TimeProvider.System),
+                persistence);
         }
 
         public string JournalDirectory { get; }

--- a/tests/EDButtkicker.Tests/SettingsPersistenceRoundTripTests.cs
+++ b/tests/EDButtkicker.Tests/SettingsPersistenceRoundTripTests.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using EDButtkicker.Configuration;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// A settings change is only worth anything if it is still there after a restart, and only honest if
+/// the answer to "is this live yet?" is the truth. These tests drive the one service every settings
+/// route goes through: a good change has to reach disk and come back on a fresh read, a format change
+/// has to admit it needs a restart, and a rejected value must leave both the running configuration
+/// and the saved one exactly as they were - including the last known good copy.
+///
+/// Everything runs against a temporary directory and never opens an audio device: the audio engine is
+/// constructed but no device-change path is exercised, so nothing here depends on WASAPI.
+/// </summary>
+public class SettingsPersistenceRoundTripTests : IDisposable
+{
+    private readonly TempDirectory _dir = new("edbk-settings-persistence");
+    private readonly AppSettings _settings = new();
+    private readonly UserSettingsService _userSettings;
+    private readonly SettingsPersistenceService _persistence;
+
+    public SettingsPersistenceRoundTripTests()
+    {
+        _userSettings = new UserSettingsService(NullLogger<UserSettingsService>.Instance, _dir.Path);
+
+        _persistence = new SettingsPersistenceService(
+            NullLogger<SettingsPersistenceService>.Instance,
+            _settings,
+            _userSettings,
+            new AudioEngineService(NullLogger<AudioEngineService>.Instance, _settings),
+            new JournalMonitorStatus(TimeProvider.System));
+    }
+
+    /// <summary>A second UserSettingsService on the same directory: what the next start would read.</summary>
+    private UserSettingsService AfterRestart() =>
+        new(NullLogger<UserSettingsService>.Instance, _dir.Path);
+
+    private string SettingsFile => _userSettings.GetUserSettingsPath();
+
+    private string BackupFile => _userSettings.GetUserSettingsBackupPath();
+
+    [Fact]
+    public async Task IntensityAndFrequency_SurviveARestart()
+    {
+        var result = await _persistence.ApplyAsync(new SettingsUpdate
+        {
+            MaxIntensity = 65,
+            DefaultFrequency = 42
+        });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Saved);
+        Assert.False(result.RestartRequired);
+        Assert.Equal("immediately", result.AppliedState);
+
+        // Live in this session...
+        Assert.Equal(65, _settings.Audio.MaxIntensity);
+        Assert.Equal(42, _settings.Audio.DefaultFrequency);
+
+        // ...and still there for the next one.
+        Assert.True(File.Exists(SettingsFile));
+        var reloaded = await AfterRestart().LoadUserPreferencesAsync();
+
+        Assert.Equal(65, reloaded.MaxIntensity);
+        Assert.Equal(42, reloaded.DefaultFrequency);
+
+        var restored = new AppSettings();
+        AfterRestart().ApplyUserPreferencesToAppSettings(reloaded, restored);
+
+        Assert.Equal(65, restored.Audio.MaxIntensity);
+        Assert.Equal(42, restored.Audio.DefaultFrequency);
+    }
+
+    [Fact]
+    public async Task OutputFormat_IsSavedButNotLiveUntilARestart()
+    {
+        var result = await _persistence.ApplyAsync(new SettingsUpdate
+        {
+            SampleRate = 48000,
+            BufferSize = 2048
+        });
+
+        Assert.True(result.Valid);
+        Assert.True(result.Saved);
+        Assert.False(result.AppliedNowFor("audio.sampleRate"));
+        Assert.False(result.AppliedNowFor("audio.bufferSize"));
+        Assert.True(result.RestartRequired);
+        Assert.Equal("after_restart", result.AppliedState);
+        Assert.Equal(
+            new[] { "audio.sampleRate", "audio.bufferSize" },
+            result.RestartRequiredSettings.ToArray());
+
+        // The point of saying "after a restart" is that the restart actually brings it back.
+        var reloaded = await AfterRestart().LoadUserPreferencesAsync();
+        Assert.Equal(48000, reloaded.SampleRate);
+        Assert.Equal(2048, reloaded.BufferSize);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public async Task RejectedIntensity_ChangesNeitherTheSessionNorTheFile(int intensity)
+    {
+        var before = _settings.Audio.MaxIntensity;
+
+        var result = await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = intensity });
+
+        Assert.False(result.Valid);
+        Assert.False(result.Saved);
+        Assert.Empty(result.Changes);
+        Assert.NotEmpty(result.ValidationErrors);
+
+        Assert.Equal(before, _settings.Audio.MaxIntensity);
+        Assert.False(File.Exists(SettingsFile));
+    }
+
+    [Fact]
+    public async Task RejectedIntensity_LeavesTheSavedSettingsAndTheBackupIntact()
+    {
+        // Two good saves, so there is both a settings file and a last known good copy to protect.
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 65, DefaultFrequency = 42 });
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 30 });
+
+        Assert.True(File.Exists(SettingsFile));
+        Assert.True(File.Exists(BackupFile));
+
+        var settingsBefore = await File.ReadAllTextAsync(SettingsFile);
+        var backupBefore = await File.ReadAllTextAsync(BackupFile);
+
+        var result = await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 101 });
+
+        Assert.False(result.Valid);
+        Assert.False(result.Saved);
+
+        // Neither the running configuration nor either file moved.
+        Assert.Equal(30, _settings.Audio.MaxIntensity);
+        Assert.Equal(settingsBefore, await File.ReadAllTextAsync(SettingsFile));
+        Assert.Equal(backupBefore, await File.ReadAllTextAsync(BackupFile));
+
+        var reloaded = await AfterRestart().LoadUserPreferencesAsync();
+        Assert.Equal(30, reloaded.MaxIntensity);
+    }
+
+    [Fact]
+    public async Task RejectedFrequency_ChangesNothing()
+    {
+        await _persistence.ApplyAsync(new SettingsUpdate { DefaultFrequency = 42 });
+
+        var result = await _persistence.ApplyAsync(new SettingsUpdate
+        {
+            DefaultFrequency = 5,
+            MaxIntensity = 65
+        });
+
+        Assert.False(result.Valid);
+
+        // A rejected field does not let a valid one through beside it: nothing was applied.
+        Assert.Equal(42, _settings.Audio.DefaultFrequency);
+        Assert.Equal(new AppSettings().Audio.MaxIntensity, _settings.Audio.MaxIntensity);
+
+        var reloaded = await AfterRestart().LoadUserPreferencesAsync();
+        Assert.Equal(42, reloaded.DefaultFrequency);
+    }
+
+    [Fact]
+    public async Task SecondSave_KeepsThePreviousValuesAsTheLastKnownGoodCopy()
+    {
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 65, DefaultFrequency = 42 });
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 30 });
+
+        Assert.True(File.Exists(BackupFile));
+
+        var backup = JsonSerializer.Deserialize<UserPreferences>(
+            await File.ReadAllTextAsync(BackupFile),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Assert.NotNull(backup);
+        Assert.Equal(65, backup!.MaxIntensity);
+        Assert.Equal(42, backup.DefaultFrequency);
+    }
+
+    [Fact]
+    public async Task CorruptSettingsFile_FallsBackToTheLastKnownGoodCopy()
+    {
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 65, DefaultFrequency = 42 });
+        await _persistence.ApplyAsync(new SettingsUpdate { MaxIntensity = 30 });
+
+        // Whatever damaged it - a crash, a full disk, a hand-edit - the working copy is still there.
+        await File.WriteAllTextAsync(SettingsFile, "{ not valid json");
+
+        var reloaded = await AfterRestart().LoadUserPreferencesAsync();
+
+        Assert.Equal(65, reloaded.MaxIntensity);
+        Assert.Equal(42, reloaded.DefaultFrequency);
+    }
+
+    [Fact]
+    public async Task NoChange_WritesNothingAndSaysSo()
+    {
+        var result = await _persistence.ApplyAsync(new SettingsUpdate
+        {
+            MaxIntensity = _settings.Audio.MaxIntensity
+        });
+
+        Assert.True(result.Valid);
+        Assert.Empty(result.Changes);
+        Assert.Equal("no_changes", result.AppliedState);
+        Assert.False(File.Exists(SettingsFile));
+    }
+
+    public void Dispose() => _dir.Dispose();
+}
+
+internal static class SettingsUpdateResultAssertions
+{
+    /// <summary>Whether the one change named <paramref name="setting"/> reports itself as live.</summary>
+    public static bool AppliedNowFor(this SettingsUpdateResult result, string setting) =>
+        result.Changes.Single(c => c.Setting == setting).AppliedNow;
+}


### PR DESCRIPTION
## Summary
- Route every settings mutation (config, journal path, audio device, contextual intelligence, user-settings save, setup persist) through one validated `SettingsPersistenceService`.
- Atomic write of `user-settings.json` plus a last-known-good backup; invalid updates change neither the running config nor the files.
- API responses say whether a change is live now (`applied: immediately`) or needs a restart (`applied: after_restart`, e.g. sample rate / buffer size / journal monitor mode).
- Restart-round-trip tests cover persist, reload, rejected values, and backup fallback.

Linux verified: `dotnet test` — 495 passed, 0 failed. WASAPI playback and haptic hardware were not exercised.

Closes #24
