### PR TITLE
fix(security): bound API bodies, JSON depth, and journal replay memory

### DIFF
--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
@@ -96,17 +97,19 @@ public class AudioApiController
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+            if (json == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
                 return;
             }
 
-            var deviceData = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+            if (!BoundedRequestReader.TryDeserialize<Dictionary<string, JsonElement>>(json, out var deviceData))
+            {
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is not valid JSON" }));
+                return;
+            }
+
             var requestedEndpointId = ReadString(deviceData, "endpointId");
             var requestedDeviceId = ReadInt(deviceData, "deviceId");
 

--- a/src/EDButtkicker/Controllers/ConfigurationApiController.cs
+++ b/src/EDButtkicker/Controllers/ConfigurationApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
 
@@ -66,7 +67,12 @@ public class ConfigurationApiController
     {
         try
         {
-            var root = await ReadJsonAsync(context);
+            var (handled, root) = await ReadJsonAsync(context);
+            if (handled)
+            {
+                return;
+            }
+
             if (root == null)
             {
                 await WriteBadRequestAsync(context, "Request body is empty");
@@ -166,7 +172,12 @@ public class ConfigurationApiController
     {
         try
         {
-            var root = await ReadJsonAsync(context);
+            var (handled, root) = await ReadJsonAsync(context);
+            if (handled)
+            {
+                return;
+            }
+
             if (root == null)
             {
                 await WriteBadRequestAsync(context, "No configuration data provided");
@@ -224,18 +235,32 @@ public class ConfigurationApiController
         }
     }
 
-    private static async Task<JsonElement?> ReadJsonAsync(HttpContext context)
+    /// <summary>
+    /// The request body as JSON, read under the shared byte cap. <c>Handled</c> means the response
+    /// is already written - 413 for a body over the cap, 400 for JSON this API will not parse - and
+    /// a null <c>Root</c> with <c>Handled</c> false means the caller sent no body at all.
+    /// </summary>
+    private static async Task<(bool Handled, JsonElement? Root)> ReadJsonAsync(HttpContext context)
     {
-        using var reader = new StreamReader(context.Request.Body);
-        var json = await reader.ReadToEndAsync();
+        var body = await BoundedRequestReader.ReadAsync(context);
 
-        if (string.IsNullOrWhiteSpace(json))
+        switch (body.Status)
         {
-            return null;
+            case BoundedBodyStatus.TooLarge:
+                await BoundedRequestReader.WriteTooLargeAsync(context);
+                return (true, null);
+
+            case BoundedBodyStatus.Empty:
+                return (false, null);
         }
 
-        using var document = JsonDocument.Parse(json);
-        return document.RootElement.Clone();
+        if (!BoundedRequestReader.TryParseDocument(body.Text, out var root))
+        {
+            await WriteBadRequestAsync(context, "Request body is not valid JSON");
+            return (true, null);
+        }
+
+        return (false, root);
     }
 
     /// <summary>

--- a/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
+++ b/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
@@ -105,23 +106,17 @@ public class ContextualIntelligenceApiController
 	{
 		try
 		{
-			using var reader = new StreamReader(context.Request.Body);
-			var json = await reader.ReadToEndAsync();
-
-			if (string.IsNullOrEmpty(json))
+			var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+			if (json == null)
 			{
-				context.Response.StatusCode = 400;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
 				return;
 			}
 
-			var configUpdate = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-			if (configUpdate == null)
+			if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var configUpdate) ||
+				configUpdate == null)
 			{
-				context.Response.StatusCode = 400;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid JSON format" }));
+				await BoundedRequestReader.WriteErrorAsync(
+					context, StatusCodes.Status400BadRequest, "Request body is not valid JSON");
 				return;
 			}
 

--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,9 @@ namespace EDButtkicker.Controllers;
 
 public class JournalApiController
 {
+    /// <summary>The replay window: the last five minutes of the source's own timeline.</summary>
+    private static readonly TimeSpan ReplayWindow = TimeSpan.FromMinutes(5);
+
     private readonly ILogger<JournalApiController> _logger;
     private readonly AppSettings _settings;
     private readonly IJournalEventStore _eventStore;
@@ -105,17 +109,19 @@ public class JournalApiController
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+            if (json == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
                 return;
             }
 
-            var pathData = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var pathData))
+            {
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is not valid JSON" }));
+                return;
+            }
+
             if (pathData == null || !pathData.ContainsKey("path"))
             {
                 context.Response.StatusCode = 400;
@@ -128,6 +134,16 @@ public class JournalApiController
             {
                 context.Response.StatusCode = 400;
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Path cannot be empty" }));
+                return;
+            }
+
+            if (journalPath.Length > RequestLimits.MaxPathLength)
+            {
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                {
+                    error = $"Path must not exceed {RequestLimits.MaxPathLength} characters"
+                }));
                 return;
             }
 
@@ -261,19 +277,28 @@ public class JournalApiController
     {
         try
         {
-            // Parse request body to get journal file selection
-            string? selectedJournalFile = null;
-            if (context.Request.ContentLength > 0)
+            // Parse request body to get journal file selection. No body at all is allowed: that is
+            // the "replay what is in memory" case.
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, emptyBodyError: null);
+            if (json == null)
             {
-                using var reader = new StreamReader(context.Request.Body);
-                var json = await reader.ReadToEndAsync();
-                if (!string.IsNullOrEmpty(json))
+                return;
+            }
+
+            string? selectedJournalFile = null;
+            if (json.Length > 0)
+            {
+                if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var requestData))
                 {
-                    var requestData = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-                    if (requestData != null && requestData.ContainsKey("journalFile"))
-                    {
-                        selectedJournalFile = requestData["journalFile"].ToString();
-                    }
+                    context.Response.StatusCode = 400;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is not valid JSON" }));
+                    return;
+                }
+
+                if (requestData != null && requestData.ContainsKey("journalFile"))
+                {
+                    selectedJournalFile = requestData["journalFile"].ToString();
                 }
             }
 
@@ -473,67 +498,29 @@ public class JournalApiController
     /// </summary>
     private async Task<List<JournalEvent>> ReadLastFiveMinutesFromJournalFile(string fullPath)
     {
-        var events = new List<JournalEvent>();
         var journalFileName = Path.GetFileName(fullPath);
 
         try
         {
-            if (!File.Exists(fullPath))
+            // Only the tail is read: a session that has been running for hours is a large file, and
+            // none of it outside the replay window is worth holding.
+            var events = await JournalReplayTailReader.ReadTailAsync(fullPath, ReplayWindow, _logger);
+
+            if (events.Count == 0)
             {
-                _logger.LogWarning("Journal file not found: {FilePath}", fullPath);
+                _logger.LogWarning("No valid events found in the replay window of journal file: {FilePath}", fullPath);
                 return events;
             }
-
-            var allLines = await File.ReadAllLinesAsync(fullPath);
-            var allEvents = new List<JournalEvent>();
-
-            // Parse all events from the journal file
-            foreach (var line in allLines)
-            {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-
-                try
-                {
-                    var journalEvent = JsonSerializer.Deserialize<JournalEvent>(line);
-                    if (journalEvent != null)
-                    {
-                        allEvents.Add(journalEvent);
-                    }
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogDebug("Failed to parse journal line: {Line} - {Error}", line, ex.Message);
-                }
-            }
-
-            if (!allEvents.Any())
-            {
-                _logger.LogWarning("No valid events found in journal file: {FilePath}", fullPath);
-                return events;
-            }
-
-            // Sort events by timestamp
-            allEvents = allEvents.OrderBy(e => e.Timestamp).ToList();
-            
-            // Find the last event timestamp and calculate 5 minutes before that
-            var lastEventTime = allEvents.Last().Timestamp;
-            var cutoffTime = lastEventTime.AddMinutes(-5);
-
-            // Get events from the last 5 minutes of the journal's timeline
-            events = allEvents
-                .Where(e => e.Timestamp >= cutoffTime)
-                .OrderBy(e => e.Timestamp)
-                .ToList();
 
             _logger.LogInformation("Loaded {EventCount} events from last 5 minutes of journal {FileName} (from {StartTime} to {EndTime})",
-                events.Count, journalFileName, cutoffTime, lastEventTime);
+                events.Count, journalFileName, events[0].Timestamp, events[^1].Timestamp);
 
+            return events;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error reading journal file: {FileName}", journalFileName);
+            return new List<JournalEvent>();
         }
-
-        return events;
     }
 }

