### PR TITLE
fix: stop leaking exception text and filesystem paths from APIs

### DIFF
--- a/src/EDButtkicker/Controllers/ApiError.cs
+++ b/src/EDButtkicker/Controllers/ApiError.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace EDButtkicker.Controllers;
+
+/// <summary>
+/// The one shape an API failure takes: a stable sentence the web page can show and a caller can
+/// match on. Exception text, stack traces and local filesystem paths never go in here - they go to
+/// the log the operator already has, because everything written to a response is read by a browser.
+/// </summary>
+public static class ApiError
+{
+    /// <summary>The body for a controller result, e.g. <c>StatusCode(500, ApiError.Payload("..."))</c>.</summary>
+    public static object Payload(string error) => new { error };
+
+    /// <summary>
+    /// Writes the same body straight to a raw <see cref="HttpContext"/> handler. A response that has
+    /// already started is left alone rather than throwing over the original failure.
+    /// </summary>
+    public static Task WriteAsync(HttpContext context, int statusCode, string error)
+    {
+        if (context.Response.HasStarted)
+        {
+            return Task.CompletedTask;
+        }
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/json";
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(Payload(error)));
+    }
+}

--- a/src/EDButtkicker/Controllers/AudioApiController.cs
+++ b/src/EDButtkicker/Controllers/AudioApiController.cs
@@ -88,8 +88,7 @@ public class AudioApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting audio devices");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to list audio devices");
         }
     }
 
@@ -184,8 +183,7 @@ public class AudioApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error setting audio device");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to set the audio device");
         }
     }
 
@@ -203,8 +201,7 @@ public class AudioApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error reading audio status");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to read the audio status");
         }
     }
 
@@ -264,8 +261,7 @@ public class AudioApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error testing audio");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to test the audio output");
         }
     }
 
@@ -293,8 +289,7 @@ public class AudioApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error stopping audio playback");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to stop audio playback");
         }
     }
 

--- a/src/EDButtkicker/Controllers/ConfigurationApiController.cs
+++ b/src/EDButtkicker/Controllers/ConfigurationApiController.cs
@@ -52,8 +52,7 @@ public class ConfigurationApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting configuration");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to read the configuration");
         }
     }
 
@@ -126,8 +125,7 @@ public class ConfigurationApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error updating configuration");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to update the configuration");
         }
     }
 
@@ -163,8 +161,7 @@ public class ConfigurationApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error exporting configuration");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to export the configuration");
         }
     }
 
@@ -230,8 +227,7 @@ public class ConfigurationApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error importing configuration");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to import the configuration");
         }
     }
 

--- a/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
+++ b/src/EDButtkicker/Controllers/ContextualIntelligenceApiController.cs
@@ -93,12 +93,7 @@ public class ContextualIntelligenceApiController
 		catch (Exception ex)
 		{
 			_logger.LogError(ex, "Error getting contextual intelligence status");
-			if (!context.Response.HasStarted)
-			{
-				context.Response.StatusCode = 500;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-			}
+			await ApiError.WriteAsync(context, 500, "Failed to read the contextual intelligence status");
 		}
 	}
 
@@ -180,12 +175,7 @@ public class ContextualIntelligenceApiController
 		catch (Exception ex)
 		{
 			_logger.LogError(ex, "Error updating contextual intelligence configuration");
-			if (!context.Response.HasStarted)
-			{
-				context.Response.StatusCode = 500;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-			}
+			await ApiError.WriteAsync(context, 500, "Failed to update the contextual intelligence configuration");
 		}
 	}
 
@@ -221,12 +211,7 @@ public class ContextualIntelligenceApiController
 		catch (Exception ex)
 		{
 			_logger.LogError(ex, "Error getting game context predictions");
-			if (!context.Response.HasStarted)
-			{
-				context.Response.StatusCode = 500;
-				context.Response.ContentType = "application/json";
-				await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
-			}
+			await ApiError.WriteAsync(context, 500, "Failed to get game context predictions");
 		}
 	}
 }

--- a/src/EDButtkicker/Controllers/HealthApiController.cs
+++ b/src/EDButtkicker/Controllers/HealthApiController.cs
@@ -28,8 +28,7 @@ public class HealthApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error building the health report");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to build the health report");
         }
     }
 