--- a/src/EDButtkicker/Controllers/PatternApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
@@ -110,18 +111,14 @@ public class PatternApiController
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+            if (json == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
                 return;
             }
 
-            var patternData = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (patternData == null)
+            if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var patternData) ||
+                patternData == null)
             {
                 context.Response.StatusCode = 400;
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid JSON format" }));
@@ -176,13 +173,9 @@ public class PatternApiController
                 return;
             }
 
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+            if (json == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Request body is empty" }));
                 return;
             }
 
@@ -259,27 +252,31 @@ public class PatternApiController
                 StationName = "Test Station"
             };
 
-            // Check for custom pattern parameters in request body
-            if (context.Request.ContentLength > 0)
+            // Check for custom pattern parameters in request body. No body is allowed here: it means
+            // "play the stored pattern for this event".
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, emptyBodyError: null);
+            if (json == null)
             {
-                using var reader = new StreamReader(context.Request.Body);
-                var json = await reader.ReadToEndAsync();
-                
-                if (!string.IsNullOrEmpty(json))
+                return;
+            }
+
+            if (json.Length > 0 &&
+                BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var customParams) &&
+                customParams != null)
+            {
+                patternToTest = CreateCustomTestPattern(eventType, customParams);
+
+                var limitErrors = PatternLimitsGuard.Validate(patternToTest, $"Event '{eventType}'");
+                if (limitErrors.Count > 0)
                 {
-                    try
+                    context.Response.StatusCode = 400;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsync(JsonSerializer.Serialize(new
                     {
-                        var customParams = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-                        if (customParams != null)
-                        {
-                            patternToTest = CreateCustomTestPattern(eventType, customParams);
-                        }
-                    }
-                    catch
-                    {
-                        // If JSON parsing fails, use default pattern
-                        patternToTest = null;
-                    }
+                        error = "Pattern exceeds the accepted limits",
+                        errors = limitErrors
+                    }));
+                    return;
                 }
             }
 
@@ -338,18 +335,14 @@ public class PatternApiController
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var json = await reader.ReadToEndAsync();
-            
-            if (string.IsNullOrEmpty(json))
+            var json = await BoundedRequestReader.ReadOrRespondAsync(context, "Pattern parameters are required");
+            if (json == null)
             {
-                context.Response.StatusCode = 400;
-                await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Pattern parameters are required" }));
                 return;
             }
 
-            var patternParams = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-            if (patternParams == null)
+            if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var patternParams) ||
+                patternParams == null)
             {
                 context.Response.StatusCode = 400;
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid pattern parameters" }));
@@ -357,7 +350,20 @@ public class PatternApiController
             }
 
             var testPattern = CreateCustomTestPattern("CustomTest", patternParams);
-            
+
+            var limitErrors = PatternLimitsGuard.Validate(testPattern, "Custom pattern");
+            if (limitErrors.Count > 0)
+            {
+                context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                {
+                    error = "Pattern exceeds the accepted limits",
+                    errors = limitErrors
+                }));
+                return;
+            }
+
             var testEvent = new JournalEvent
             {
                 Event = "CustomTest",

--- a/src/EDButtkicker/Controllers/PatternEditorApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternEditorApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using EDButtkicker.Hosting;
 using EDButtkicker.Services;
 using EDButtkicker.Models;
 using System.Text.Json;
@@ -129,9 +130,15 @@ public class PatternEditorController : ControllerBase
             // Validate pack name format
             if (!IsValidPackName(request.PackName))
             {
-                return BadRequest(new { 
-                    error = "Invalid pack name. Use only letters, numbers, spaces, underscores, and hyphens" 
+                return BadRequest(new {
+                    error = "Invalid pack name. Use only letters, numbers, spaces, underscores, and hyphens"
                 });
+            }
+
+            var limitErrors = PatternLimitsGuard.Validate(request);
+            if (limitErrors.Count > 0)
+            {
+                return BadRequest(new { error = "Pattern pack exceeds the allowed limits", errors = limitErrors });
             }
 
             // Generate safe filename
@@ -188,6 +195,12 @@ public class PatternEditorController : ControllerBase
             if (request.PatternFile?.Metadata == null)
             {
                 return BadRequest(new { error = "Pattern file data is required" });
+            }
+
+            var limitErrors = PatternLimitsGuard.Validate(request.PatternFile);
+            if (limitErrors.Count > 0)
+            {
+                return BadRequest(new { error = "Pattern pack exceeds the allowed limits", errors = limitErrors });
             }
 
             // Generate safe filename if not provided
@@ -357,12 +370,18 @@ public class PatternEditorController : ControllerBase
                                 validation.Warnings.Add($"Ship '{ship.Key}' event '{eventPattern.Key}': Frequency should be between 10-100Hz");
                             if (pattern.Intensity < 1 || pattern.Intensity > 100)
                                 validation.Errors.Add($"Ship '{ship.Key}' event '{eventPattern.Key}': Intensity must be between 1-100%");
-                            if (pattern.Duration < 50 || pattern.Duration > 10000)
+                            // Over the cap is an error, reported by the limits guard below; a short
+                            // pattern is merely questionable, so it stays a warning.
+                            if (pattern.Duration < 50)
                                 validation.Warnings.Add($"Ship '{ship.Key}' event '{eventPattern.Key}': Duration should be between 50-10000ms");
                         }
                     }
                 }
             }
+
+            // The content limits the pack must respect to be accepted at all: size, depth of lists
+            // and how long a single pattern may play.
+            validation.Errors.AddRange(PatternLimitsGuard.Validate(patternFile));
 
             validation.IsValid = !validation.Errors.Any();
 
@@ -383,6 +402,12 @@ public class PatternEditorController : ControllerBase
             if (request.Pattern == null)
             {
                 return BadRequest(new { error = "Pattern is required for testing" });
+            }
+
+            var limitErrors = PatternLimitsGuard.Validate(request.Pattern);
+            if (limitErrors.Count > 0)
+            {
+                return BadRequest(new { error = "Pattern exceeds the allowed limits", errors = limitErrors });
             }
 
             // Test the pattern by playing it
@@ -566,17 +591,17 @@ public class PatternEditorController : ControllerBase
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var requestBody = await reader.ReadToEndAsync();
-            var request = JsonSerializer.Deserialize<CreatePatternRequest>(requestBody, new JsonSerializerOptions
+            var requestBody = await BoundedRequestReader.ReadOrRespondAsync(context, "Invalid request body");
+            if (requestBody == null)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
-            });
+                return;
+            }
 
-            if (request == null)
+            if (!BoundedRequestReader.TryDeserialize<CreatePatternRequest>(
+                    requestBody, out var request, RequestLimits.CamelCaseJson) || request == null)
             {
                 context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid request body" }));
                 return;
             }
@@ -612,17 +637,17 @@ public class PatternEditorController : ControllerBase
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var requestBody = await reader.ReadToEndAsync();
-            var request = JsonSerializer.Deserialize<SavePatternRequest>(requestBody, new JsonSerializerOptions
+            var requestBody = await BoundedRequestReader.ReadOrRespondAsync(context, "Invalid request body");
+            if (requestBody == null)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
-            });
+                return;
+            }
 
-            if (request == null)
+            if (!BoundedRequestReader.TryDeserialize<SavePatternRequest>(
+                    requestBody, out var request, RequestLimits.CamelCaseJson) || request == null)
             {
                 context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid request body" }));
                 return;
             }
@@ -689,17 +714,17 @@ public class PatternEditorController : ControllerBase
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var requestBody = await reader.ReadToEndAsync();
-            var request = JsonSerializer.Deserialize<PatternFileDefinition>(requestBody, new JsonSerializerOptions
+            var requestBody = await BoundedRequestReader.ReadOrRespondAsync(context, "Invalid request body");
+            if (requestBody == null)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
-            });
+                return;
+            }
 
-            if (request == null)
+            if (!BoundedRequestReader.TryDeserialize<PatternFileDefinition>(
+                    requestBody, out var request, RequestLimits.CamelCaseJson) || request == null)
             {
                 context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid request body" }));
                 return;
             }
@@ -735,17 +760,17 @@ public class PatternEditorController : ControllerBase
     {
         try
         {
-            using var reader = new StreamReader(context.Request.Body);
-            var requestBody = await reader.ReadToEndAsync();
-            var request = JsonSerializer.Deserialize<TestPatternRequest>(requestBody, new JsonSerializerOptions
+            var requestBody = await BoundedRequestReader.ReadOrRespondAsync(context, "Invalid request body");
+            if (requestBody == null)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
-            });
+                return;
+            }
 
-            if (request == null)
+            if (!BoundedRequestReader.TryDeserialize<TestPatternRequest>(
+                    requestBody, out var request, RequestLimits.CamelCaseJson) || request == null)
             {
                 context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Invalid request body" }));
                 return;
             }

--- a/src/EDButtkicker/Controllers/PatternFilesApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternFilesApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using EDButtkicker.Hosting;
 using EDButtkicker.Services;
 using EDButtkicker.Models;
 
@@ -265,11 +266,31 @@ public class PatternFilesController : ControllerBase
                 return BadRequest(new { error = "Invalid file name" });
             }
 
+            // The declared length is refused before a byte is written; the bounded copy below is what
+            // actually enforces the cap, because the declaration is the caller's word for it.
+            if (file.Length > RequestLimits.MaxRequestBodyBytes)
+            {
+                return StatusCode(StatusCodes.Status413PayloadTooLarge,
+                    new { error = RequestLimits.UploadTooLargeError });
+            }
+
             // Save to temporary location first
             var tempPath = Path.GetTempFileName();
+            bool withinLimit;
             using (var stream = new FileStream(tempPath, FileMode.Create))
             {
-                await file.CopyToAsync(stream);
+                withinLimit = await BoundedRequestReader.CopyBoundedAsync(
+                    file.OpenReadStream(),
+                    stream,
+                    RequestLimits.MaxRequestBodyBytes,
+                    HttpContext?.RequestAborted ?? CancellationToken.None);
+            }
+
+            if (!withinLimit)
+            {
+                System.IO.File.Delete(tempPath);
+                return StatusCode(StatusCodes.Status413PayloadTooLarge,
+                    new { error = RequestLimits.UploadTooLargeError });
             }
 
             // Import the file