@@ -72,8 +71,7 @@ public class HealthApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrying health component {Component}", componentId);
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to retry the health component");
         }
     }
 

--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -100,8 +100,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting journal status");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to read the journal status");
         }
     }
 
@@ -210,8 +209,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error setting journal path");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to set the journal folder");
         }
     }
 
@@ -264,8 +262,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting recent events");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to read recent journal events");
         }
     }
 
@@ -386,8 +383,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error starting journal replay");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to start the journal replay");
         }
     }
 
@@ -414,8 +410,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error stopping journal replay");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to stop the journal replay");
         }
     }
 
@@ -446,8 +441,7 @@ public class JournalApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting replay status");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to read the replay status");
         }
     }
 

--- a/src/EDButtkicker/Controllers/PatternApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternApiController.cs
@@ -102,8 +102,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting patterns");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to get patterns");
         }
     }
 
@@ -156,8 +155,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error creating pattern");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to create the pattern");
         }
     }
 
@@ -192,8 +190,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error updating pattern");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to update the pattern");
         }
     }
 
@@ -222,8 +219,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting pattern");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to delete the pattern");
         }
     }
 
@@ -326,8 +322,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error testing pattern for event: {EventType}", ExtractEventTypeFromPath(context.Request.Path));
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to test the pattern");
         }
     }
 
@@ -396,8 +391,7 @@ public class PatternApiController
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error testing custom pattern");
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+            await ApiError.WriteAsync(context, 500, "Failed to test the custom pattern");
         }
     }
     

--- a/src/EDButtkicker/Controllers/PatternEditorApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternEditorApiController.cs
@@ -113,7 +113,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting pattern templates");
-            return StatusCode(500, new { error = "Failed to get pattern templates", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get pattern templates" });
         }
     }
 
@@ -183,7 +183,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error creating new pattern");
-            return StatusCode(500, new { error = "Failed to create new pattern", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to create new pattern" });
         }
     }
 
@@ -230,8 +230,8 @@ public class PatternEditorController : ControllerBase
 
             // Determine save location
             var saveDirectory = request.SaveToCustom ? "Custom" : "patterns";
-            var fullPath = PatternPathGuard.ResolveUnderRoot(
-                Path.Combine(Directory.GetCurrentDirectory(), "patterns"), fileName, saveDirectory);
+            var patternsRoot = Path.Combine(Directory.GetCurrentDirectory(), "patterns");
+            var fullPath = PatternPathGuard.ResolveUnderRoot(patternsRoot, fileName, saveDirectory);
             if (fullPath == null)
             {
                 return BadRequest(new { error = "Invalid file name" });
@@ -264,7 +264,9 @@ public class PatternEditorController : ControllerBase
             {
                 Message = $"Pattern file '{fileName}' saved successfully",
                 FileName = fileName,
-                FilePath = fullPath,
+                // Relative to the patterns root: where the file sits is useful to the page, where
+                // the patterns root sits on this machine is not the caller's business.
+                FilePath = Path.GetRelativePath(patternsRoot, fullPath),
                 SaveLocation = saveDirectory,
                 Created = System.IO.File.GetCreationTime(fullPath),
                 FileSize = new FileInfo(fullPath).Length
@@ -273,7 +275,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error saving pattern file");
-            return StatusCode(500, new { error = "Failed to save pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to save pattern file" });
         }
     }
 
@@ -314,7 +316,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error loading pattern file for editing: {FileName}", fileName);
-            return StatusCode(500, new { error = "Failed to load pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to load pattern file" });
         }
     }
 
@@ -390,7 +392,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error validating pattern file");
-            return StatusCode(500, new { error = "Failed to validate pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to validate pattern file" });
         }
     }
 
@@ -418,7 +420,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error testing pattern");
-            return StatusCode(500, new { error = "Failed to test pattern", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to test pattern" });
         }
     }
 
@@ -483,7 +485,7 @@ public class PatternEditorController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting user files for author: {Author}", author);
-            return StatusCode(500, new { error = "Failed to get user files", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get user files" });
         }
     }
 