@@ -422,10 +443,20 @@ public class PatternFilesController : ControllerBase
     {
         try
         {
-            var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
-            var request = System.Text.Json.JsonSerializer.Deserialize<ExportPatternRequest>(body);
-            
-            var result = await ExportPatternPack(request!);
+            var body = await BoundedRequestReader.ReadOrRespondAsync(context, "Request body is empty");
+            if (body == null)
+            {
+                return;
+            }
+
+            if (!BoundedRequestReader.TryDeserialize<ExportPatternRequest>(body, out var request) || request == null)
+            {
+                await BoundedRequestReader.WriteErrorAsync(
+                    context, StatusCodes.Status400BadRequest, "Request body is not valid JSON");
+                return;
+            }
+
+            var result = await ExportPatternPack(request);
             
             context.Response.ContentType = "application/json";
             

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text.Json;
 using EDButtkicker.Configuration;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using EDButtkicker.Services;
 using Microsoft.Extensions.Logging;
@@ -110,7 +111,12 @@ public class SetupApiController
     {
         try
         {
-            var body = await ReadJsonAsync(context);
+            var (handled, body) = await ReadJsonAsync(context);
+            if (handled)
+            {
+                return;
+            }
+
             var requestedPath = ReadString(body, "path");
 
             if (string.IsNullOrWhiteSpace(requestedPath))
@@ -177,7 +183,12 @@ public class SetupApiController
     {
         try
         {
-            var body = await ReadJsonAsync(context);
+            var (handled, body) = await ReadJsonAsync(context);
+            if (handled)
+            {
+                return;
+            }
+
             var requestedEndpointId = ReadString(body, "endpointId");
             var requestedName = ReadString(body, "name");
             var requestedId = ReadInt(body, "deviceId");
@@ -472,17 +483,32 @@ public class SetupApiController
         }, new JsonSerializerOptions { WriteIndented = true }));
     }
 
-    private static async Task<Dictionary<string, JsonElement>?> ReadJsonAsync(HttpContext context)
+    /// <summary>
+    /// The request body as JSON, read under the shared byte cap. <c>Handled</c> means the response
+    /// is already written - 413 for a body over the cap, 400 for JSON this API will not parse - and
+    /// a null <c>Body</c> with <c>Handled</c> false means the caller sent no body at all.
+    /// </summary>
+    private static async Task<(bool Handled, Dictionary<string, JsonElement>? Body)> ReadJsonAsync(HttpContext context)
     {
-        using var reader = new StreamReader(context.Request.Body);
-        var json = await reader.ReadToEndAsync();
+        var body = await BoundedRequestReader.ReadAsync(context);
 
-        if (string.IsNullOrWhiteSpace(json))
+        switch (body.Status)
         {
-            return null;
+            case BoundedBodyStatus.TooLarge:
+                await BoundedRequestReader.WriteTooLargeAsync(context);
+                return (true, null);
+
+            case BoundedBodyStatus.Empty:
+                return (false, null);
         }
 
-        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        if (!BoundedRequestReader.TryDeserialize<Dictionary<string, JsonElement>>(body.Text, out var parsed))
+        {
+            await WriteBadRequestAsync(context, "Request body is not valid JSON");
+            return (true, null);
+        }
+
+        return (false, parsed);
     }
 
     private static string? ReadString(Dictionary<string, JsonElement>? body, string key) =>

--- a/src/EDButtkicker/Hosting/BoundedRequestReader.cs
+++ b/src/EDButtkicker/Hosting/BoundedRequestReader.cs
@@ -1,0 +1,176 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>How a request body ended up being read.</summary>
+public enum BoundedBodyStatus
+{
+    /// <summary>A body was read whole and is within the cap.</summary>
+    Ok,
+
+    /// <summary>There was no body, or it was whitespace only.</summary>
+    Empty,
+
+    /// <summary>The body is larger than <see cref="RequestLimits.MaxRequestBodyBytes"/>.</summary>
+    TooLarge
+}
+
+/// <summary>The outcome of a bounded read. <see cref="Text"/> is empty unless the status is Ok.</summary>
+public readonly record struct BoundedBody(BoundedBodyStatus Status, string Text);
+
+/// <summary>
+/// Reads request bodies with a hard byte cap. Content-Length is a hint that can be missing or wrong,
+/// so the cap is enforced against the bytes actually read: a body that grows past the limit is
+/// abandoned rather than buffered, and the caller answers 413.
+/// </summary>
+public static class BoundedRequestReader
+{
+    private const int ChunkSize = 8192;
+
+    /// <summary>Reads the body, stopping as soon as it is known to be over the cap.</summary>
+    public static async Task<BoundedBody> ReadAsync(
+        HttpContext context,
+        long limitBytes = RequestLimits.MaxRequestBodyBytes)
+    {
+        // A declared length over the cap is refused without reading a byte; the loop below is what
+        // actually enforces the limit, because the declaration is the caller's word for it.
+        if (context.Request.ContentLength > limitBytes)
+        {
+            return new BoundedBody(BoundedBodyStatus.TooLarge, string.Empty);
+        }
+
+        var buffer = new byte[ChunkSize];
+        using var accumulated = new MemoryStream();
+
+        while (true)
+        {
+            var read = await context.Request.Body.ReadAsync(buffer.AsMemory(), context.RequestAborted);
+            if (read == 0)
+            {
+                break;
+            }
+
+            if (accumulated.Length + read > limitBytes)
+            {
+                return new BoundedBody(BoundedBodyStatus.TooLarge, string.Empty);
+            }
+
+            accumulated.Write(buffer, 0, read);
+        }
+
+        var text = Encoding.UTF8.GetString(accumulated.GetBuffer(), 0, (int)accumulated.Length);
+
+        return string.IsNullOrWhiteSpace(text)
+            ? new BoundedBody(BoundedBodyStatus.Empty, string.Empty)
+            : new BoundedBody(BoundedBodyStatus.Ok, text);
+    }
+
+    /// <summary>
+    /// The body text, or <c>null</c> when this method has already written the response: 413 for a
+    /// body over the cap, and 400 with <paramref name="emptyBodyError"/> for a missing body. Pass a
+    /// null <paramref name="emptyBodyError"/> where an empty body is allowed; the result is then an
+    /// empty string rather than a rejection.
+    /// </summary>
+    public static async Task<string?> ReadOrRespondAsync(HttpContext context, string? emptyBodyError)
+    {
+        var body = await ReadAsync(context);
+
+        switch (body.Status)
+        {
+            case BoundedBodyStatus.TooLarge:
+                await WriteTooLargeAsync(context);
+                return null;
+
+            case BoundedBodyStatus.Empty when emptyBodyError != null:
+                await WriteErrorAsync(context, StatusCodes.Status400BadRequest, emptyBodyError);
+                return null;
+
+            case BoundedBodyStatus.Empty:
+                return string.Empty;
+
+            default:
+                return body.Text;
+        }
+    }
+
+    /// <summary>
+    /// Deserializes request JSON with the depth cap applied. Malformed JSON, JSON nested deeper than
+    /// <see cref="RequestLimits.MaxJsonDepth"/> and values of the wrong shape all come back false;
+    /// no exception detail reaches the caller.
+    /// </summary>
+    public static bool TryDeserialize<T>(string json, out T? value, JsonSerializerOptions? options = null)
+    {
+        try
+        {
+            value = JsonSerializer.Deserialize<T>(json, options ?? RequestLimits.Json);
+            return value != null;
+        }
+        catch (JsonException)
+        {
+            value = default;
+            return false;
+        }
+    }
+
+    /// <summary>As <see cref="TryDeserialize{T}"/>, for handlers that walk the document themselves.</summary>
+    public static bool TryParseDocument(string json, out JsonElement root)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json, RequestLimits.Document);
+            root = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            root = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Copies at most <paramref name="limitBytes"/> from <paramref name="source"/>. False means the
+    /// source had more to give, so a lying Content-Length cannot fill the disk.
+    /// </summary>
+    public static async Task<bool> CopyBoundedAsync(
+        Stream source,
+        Stream destination,
+        long limitBytes,
+        CancellationToken cancellationToken = default)
+    {
+        var buffer = new byte[ChunkSize];
+        long copied = 0;
+
+        while (true)
+        {
+            var read = await source.ReadAsync(buffer.AsMemory(), cancellationToken);
+            if (read == 0)
+            {
+                return true;
+            }
+
+            copied += read;
+            if (copied > limitBytes)
+            {
+                return false;
+            }
+
+            await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+        }
+    }
+
+    /// <summary>413 with the stable body-too-large error.</summary>
+    public static Task WriteTooLargeAsync(HttpContext context) =>
+        WriteErrorAsync(context, StatusCodes.Status413PayloadTooLarge, RequestLimits.BodyTooLargeError);
+
+    /// <summary>An error response in the shape the rest of the API uses.</summary>
+    public static Task WriteErrorAsync(HttpContext context, int statusCode, string error)
+    {
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/json";
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(new { error }));
+    }
+}

--- a/src/EDButtkicker/Hosting/PatternLimitsGuard.cs
+++ b/src/EDButtkicker/Hosting/PatternLimitsGuard.cs
@@ -1,0 +1,135 @@
+using EDButtkicker.Controllers;
+using EDButtkicker.Models;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// The content limits on a pattern that arrives from outside: how long it may play, how many layers,
+/// chained names and curve points it may carry, and how much text it may bring with it. A pack is
+/// refused rather than trimmed, so nothing a user sent is silently thrown away.
+/// </summary>
+public static class PatternLimitsGuard
+{
+    /// <summary>Every limit an imported pattern pack breaks, or an empty list when it breaks none.</summary>
+    public static IReadOnlyList<string> Validate(PatternFileDefinition patternFile)
+    {
+        var errors = new List<string>();
+
+        if (patternFile.Metadata != null)
+        {
+            CheckText(errors, patternFile.Metadata.Name, "Pack name", RequestLimits.MaxStringLength);
+            CheckText(errors, patternFile.Metadata.Author, "Author", RequestLimits.MaxStringLength);
+            CheckText(errors, patternFile.Metadata.Description, "Description", RequestLimits.MaxStringLength);
+            CheckText(errors, patternFile.Metadata.Version, "Version", RequestLimits.MaxStringLength);
+
+            if (patternFile.Metadata.Tags is { Count: > RequestLimits.MaxTags })
+            {
+                errors.Add($"A pattern pack may not carry more than {RequestLimits.MaxTags} tags");
+            }
+        }
+
+        if (patternFile.Ships == null)
+        {
+            return errors;
+        }
+
+        if (patternFile.Ships.Count > RequestLimits.MaxShipsPerPack)
+        {
+            errors.Add($"A pattern pack may not define more than {RequestLimits.MaxShipsPerPack} ships");
+            return errors;
+        }
+
+        foreach (var ship in patternFile.Ships)
+        {
+            CheckText(errors, ship.Key, "Ship type", RequestLimits.MaxStringLength);
+            CheckText(errors, ship.Value.DisplayName, $"Ship '{ship.Key}' display name", RequestLimits.MaxStringLength);
+
+            if (ship.Value.Events == null)
+            {
+                continue;
+            }
+
+            if (ship.Value.Events.Count > RequestLimits.MaxEventsPerShip)
+            {
+                errors.Add($"Ship '{ship.Key}' may not define more than {RequestLimits.MaxEventsPerShip} events");
+                continue;
+            }
+
+            foreach (var eventPattern in ship.Value.Events)
+            {
+                errors.AddRange(Validate(eventPattern.Value, $"Ship '{ship.Key}' event '{eventPattern.Key}'"));
+            }
+        }
+
+        return errors;
+    }
+
+    /// <summary>Every limit a single pattern breaks, named by <paramref name="description"/>.</summary>
+    public static IReadOnlyList<string> Validate(HapticPattern pattern, string description = "Pattern")
+    {
+        var errors = new List<string>();
+
+        if (pattern.Duration > RequestLimits.MaxPatternDurationMs)
+        {
+            errors.Add($"{description}: Duration must not exceed {RequestLimits.MaxPatternDurationMs}ms");
+        }
+
+        if (pattern.Layers is { Count: > RequestLimits.MaxPatternLayers })
+        {
+            errors.Add($"{description}: A pattern may not define more than {RequestLimits.MaxPatternLayers} layers");
+        }
+
+        if (pattern.ChainedPatterns is { Count: > RequestLimits.MaxChainedPatterns })
+        {
+            errors.Add($"{description}: A pattern may not chain more than {RequestLimits.MaxChainedPatterns} patterns");
+        }
+
+        if (pattern.CustomCurvePoints is { Count: > RequestLimits.MaxCurvePoints })
+        {
+            errors.Add($"{description}: A pattern may not carry more than {RequestLimits.MaxCurvePoints} curve points");
+        }
+
+        if (pattern.Conditions is { Count: > RequestLimits.MaxConditions })
+        {
+            errors.Add($"{description}: A pattern may not carry more than {RequestLimits.MaxConditions} conditions");
+        }
+
+        CheckText(errors, pattern.Name, $"{description}: Name", RequestLimits.MaxStringLength);
+        CheckText(errors, pattern.VoiceMessage, $"{description}: Voice message", RequestLimits.MaxStringLength);
+        CheckText(errors, pattern.AudioCueFile, $"{description}: Audio cue file", RequestLimits.MaxPathLength);
+
+        foreach (var chained in pattern.ChainedPatterns ?? new List<string>())
+        {
+            CheckText(errors, chained, $"{description}: Chained pattern name", RequestLimits.MaxStringLength);
+        }
+
+        return errors;
+    }
+
+    /// <summary>Every limit a new-pack request breaks, before anything is created from it.</summary>
+    public static IReadOnlyList<string> Validate(CreatePatternRequest request)
+    {
+        var errors = new List<string>();
+
+        CheckText(errors, request.PackName, "Pack name", RequestLimits.MaxStringLength);
+        CheckText(errors, request.Author, "Author", RequestLimits.MaxStringLength);
+        CheckText(errors, request.Description, "Description", RequestLimits.MaxStringLength);
+        CheckText(errors, request.InitialShipType, "Ship type", RequestLimits.MaxStringLength);
+        CheckText(errors, request.InitialShipDisplayName, "Ship display name", RequestLimits.MaxStringLength);
+
+        if (request.Tags is { Count: > RequestLimits.MaxTags })
+        {
+            errors.Add($"A pattern pack may not carry more than {RequestLimits.MaxTags} tags");
+        }
+
+        return errors;
+    }
+
+    private static void CheckText(List<string> errors, string? value, string description, int limit)
+    {
+        if (value != null && value.Length > limit)
+        {
+            errors.Add($"{description} must not exceed {limit} characters");
+        }
+    }
+}