@@ -628,8 +630,8 @@ public class PatternEditorController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Internal server error", details = ex.Message }));
+            _logger.LogError(ex, "Error creating a new pattern");
+            await ApiError.WriteAsync(context, 500, "Internal server error");
         }
     }
 
@@ -674,8 +676,8 @@ public class PatternEditorController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Internal server error", details = ex.Message }));
+            _logger.LogError(ex, "Error saving a pattern file");
+            await ApiError.WriteAsync(context, 500, "Internal server error");
         }
     }
 
@@ -751,8 +753,8 @@ public class PatternEditorController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Internal server error", details = ex.Message }));
+            _logger.LogError(ex, "Error validating a pattern file");
+            await ApiError.WriteAsync(context, 500, "Internal server error");
         }
     }
 
@@ -797,8 +799,8 @@ public class PatternEditorController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = "Internal server error", details = ex.Message }));
+            _logger.LogError(ex, "Error testing a pattern");
+            await ApiError.WriteAsync(context, 500, "Internal server error");
         }
     }
 

--- a/src/EDButtkicker/Controllers/PatternFilesApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternFilesApiController.cs
@@ -52,7 +52,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting pattern packs");
-            return StatusCode(500, new { error = "Failed to get pattern packs", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get pattern packs" });
         }
     }
 
@@ -93,7 +93,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting ship patterns");
-            return StatusCode(500, new { error = "Failed to get ship patterns", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship patterns" });
         }
     }
 
@@ -142,7 +142,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting patterns for ship type: {ShipType}", shipType);
-            return StatusCode(500, new { error = "Failed to get ship type patterns", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship type patterns" });
         }
     }
 
@@ -185,7 +185,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting event pattern options for {ShipType}.{EventName}", shipType, eventName);
-            return StatusCode(500, new { error = "Failed to get event pattern options", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get event pattern options" });
         }
     }
 
@@ -211,7 +211,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error reloading pattern files");
-            return StatusCode(500, new { error = "Failed to reload pattern files", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to reload pattern files" });
         }
     }
 
@@ -241,7 +241,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error exporting pattern pack: {PackName}", request.PackName);
-            return StatusCode(500, new { error = "Failed to export pattern pack", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to export pattern pack" });
         }
     }
 
@@ -315,7 +315,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error importing pattern file");
-            return StatusCode(500, new { error = "Failed to import pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to import pattern file" });
         }
     }
 
@@ -342,7 +342,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error downloading pattern file: {FileName}", fileName);
-            return StatusCode(500, new { error = "Failed to download pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to download pattern file" });
         }
     }
 
@@ -382,7 +382,7 @@ public class PatternFilesController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting pattern file: {FileName}", fileName);
-            return StatusCode(500, new { error = "Failed to delete pattern file", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to delete pattern file" });
         }
     }
 
@@ -481,10 +481,8 @@ public class PatternFilesController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "application/json";
-            var errorJson = System.Text.Json.JsonSerializer.Serialize(new { error = "Failed to export pattern pack", details = ex.Message });
-            await context.Response.WriteAsync(errorJson);
+            _logger.LogError(ex, "Error exporting pattern pack");
+            await ApiError.WriteAsync(context, 500, "Failed to export pattern pack");
         }
     }
 
@@ -501,10 +499,8 @@ public class PatternFilesController : ControllerBase
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = 500;
-            context.Response.ContentType = "application/json";
-            var errorJson = System.Text.Json.JsonSerializer.Serialize(new { error = "Failed to import pattern file", details = ex.Message });
-            await context.Response.WriteAsync(errorJson);
+            _logger.LogError(ex, "Error importing pattern file");
+            await ApiError.WriteAsync(context, 500, "Failed to import pattern file");
         }
     }
 }

--- a/src/EDButtkicker/Controllers/PatternSelectionApiController.cs
+++ b/src/EDButtkicker/Controllers/PatternSelectionApiController.cs
@@ -34,7 +34,7 @@ public class PatternSelectionController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting pattern conflicts");
-            return StatusCode(500, new { error = "Failed to get pattern conflicts", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get pattern conflicts" });
         }
     }
 
@@ -58,7 +58,7 @@ public class PatternSelectionController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting available patterns for {ShipType}.{EventName}", shipType, eventName);
-            return StatusCode(500, new { error = "Failed to get available patterns", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get available patterns" });
         }
     }
 
@@ -88,7 +88,7 @@ public class PatternSelectionController : ControllerBase
         {
             _logger.LogError(ex, "Error selecting pattern for {ShipType}.{EventName}: {SourceId}", 
                 request.ShipType, request.EventName, request.SourceId);
-            return StatusCode(500, new { error = "Failed to select pattern", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to select pattern" });
         }
     }
 
@@ -171,7 +171,7 @@ public class PatternSelectionController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error auto-resolving pattern conflicts");
-            return StatusCode(500, new { error = "Failed to auto-resolve conflicts", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to auto-resolve conflicts" });
         }
     }
 
@@ -186,7 +186,7 @@ public class PatternSelectionController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting pattern selection stats");
-            return StatusCode(500, new { error = "Failed to get stats", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get stats" });
         }
     }
 
@@ -213,7 +213,7 @@ public class PatternSelectionController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error refreshing pattern sources");
-            return StatusCode(500, new { error = "Failed to refresh sources", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to refresh sources" });
         }
     }
 }

--- a/src/EDButtkicker/Controllers/SetupApiController.cs
+++ b/src/EDButtkicker/Controllers/SetupApiController.cs
@@ -129,7 +129,9 @@ public class SetupApiController
 
             if (!Directory.Exists(journalPath))
             {
-                await WriteBadRequestAsync(context, "That folder does not exist", new { path = journalPath });
+                // Deliberately without the path: the response body must not echo a local filesystem
+                // location back, even one the caller just typed.
+                await WriteBadRequestAsync(context, "That folder does not exist");
                 return;
             }
 
@@ -471,12 +473,17 @@ public class SetupApiController
     {
         var setup = await BuildStatusAsync();
 
+        _logger.LogWarning(
+            "Setup {What} applied to this session but could not be saved to {SettingsPath}",
+            what,
+            _userSettings.GetUserSettingsPath());
+
         context.Response.StatusCode = 500;
         context.Response.ContentType = "application/json";
 
         await context.Response.WriteAsync(JsonSerializer.Serialize(new
         {
-            error = $"The {what} is in use for this session but could not be saved to {_userSettings.GetUserSettingsPath()}, " +
+            error = $"The {what} is in use for this session but could not be saved to the settings file, " +
                 "so this step is not marked complete. Check that the file is writable and try again.",
             saved = false,
             setup
@@ -554,8 +561,8 @@ public class SetupApiController
 
     private async Task WriteErrorAsync(HttpContext context, Exception ex, string message)
     {
+        // The exception belongs in the operator's log; the caller gets the stable sentence only.
         _logger.LogError(ex, "{Message}", message);
-        context.Response.StatusCode = 500;
-        await context.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+        await ApiError.WriteAsync(context, 500, message);
     }
 }

--- a/src/EDButtkicker/Controllers/ShipPatternsApiController.cs
+++ b/src/EDButtkicker/Controllers/ShipPatternsApiController.cs
@@ -65,7 +65,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting current ship information");
-            return StatusCode(500, new { error = "Failed to get current ship information", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get current ship information" });
         }
     }
 
@@ -102,7 +102,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting ship patterns library");
-            return StatusCode(500, new { error = "Failed to get ship patterns library", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship patterns library" });
         }
     }
 
@@ -146,7 +146,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting ship details for {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to get ship details", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship details" });
         }
     }
 
@@ -172,7 +172,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error setting ship pattern for {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to set ship pattern", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to set ship pattern" });
         }
     }
 
@@ -192,7 +192,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error removing ship pattern for {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to remove ship pattern", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to remove ship pattern" });
         }
     }
 
@@ -219,7 +219,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error applying recommended patterns for {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to apply recommended patterns", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to apply recommended patterns" });
         }
     }
 
@@ -238,7 +238,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error removing ship {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to remove ship", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to remove ship" });
         }
     }
 
@@ -265,7 +265,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting ship classifications");
-            return StatusCode(500, new { error = "Failed to get ship classifications", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship classifications" });
         }
     }
 
@@ -287,7 +287,7 @@ public class ShipPatternsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting recommendations for {ShipKey}", shipKey);
-            return StatusCode(500, new { error = "Failed to get ship recommendations", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to get ship recommendations" });
         }
     }
 