--- a/src/EDButtkicker/Hosting/RequestLimits.cs
+++ b/src/EDButtkicker/Hosting/RequestLimits.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace EDButtkicker.Hosting;
+
+/// <summary>
+/// Every bound the loopback API applies to what a caller sends: the request body size Kestrel and
+/// the handlers agree on, the JSON shape limits, and the content limits on an imported pattern.
+/// They live in one place so the server, the handlers and the tests all mean the same numbers.
+/// </summary>
+public static class RequestLimits
+{
+    /// <summary>
+    /// The one body cap. This is a JSON configuration API for a single machine: a pattern pack that
+    /// does not fit in a mebibyte is not a pattern pack, it is an attempt to fill memory or disk.
+    /// </summary>
+    public const long MaxRequestBodyBytes = 1_048_576;
+
+    /// <summary>Nesting depth accepted while parsing request JSON.</summary>
+    public const int MaxJsonDepth = 32;
+
+    /// <summary>Characters accepted in a name, message or description.</summary>
+    public const int MaxStringLength = 4096;
+
+    /// <summary>Characters accepted in anything that names a file.</summary>
+    public const int MaxPathLength = 1024;
+
+    public const int MaxShipsPerPack = 128;
+    public const int MaxEventsPerShip = 128;
+    public const int MaxTags = 64;
+    public const int MaxChainedPatterns = 32;
+    public const int MaxPatternLayers = 8;
+    public const int MaxCurvePoints = 256;
+    public const int MaxConditions = 64;
+
+    /// <summary>Longest single haptic pattern, in milliseconds.</summary>
+    public const int MaxPatternDurationMs = 10_000;
+
+    /// <summary>Stable body-too-large message, so a caller can match on it.</summary>
+    public static readonly string BodyTooLargeError =
+        $"Request body exceeds the {MaxRequestBodyBytes} byte limit";
+
+    /// <summary>Stable upload-too-large message, so a caller can match on it.</summary>
+    public static readonly string UploadTooLargeError =
+        $"Uploaded file exceeds the {MaxRequestBodyBytes} byte limit";
+
+    /// <summary>Deserialization options for request JSON: depth capped, names as the UI sends them.</summary>
+    public static readonly JsonSerializerOptions Json = new()
+    {
+        MaxDepth = MaxJsonDepth,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>As <see cref="Json"/>, for the endpoints whose DTOs are camelCase on the wire.</summary>
+    public static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        MaxDepth = MaxJsonDepth,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>Document parsing options for request JSON.</summary>
+    public static readonly JsonDocumentOptions Document = new()
+    {
+        MaxDepth = MaxJsonDepth
+    };
+}

--- a/src/EDButtkicker/Program.cs
+++ b/src/EDButtkicker/Program.cs
@@ -174,7 +174,14 @@ class Program
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 // The web app lives in the primary service provider - there is no second container.
-                webBuilder.UseKestrel(options => options.ListenLocalhost(WebUiConfiguration.Port));
+                webBuilder.UseKestrel(options =>
+                {
+                    options.ListenLocalhost(WebUiConfiguration.Port);
+
+                    // First line of the body bound: the server refuses an oversize request before a
+                    // handler sees it. Every handler enforces the same cap on what it actually reads.
+                    options.Limits.MaxRequestBodySize = RequestLimits.MaxRequestBodyBytes;
+                });
                 webBuilder.Configure(WebUiConfiguration.Configure);
             })
             .ConfigureLogging(logging =>

--- a/src/EDButtkicker/Services/JournalReplayTailReader.cs
+++ b/src/EDButtkicker/Services/JournalReplayTailReader.cs
@@ -1,0 +1,146 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using EDButtkicker.Models;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>
+/// Reads the tail of an Elite Dangerous journal - NDJSON, one event per line - without ever holding
+/// the whole file. The file is scanned backwards in chunks and only the events inside the replay
+/// window are kept, so a multi-hour journal costs the same as a short one.
+/// </summary>
+public static class JournalReplayTailReader
+{
+    /// <summary>Events kept at most, so a journal written entirely inside the window stays bounded.</summary>
+    public const int MaxEvents = 10_000;
+
+    private const int ChunkSize = 64 * 1024;
+
+    /// <summary>A line longer than this is not a journal line; the scan stops rather than buffer it.</summary>
+    private const int MaxLineBytes = 1_048_576;
+
+    private static readonly JsonSerializerOptions JournalJson = new() { MaxDepth = 32 };
+
+    /// <summary>
+    /// Events from the last <paramref name="window"/> of the journal's own timeline: the window ends
+    /// at the last event in the file, which is the same rule the whole-file read used. Journals are
+    /// written in order, so the backward scan stops at the first event older than the window.
+    /// The returned list is chronological. The caller must pass a path that
+    /// <see cref="JournalFileGuard.Resolve"/> has already validated.
+    /// </summary>
+    public static async Task<List<JournalEvent>> ReadTailAsync(
+        string fullPath,
+        TimeSpan window,
+        ILogger logger,
+        int maxEvents = MaxEvents,
+        CancellationToken cancellationToken = default)
+    {
+        var events = new List<JournalEvent>();
+
+        if (!File.Exists(fullPath))
+        {
+            logger.LogWarning("Journal file not found: {FilePath}", fullPath);
+            return events;
+        }
+
+        await using var stream = new FileStream(
+            fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, ChunkSize, useAsync: true);
+
+        DateTime? cutoff = null;
+
+        await foreach (var line in ReadLinesBackwardAsync(stream, cancellationToken))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            JournalEvent? journalEvent;
+            try
+            {
+                journalEvent = JsonSerializer.Deserialize<JournalEvent>(line, JournalJson);
+            }
+            catch (JsonException ex)
+            {
+                logger.LogDebug("Failed to parse journal line: {Line} - {Error}", line, ex.Message);
+                continue;
+            }
+
+            if (journalEvent == null) continue;
+
+            // The last event in the file defines the window, exactly as before.
+            cutoff ??= journalEvent.Timestamp - window;
+
+            if (journalEvent.Timestamp < cutoff) break;
+
+            events.Add(journalEvent);
+
+            if (events.Count >= maxEvents)
+            {
+                logger.LogWarning(
+                    "Journal tail reached the {MaxEvents} event limit; older events in the window were not read",
+                    maxEvents);
+                break;
+            }
+        }
+
+        events.Reverse();
+        return events;
+    }
+
+    /// <summary>
+    /// The file's lines from last to first. Chunks are split on the newline byte before they are
+    /// decoded, so a UTF-8 character that straddles a chunk boundary is still decoded whole.
+    /// </summary>
+    private static async IAsyncEnumerable<string> ReadLinesBackwardAsync(
+        FileStream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var buffer = new byte[ChunkSize];
+        var carry = Array.Empty<byte>();
+        var position = stream.Length;
+
+        while (position > 0)
+        {
+            var toRead = (int)Math.Min(ChunkSize, position);
+            position -= toRead;
+
+            stream.Seek(position, SeekOrigin.Begin);
+            await stream.ReadExactlyAsync(buffer.AsMemory(0, toRead), cancellationToken);
+
+            var end = toRead;
+            for (var i = toRead - 1; i >= 0; i--)
+            {
+                if (buffer[i] != (byte)'\n') continue;
+
+                yield return Decode(Concat(buffer, i + 1, end, carry));
+                carry = Array.Empty<byte>();
+                end = i;
+            }
+
+            carry = Concat(buffer, 0, end, carry);
+
+            if (carry.Length > MaxLineBytes)
+            {
+                yield break;
+            }
+        }
+
+        if (carry.Length > 0)
+        {
+            yield return Decode(carry);
+        }
+    }
+
+    private static byte[] Concat(byte[] buffer, int start, int end, byte[] tail)
+    {
+        var length = end - start;
+        var joined = new byte[length + tail.Length];
+
+        Buffer.BlockCopy(buffer, start, joined, 0, length);
+        Buffer.BlockCopy(tail, 0, joined, length, tail.Length);
+
+        return joined;
+    }
+
+    private static string Decode(byte[] line) => Encoding.UTF8.GetString(line).TrimEnd('\r');
+}