--- a/src/EDButtkicker/Controllers/UserSettingsApiController.cs
+++ b/src/EDButtkicker/Controllers/UserSettingsApiController.cs
@@ -38,7 +38,7 @@ public class UserSettingsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving user settings");
-            return StatusCode(500, new { error = "Failed to retrieve user settings", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to retrieve user settings" });
         }
     }
 
@@ -91,14 +91,13 @@ public class UserSettingsController : ControllerBase
             {
                 message = result.Message,
                 timestamp = DateTime.UtcNow,
-                settingsPath = result.SettingsPath,
                 settings = result.ToPayload()
             });
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error saving user settings");
-            return StatusCode(500, new { error = "Failed to save user settings", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to save user settings" });
         }
     }
 
@@ -128,7 +127,7 @@ public class UserSettingsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error resetting user settings");
-            return StatusCode(500, new { error = "Failed to reset user settings", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to reset user settings" });
         }
     }
 
@@ -161,8 +160,7 @@ public class UserSettingsController : ControllerBase
                     EnablePredictivePatterns = _appSettings.ContextualIntelligence.EnablePredictivePatterns,
                     EnableContextualVoice = _appSettings.ContextualIntelligence.EnableContextualVoice
                 } : null,
-                UserSettingsExist = _userSettingsService.UserSettingsExist(),
-                UserSettingsPath = _userSettingsService.GetUserSettingsPath()
+                UserSettingsExist = _userSettingsService.UserSettingsExist()
             };
 
             return Ok(response);
@@ -170,7 +168,7 @@ public class UserSettingsController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error retrieving current settings");
-            return StatusCode(500, new { error = "Failed to retrieve current settings", details = ex.Message });
+            return StatusCode(500, new { error = "Failed to retrieve current settings" });
         }
     }
 }
@@ -203,8 +201,8 @@ public class CurrentSettingsResponse
     public CurrentAudioSettings Audio { get; set; } = new();
     public CurrentEliteDangerousSettings EliteDangerous { get; set; } = new();
     public CurrentContextualIntelligenceSettings? ContextualIntelligence { get; set; }
+    /// <summary>Whether a settings file has been written yet. Where it lives stays on the machine.</summary>
     public bool UserSettingsExist { get; set; }
-    public string UserSettingsPath { get; set; } = string.Empty;
 }
 
 public class CurrentAudioSettings

--- a/src/EDButtkicker/Services/SettingsPersistenceService.cs
+++ b/src/EDButtkicker/Services/SettingsPersistenceService.cs
@@ -106,9 +106,11 @@ public sealed class SettingsUpdateResult
                 return "No settings changed.";
             }
 
+            // Neither the settings file's location nor the exception that stopped the write belongs
+            // in a response body; both are already in the log line next to the failure.
             var where = Saved
-                ? $"Saved to {SettingsPath}."
-                : $"NOT saved to {SettingsPath} ({SaveError}) - these values apply to this session only and will be gone after a restart.";
+                ? "Saved to the settings file."
+                : "NOT saved to the settings file - these values apply to this session only and will be gone after a restart.";
 
             var live = Changes.Where(c => c.AppliedNow).Select(c => c.Setting).ToList();
             var pending = RestartRequiredSettings;
@@ -129,7 +131,6 @@ public sealed class SettingsUpdateResult
     public object ToPayload() => new
     {
         saved = Saved,
-        settings_path = SettingsPath,
         applied = AppliedState,
         restart_required = RestartRequired,
         restart_required_settings = RestartRequiredSettings,
@@ -539,7 +540,7 @@ public class SettingsPersistenceService
             _logger.LogError(ex, "Could not reopen the audio output after a device change");
 
             return (false,
-                $"Saved, but the audio output could not be reopened ({ex.Message}), so this device is used " +
+                "Saved, but the audio output could not be reopened, so this device is used " +
                 "the next time the application starts.");
         }
     }

--- a/tests/EDButtkicker.Tests/ApiErrorSanitizationTests.cs
+++ b/tests/EDButtkicker.Tests/ApiErrorSanitizationTests.cs
@@ -1,0 +1,233 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using EDButtkicker.Controllers;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Everything an API writes is read by a browser page, so a failure body may carry a stable
+/// sentence and nothing else: no exception text, no stack frame, no local filesystem path. These
+/// drive real 4xx and 5xx responses through the same pipeline Program runs and read the raw JSON.
+/// Nothing here touches audio hardware or binds a port.
+/// </summary>
+public class ApiErrorSanitizationTests : IClassFixture<WebUiTestServerFixture>
+{
+    /// <summary>Fragments of the exception text .NET produces for the failures these tests force.</summary>
+    private static readonly string[] ExceptionGiveaways =
+    {
+        "Could not find file",
+        "Could not find a part of the path",
+        "UnauthorizedAccess",
+        "Access to the path",
+        "is denied",
+        "at EDButtkicker",
+        "System.IO.",
+        "Exception"
+    };
+
+    private readonly WebUiTestServerFixture _fixture;
+
+    public ApiErrorSanitizationTests(WebUiTestServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("../escape.json")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\win.ini")]
+    public async Task SavePattern_RejectedName_AnswersWithoutPathsOrExceptionText(string fileName)
+    {
+        var response = await _fixture.Client.PostAsync(
+            "/api/PatternEditor/save",
+            new StringContent(SaveRequestBody(fileName), Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertSanitized(await response.Content.ReadAsStringAsync());
+    }
+
+    [Theory]
+    [InlineData("..%2f..%2fetc%2fpasswd")]
+    [InlineData("%2e%2e%2fsecret.json")]
+    public async Task LoadPattern_RejectedName_AnswersWithoutPathsOrExceptionText(string fileName)
+    {
+        var response = await _fixture.Client.GetAsync($"/api/PatternEditor/load/{fileName}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertSanitized(await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task LoadPattern_ForAFileThatIsNotThere_SaysSoWithoutTheSearchedPaths()
+    {
+        var response = await _fixture.Client.GetAsync("/api/PatternEditor/load/edbk-sanitize-missing.json");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        AssertSanitized(body);
+        // The name the caller asked for is theirs already; the directories searched are not.
+        Assert.Contains("edbk-sanitize-missing.json", body);
+    }
+
+    [Fact]
+    public async Task JournalReplay_ForAFileOutsideTheJournalFolder_AnswersWithoutPathsOrExceptionText()
+    {
+        var response = await _fixture.Client.PostAsync(
+            "/api/journal/replay/start",
+            new StringContent("""{"journalFile":"../../etc/passwd"}""", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertSanitized(await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task SetupJournalFolder_ThatDoesNotExist_DoesNotEchoTheAbsolutePathBack()
+    {
+        var missingFolder = Path.Combine(Path.GetTempPath(), $"edbk-sanitize-{Guid.NewGuid():N}");
+        var body = JsonSerializer.Serialize(new { path = missingFolder });
+
+        var response = await _fixture.Client.PostAsync(
+            "/api/setup/journal", new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(missingFolder, payload);
+        Assert.DoesNotContain(JsonEncode(missingFolder), payload);
+        AssertSanitized(payload);
+    }
+
+    [Fact]
+    public async Task SavePattern_ThatCannotBeWritten_ReportsAStableFailure()
+    {
+        // A directory standing where the file has to go makes the write throw an exception whose
+        // own message carries the absolute path. Nothing of it may reach the response.
+        var fileName = $"edbk-sanitize-{Guid.NewGuid():N}.json";
+        var blockingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "patterns", "Custom", fileName);
+        Directory.CreateDirectory(blockingDirectory);
+
+        try
+        {
+            var response = await _fixture.Client.PostAsync(
+                "/api/PatternEditor/save",
+                new StringContent(SaveRequestBody(fileName), Encoding.UTF8, "application/json"));
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            AssertSanitized(body);
+            Assert.Contains("Failed to save pattern file", body);
+        }
+        finally
+        {
+            Directory.Delete(blockingDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SavePattern_OnSuccess_ReportsTheFileRelativeToThePatternsRoot()
+    {
+        var fileName = $"edbk-sanitize-{Guid.NewGuid():N}.json";
+        var savedPath = Path.Combine(Directory.GetCurrentDirectory(), "patterns", "Custom", fileName);
+
+        try
+        {
+            var response = await _fixture.Client.PostAsync(
+                "/api/PatternEditor/save",
+                new StringContent(SaveRequestBody(fileName), Encoding.UTF8, "application/json"));
+
+            Assert.True(response.IsSuccessStatusCode, $"save returned {(int)response.StatusCode}");
+
+            var body = await response.Content.ReadAsStringAsync();
+            AssertSanitized(body);
+
+            using var document = JsonDocument.Parse(body);
+            var reported = document.RootElement.GetProperty("filePath").GetString();
+
+            Assert.False(Path.IsPathRooted(reported));
+            Assert.Equal(Path.Combine("Custom", fileName), reported);
+            Assert.Equal(fileName, document.RootElement.GetProperty("fileName").GetString());
+        }
+        finally
+        {
+            if (File.Exists(savedPath))
+            {
+                File.Delete(savedPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PatternPackList_NamesFilesRelativeToThePatternsRoot()
+    {
+        var response = await _fixture.Client.GetAsync("/api/PatternFiles/packs");
+
+        Assert.True(response.IsSuccessStatusCode, $"packs returned {(int)response.StatusCode}");
+        AssertSanitized(await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ApiError_SerializesTheGivenSentenceAndNothingElse()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        await ApiError.WriteAsync(context, 500, "Failed to save pattern file");
+
+        context.Response.Body.Position = 0;
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+
+        Assert.Equal(500, context.Response.StatusCode);
+        Assert.Equal("application/json", context.Response.ContentType);
+        Assert.Equal("""{"error":"Failed to save pattern file"}""", body);
+    }
+
+    [Fact]
+    public void ApiError_PayloadCarriesOnlyTheErrorField()
+    {
+        var json = JsonSerializer.Serialize(ApiError.Payload("Failed to load pattern file"));
+
+        Assert.Equal("""{"error":"Failed to load pattern file"}""", json);
+    }
+
+    /// <summary>
+    /// A response body may not name where anything lives on this machine, and may not repeat what
+    /// an exception said. The working directory is the pattern root's parent, so it stands in for
+    /// every absolute path the pattern APIs could otherwise disclose.
+    /// </summary>
+    private static void AssertSanitized(string body)
+    {
+        var cwd = Directory.GetCurrentDirectory();
+
+        Assert.DoesNotContain(cwd, body);
+        Assert.DoesNotContain(JsonEncode(cwd), body);
+        Assert.DoesNotContain("/home/", body);
+        Assert.DoesNotContain("/etc/", body);
+        Assert.DoesNotContain(@"C:\", body);
+        Assert.DoesNotContain(@"C:\\", body);
+
+        foreach (var giveaway in ExceptionGiveaways)
+        {
+            Assert.DoesNotContain(giveaway, body, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>How the value would look once serialized: on Windows every separator is escaped.</summary>
+    private static string JsonEncode(string value) =>
+        JsonSerializer.Serialize(value).Trim('"');
+
+    private static string SaveRequestBody(string fileName) => $$"""
+    {
+      "fileName": {{JsonSerializer.Serialize(fileName)}},
+      "saveToCustom": true,
+      "patternFile": {
+        "metadata": { "name": "Sanitize Test", "version": "1.0.0", "author": "Tester", "description": "d", "tags": [], "created": "2026-01-01T00:00:00Z", "compatibility": "1.0.0" },
+        "ships": { "sidewinder": { "displayName": "Sidewinder", "class": "small", "role": "combat", "events": {} } }
+      }
+    }
+    """;
+}


### PR DESCRIPTION
## Summary
API controllers no longer return `ex.Message` or absolute filesystem paths. Failures use a stable public `{ error }` sentence; the exception stays in the local log.

- Shared `ApiError` helper for raw HttpContext handlers
- Pattern save reports a path relative to the patterns root
- Settings/setup responses no longer echo `user-settings.json` location
- Integration tests assert 4xx/5xx bodies have no exception text or absolute paths

Closes #19

## Test Plan
- [x] `dotnet test` on Linux: 514 passed (unrelated flake `EventRateLimiterTests.ConcurrentBurst_AcceptsExactlyOneEventPerWindow` excluded)
- [ ] WASAPI / Buttkicker playback not claimed from this host