--- a/tests/EDButtkicker.Tests/JournalReplayTailReaderTests.cs
+++ b/tests/EDButtkicker.Tests/JournalReplayTailReaderTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Replay reads the tail of a journal rather than the whole file. These drive the reader directly:
+/// a long journal costs only the events inside the window, the window is measured from the last
+/// event in the file, and a journal that is not there yields nothing rather than throwing.
+/// </summary>
+public class JournalReplayTailReaderTests
+{
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public async Task ReadTailAsync_OnALongJournal_ReturnsOnlyTheEventsInsideTheWindow()
+    {
+        using var directory = new TempDirectory("edbk-journal-tail");
+        var path = directory.File("Journal.2026-01-01T000000.01.log");
+
+        var now = DateTime.UtcNow;
+        var lines = new List<string>();
+
+        for (var i = 0; i < 5000; i++)
+        {
+            lines.Add(Line(now.AddHours(-1).AddMilliseconds(i), "FSDJump", $"Old {i}"));
+        }
+
+        lines.Add(Line(now.AddSeconds(-30), "FSDJump", "Recent One"));
+        lines.Add(Line(now.AddSeconds(-20), "HullDamage", "Recent Two"));
+        lines.Add(Line(now.AddSeconds(-10), "ShieldDown", "Recent Three"));
+
+        await File.WriteAllLinesAsync(path, lines);
+
+        var events = await JournalReplayTailReader.ReadTailAsync(path, Window, NullLogger.Instance);
+
+        Assert.Equal(3, events.Count);
+        Assert.Equal(new[] { "Recent One", "Recent Two", "Recent Three" }, events.Select(e => e.StarSystem));
+        Assert.Equal(new[] { "FSDJump", "HullDamage", "ShieldDown" }, events.Select(e => e.Event));
+    }
+
+    [Fact]
+    public async Task ReadTailAsync_OnAMissingFile_ReturnsNothing()
+    {
+        using var directory = new TempDirectory("edbk-journal-tail");
+
+        var events = await JournalReplayTailReader.ReadTailAsync(
+            directory.File("not-there.log"), Window, NullLogger.Instance);
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public async Task ReadTailAsync_WhenOnlyTheLastEventIsInsideTheWindow_ReturnsThatEventAlone()
+    {
+        using var directory = new TempDirectory("edbk-journal-tail");
+        var path = directory.File("Journal.2026-01-02T000000.01.log");
+
+        var now = DateTime.UtcNow;
+        await File.WriteAllLinesAsync(path, new[]
+        {
+            Line(now.AddMinutes(-30), "Docked", "Long Ago"),
+            Line(now.AddMinutes(-10), "Undocked", "Ten Minutes Ago"),
+            Line(now, "FSDJump", "Now")
+        });
+
+        var events = await JournalReplayTailReader.ReadTailAsync(path, Window, NullLogger.Instance);
+
+        var single = Assert.Single(events);
+        Assert.Equal("Now", single.StarSystem);
+    }
+
+    private static string Line(DateTime timestamp, string eventName, string starSystem) =>
+        JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["timestamp"] = timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            ["event"] = eventName,
+            ["StarSystem"] = starSystem
+        });
+}

--- a/tests/EDButtkicker.Tests/PatternValidationTests.cs
+++ b/tests/EDButtkicker.Tests/PatternValidationTests.cs
@@ -1,4 +1,5 @@
 using EDButtkicker.Controllers;
+using EDButtkicker.Hosting;
 using EDButtkicker.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -126,18 +127,42 @@ public class PatternValidationTests : IClassFixture<WebUiTestServerFixture>
         Assert.Contains(result.Warnings, w => w.Contains("Frequency should be between 10-100Hz"));
     }
 
-    [Theory]
-    [InlineData(49)]
-    [InlineData(10001)]
-    public void DurationOutsideFiftyToTenThousandMs_IsAWarningNotAnError(int duration)
+    [Fact]
+    public void DurationBelowFiftyMs_IsAWarningNotAnError()
     {
         var file = Pack();
-        file.Ships["anaconda"].Events["HullDamage"].Duration = duration;
+        file.Ships["anaconda"].Events["HullDamage"].Duration = 49;
 
         var result = Validate(file);
 
         Assert.True(result.IsValid);
         Assert.Contains(result.Warnings, w => w.Contains("Duration should be between 50-10000ms"));
+    }
+
+    [Fact]
+    public void DurationOverTenThousandMs_IsAnError()
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Duration = 10001;
+
+        var result = Validate(file);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("Duration must not exceed 10000ms"));
+    }
+
+    [Fact]
+    public void PatternWithMoreLayersThanTheCap_IsAnError()
+    {
+        var file = Pack();
+        file.Ships["anaconda"].Events["HullDamage"].Layers =
+            Enumerable.Range(0, RequestLimits.MaxPatternLayers + 1).Select(_ => new PatternLayer()).ToList();
+
+        var result = Validate(file);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("layers"));
+        Assert.Contains(result.Errors, e => e.Contains(RequestLimits.MaxPatternLayers.ToString()));
     }
 
     [Fact]

--- a/tests/EDButtkicker.Tests/RequestBodyAndImportLimitTests.cs
+++ b/tests/EDButtkicker.Tests/RequestBodyAndImportLimitTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Text;
+using EDButtkicker.Hosting;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// What the loopback API accepts from a caller who sends too much: a body over the byte cap is
+/// refused with 413 by the handler itself - never buffered whole - and JSON nested past the depth
+/// cap is a bad request rather than a crash. The bound is enforced in the handler, not only by
+/// Kestrel, so it still holds here where TestServer is the transport.
+/// </summary>
+public class RequestBodyAndImportLimitTests : IClassFixture<WebUiTestServerFixture>
+{
+    private readonly WebUiTestServerFixture _fixture;
+
+    public RequestBodyAndImportLimitTests(WebUiTestServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task JournalPath_WithABodyJustUnderTheCap_IsNotRefusedForSize()
+    {
+        // A valid JSON object of very nearly the largest allowed body: whatever the API makes of the
+        // path itself, the size is not what it objects to.
+        var padding = new string('p', (int)RequestLimits.MaxRequestBodyBytes - 100);
+        var body = $"{{\"path\":\"{padding}\"}}";
+
+        var response = await _fixture.Client.PostAsync("/api/journal/path", JsonContent(body));
+
+        Assert.NotEqual(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task JournalPath_WithABodyOverTheCap_Is413()
+    {
+        var oversized = new byte[RequestLimits.MaxRequestBodyBytes + 1024];
+        Array.Fill(oversized, (byte)'x');
+
+        var response = await _fixture.Client.PostAsync("/api/journal/path", JsonContent(oversized));
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        Assert.Contains(RequestLimits.BodyTooLargeError, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ValidatePattern_WithJsonNestedPastTheDepthCap_Is400NotAnUnhandledError()
+    {
+        var depth = RequestLimits.MaxJsonDepth + 8;
+        var body = new string('{', depth) + "\"a\":1" + new string('}', depth);
+
+        var response = await _fixture.Client.PostAsync("/api/PatternEditor/validate", JsonContent(body));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static ByteArrayContent JsonContent(string body) => JsonContent(Encoding.UTF8.GetBytes(body));
+
+    private static ByteArrayContent JsonContent(byte[] body)
+    {
+        var content = new ByteArrayContent(body);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+        return content;
+    }
+}


### PR DESCRIPTION
## Summary
- Kestrel and every request-body handler share a 1 MiB cap; oversize bodies return 413 with a stable error string.
- Imported JSON is refused past depth 32, 8 pattern layers, 10000 ms duration, and collection/string limits (400, not truncated).
- Journal replay streams the file tail instead of `File.ReadAllLinesAsync` on the whole journal.

## Test Plan
- [x] `dotnet test` on Linux: 502 passed, 0 failed (no WASAPI / no Buttkicker hardware).

Closes #18
