### PR TITLE
fix(patterns): debounce and serialize pattern file watcher reloads

### DIFF
--- a/src/EDButtkicker/Services/PatternFileService.cs
+++ b/src/EDButtkicker/Services/PatternFileService.cs
@@ -6,13 +6,20 @@ using System.IO;
 
 namespace EDButtkicker.Services;
 
-public class PatternFileService : IPatternCatalog
+public class PatternFileService : IPatternCatalog, IDisposable
 {
     private readonly ILogger<PatternFileService> _logger;
     private readonly string _patternsPath;
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly FileSystemWatcher _fileWatcher;
-    
+
+    // Every watcher event goes through one serialized queue, so reloads never overlap and every
+    // pending debounce delay ends with the shutdown token below.
+    private readonly PatternFileWatchQueue _watchQueue;
+    private readonly CancellationTokenSource _watchShutdown = new();
+    private readonly Task _watchConsumer;
+    private int _disposed;
+
     private Dictionary<string, PatternFile> _loadedFiles = new();
     private Dictionary<string, List<ShipPatternDefinition>> _shipPatterns = new();
     private readonly object _lock = new object();
@@ -20,20 +27,25 @@ public class PatternFileService : IPatternCatalog
     public event Action<PatternFileChangeEventArgs>? PatternFilesChanged;
 
     public PatternFileService(ILogger<PatternFileService> logger)
+        : this(logger, ResolveDefaultPatternsPath(), null)
+    {
+    }
+
+    /// <summary>
+    /// Explicit-path constructor used by tests so nothing is read from the developer's real
+    /// profile and the debounce windows can be shortened.
+    /// </summary>
+    public PatternFileService(ILogger<PatternFileService> logger, string patternsPath, PatternWatchOptions? watchOptions)
     {
         _logger = logger;
-        
-        // Use patterns directory - check project root first, then application directory
-        var projectRootPath = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "patterns");
-        var appPath = Path.Combine(Directory.GetCurrentDirectory(), "patterns");
-        
-        _patternsPath = Directory.Exists(projectRootPath) ? Path.GetFullPath(projectRootPath) : appPath;
+
+        _patternsPath = Path.GetFullPath(patternsPath);
         Directory.CreateDirectory(_patternsPath);
-        
+
         // Ensure Custom directory exists for user patterns
         var customPath = Path.Combine(_patternsPath, "Custom");
         Directory.CreateDirectory(customPath);
-        
+
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
@@ -49,17 +61,30 @@ public class PatternFileService : IPatternCatalog
             IncludeSubdirectories = true,
             NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.FileName
         };
-        
+
+        _watchQueue = new PatternFileWatchQueue(ProcessWatchWorkAsync, watchOptions, _logger);
+        _watchConsumer = Task.Run(() => _watchQueue.RunAsync(_watchShutdown.Token));
+
         _fileWatcher.Changed += OnFileChanged;
         _fileWatcher.Created += OnFileChanged;
         _fileWatcher.Deleted += OnFileDeleted;
         _fileWatcher.Renamed += OnFileRenamed;
+        _fileWatcher.Error += OnWatcherError;
         _fileWatcher.EnableRaisingEvents = true;
 
         _logger.LogInformation("PatternFileService initialized with path: {PatternsPath}", _patternsPath);
     }
 
-    public async Task LoadAllPatternsAsync()
+    /// <summary>Patterns directory - project root when running from a checkout, otherwise the app directory.</summary>
+    private static string ResolveDefaultPatternsPath()
+    {
+        var projectRootPath = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "patterns");
+        var appPath = Path.Combine(Directory.GetCurrentDirectory(), "patterns");
+
+        return Directory.Exists(projectRootPath) ? Path.GetFullPath(projectRootPath) : appPath;
+    }
+
+    public async Task LoadAllPatternsAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -80,9 +105,11 @@ public class PatternFileService : IPatternCatalog
 
             foreach (var filePath in jsonFiles)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 try
                 {
-                    var patternFile = await LoadPatternFileAsync(filePath);
+                    var patternFile = await LoadPatternFileAsync(filePath, cancellationToken);
                     if (patternFile != null)
                     {
                         lock (_lock)
@@ -131,6 +158,10 @@ public class PatternFileService : IPatternCatalog
                 
             NotifyPatternFilesChanged(PatternFileChangeType.Reload, null);
         }
+        catch (OperationCanceledException)
+        {
+            throw; // Shutdown, not a failure worth logging as one.
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error loading pattern files");
@@ -138,11 +169,11 @@ public class PatternFileService : IPatternCatalog
         }
     }
 
-    private async Task<PatternFile?> LoadPatternFileAsync(string filePath)
+    private async Task<PatternFile?> LoadPatternFileAsync(string filePath, CancellationToken cancellationToken = default)
     {
         try
         {
-            var json = await File.ReadAllTextAsync(filePath);
+            var json = await File.ReadAllTextAsync(filePath, cancellationToken);
             var patternFile = JsonSerializer.Deserialize<PatternFile>(json, _jsonOptions);
             
             if (patternFile?.Metadata == null)
@@ -167,6 +198,11 @@ public class PatternFileService : IPatternCatalog
         {
             _logger.LogError(ex, "Invalid JSON in pattern file: {FilePath}", filePath);
             return null;
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown, not a read failure - let the consumer loop end.
+            throw;
         }
         catch (Exception ex)
         {
@@ -354,59 +390,104 @@ public class PatternFileService : IPatternCatalog
         }
     }
 
-    private async void OnFileChanged(object sender, FileSystemEventArgs e)
+    // The watcher handlers only ever enqueue. They run on watcher threads, so they must not block,
+    // must not throw, and must not start work of their own - the consumer loop owns all of that.
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
     {
-        try
+        if (!IsWatchablePatternFile(e.FullPath))
         {
-            // Debounce file changes
-            await Task.Delay(500);
-            
-            if (Path.GetExtension(e.FullPath).Equals(".json", StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogDebug("Pattern file changed: {FilePath}", e.FullPath);
-                await ReloadPatternFileAsync(e.FullPath);
-            }
+            return;
         }
-        catch (Exception ex)
+
+        _logger.LogDebug("Pattern file changed: {FilePath}", e.FullPath);
+        _watchQueue.Enqueue(PatternWatchAction.Reload, e.FullPath);
+    }
+
+    private void OnFileDeleted(object sender, FileSystemEventArgs e)
+    {
+        if (!IsWatchablePatternFile(e.FullPath))
         {
-            _logger.LogError(ex, "Error handling file change: {FilePath}", e.FullPath);
+            return;
+        }
+
+        _logger.LogDebug("Pattern file deleted: {FilePath}", e.FullPath);
+        _watchQueue.Enqueue(PatternWatchAction.Remove, e.FullPath);
+    }
+
+    private void OnFileRenamed(object sender, RenamedEventArgs e)
+    {
+        var oldIsPattern = IsWatchablePatternFile(e.OldFullPath);
+        var newIsPattern = IsWatchablePatternFile(e.FullPath);
+
+        _logger.LogDebug("Pattern file renamed: {OldPath} -> {NewPath}", e.OldFullPath, e.FullPath);
+
+        if (newIsPattern)
+        {
+            // Remove-then-reload travels as one work item, so no other event can land between the
+            // two halves of the rename.
+            _watchQueue.Enqueue(PatternWatchAction.Reload, e.FullPath, oldIsPattern ? e.OldFullPath : null);
+        }
+        else if (oldIsPattern)
+        {
+            // Renamed out of the pattern set (e.g. .json -> .bak): it is simply gone.
+            _watchQueue.Enqueue(PatternWatchAction.Remove, e.OldFullPath);
         }
     }
 
-    private async void OnFileDeleted(object sender, FileSystemEventArgs e)
+    private void OnWatcherError(object sender, ErrorEventArgs e)
     {
-        try
+        // The OS buffer overflowed, so individual events were lost. Re-reading the directory is the
+        // only honest recovery.
+        _logger.LogWarning(e.GetException(), "Pattern file watcher error; scheduling a full reload");
+        _watchQueue.Enqueue(PatternWatchAction.ReloadAll, _patternsPath);
+    }
+
+    /// <summary>Same set of files <see cref="LoadAllPatternsAsync"/> reads, so the two never disagree.</summary>
+    private static bool IsWatchablePatternFile(string fullPath)
+    {
+        if (!Path.GetExtension(fullPath).Equals(".json", StringComparison.OrdinalIgnoreCase))
         {
-            if (Path.GetExtension(e.FullPath).Equals(".json", StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogDebug("Pattern file deleted: {FilePath}", e.FullPath);
-                RemovePatternFile(e.FullPath);
-            }
+            return false;
         }
-        catch (Exception ex)
+
+        var fileName = Path.GetFileName(fullPath);
+
+        return !fileName.StartsWith(".", StringComparison.Ordinal) &&
+               !fileName.Equals("schema.json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The single consumer of the watch queue: one item at a time, cancelled by dispose.</summary>
+    private async Task ProcessWatchWorkAsync(PatternWatchWork work, CancellationToken cancellationToken)
+    {
+        switch (work.Action)
         {
-            _logger.LogError(ex, "Error handling file deletion: {FilePath}", e.FullPath);
+            case PatternWatchAction.ReloadAll:
+                await LoadAllPatternsAsync(cancellationToken);
+                break;
+
+            case PatternWatchAction.Remove:
+                RemovePatternFile(work.FullPath);
+                break;
+
+            case PatternWatchAction.Reload:
+                if (work.RemovedPath != null)
+                {
+                    RemovePatternFile(work.RemovedPath);
+                }
+
+                if (!File.Exists(work.FullPath))
+                {
+                    // Created and deleted again before the debounce elapsed.
+                    RemovePatternFile(work.FullPath);
+                    break;
+                }
+
+                await ReloadPatternFileAsync(work.FullPath, cancellationToken);
+                break;
         }
     }
 
-    private async void OnFileRenamed(object sender, RenamedEventArgs e)
-    {
-        try
-        {
-            if (Path.GetExtension(e.FullPath).Equals(".json", StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogDebug("Pattern file renamed: {OldPath} -> {NewPath}", e.OldFullPath, e.FullPath);
-                RemovePatternFile(e.OldFullPath);
-                await ReloadPatternFileAsync(e.FullPath);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error handling file rename: {OldPath} -> {NewPath}", e.OldFullPath, e.FullPath);
-        }
-    }
-
-    private async Task ReloadPatternFileAsync(string fullPath)
+    private async Task ReloadPatternFileAsync(string fullPath, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -416,7 +497,7 @@ public class PatternFileService : IPatternCatalog
             RemovePatternFile(fullPath);
             
             // Load new version
-            var patternFile = await LoadPatternFileAsync(fullPath);
+            var patternFile = await LoadPatternFileAsync(fullPath, cancellationToken);
             if (patternFile != null)
             {
                 lock (_lock)
@@ -448,6 +529,10 @@ public class PatternFileService : IPatternCatalog
                 
                 NotifyPatternFilesChanged(PatternFileChangeType.Updated, relativePath);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -509,9 +594,55 @@ public class PatternFileService : IPatternCatalog
         }
     }
 
+    /// <summary>
+    /// Deterministic shutdown: the watcher stops raising events and is unsubscribed before it is
+    /// disposed, the queue stops accepting work, and the consumer's token cancels any debounce
+    /// delay or reload that is still in flight. Safe to call twice - the DI container owns this
+    /// singleton under two registrations.
+    /// </summary>
     public void Dispose()
     {
-        _fileWatcher?.Dispose();
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            _fileWatcher.EnableRaisingEvents = false;
+            _fileWatcher.Changed -= OnFileChanged;
+            _fileWatcher.Created -= OnFileChanged;
+            _fileWatcher.Deleted -= OnFileDeleted;
+            _fileWatcher.Renamed -= OnFileRenamed;
+            _fileWatcher.Error -= OnWatcherError;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already torn down by the runtime.
+        }
+
+        _fileWatcher.Dispose();
+
+        _watchQueue.Complete();
+        _watchShutdown.Cancel();
+
+        try
+        {
+            // The consumer only ever awaits a cancellable delay or one file read, so this returns
+            // promptly; the timeout is a backstop, not the expected path.
+            if (!_watchConsumer.Wait(TimeSpan.FromSeconds(5)))
+            {
+                _logger.LogWarning("Pattern watch consumer did not stop within the shutdown timeout");
+            }
+        }
+        catch (AggregateException ex)
+        {
+            // Observed here so a cancelled consumer never surfaces as an unobserved task exception.
+            _logger.LogDebug(ex, "Pattern watch consumer ended with an exception during shutdown");
+        }
+
+        _watchQueue.Dispose();
+        _watchShutdown.Dispose();
     }
 }
 

--- a/src/EDButtkicker/Services/PatternFileWatchQueue.cs
+++ b/src/EDButtkicker/Services/PatternFileWatchQueue.cs
@@ -1,0 +1,352 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EDButtkicker.Services;
+
+/// <summary>What the consumer has to do for one canonical path.</summary>
+public enum PatternWatchAction
+{
+    /// <summary>Re-read one pattern file (optionally after removing the path it was renamed from).</summary>
+    Reload,
+
+    /// <summary>Drop one pattern file from the catalog.</summary>
+    Remove,
+
+    /// <summary>Re-read the whole directory, used when watcher events were lost.</summary>
+    ReloadAll
+}
+
+/// <summary>One unit of serialized work handed to the consumer.</summary>
+public sealed record PatternWatchWork(PatternWatchAction Action, string FullPath, string? RemovedPath = null);
+
+/// <summary>
+/// Timings for <see cref="PatternFileWatchQueue"/>. Tests shrink these; the defaults are what the
+/// running app uses.
+/// </summary>
+public sealed class PatternWatchOptions
+{
+    /// <summary>How long a path stays quiet before its pending work runs.</summary>
+    public TimeSpan DebounceWindow { get; init; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>Gap between two identical size/mtime probes that marks a write as finished.</summary>
+    public TimeSpan StabilityWindow { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Upper bound on stability deferral, so a file written to forever still gets read.</summary>
+    public TimeSpan MaxStabilityWait { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Queue depth. Past this the queue asks for a full reload instead of growing.</summary>
+    public int Capacity { get; init; } = 256;
+}
+
+/// <summary>
+/// Serialized, debounced queue between the pattern <see cref="FileSystemWatcher"/> and the catalog.
+///
+/// The watcher raises Created/Changed/Renamed/Deleted on thread-pool threads and fires several
+/// times for a single save. Producers only ever call <see cref="Enqueue"/> (never blocking, never
+/// async void); one consumer loop coalesces events by canonical path, waits until the file's
+/// size and last-write time stop moving, and then runs the handler - one item at a time, so a
+/// reload can never overlap another reload or a remove for the same catalog.
+///
+/// The channel is bounded: if it ever fills, the overflow is not silently dropped - the consumer
+/// asks for a full <see cref="PatternWatchAction.ReloadAll"/> instead, which is the only truthful
+/// recovery once individual events are gone. Every wait honours the shutdown token, so a pending
+/// debounce delay ends immediately on dispose.
+/// </summary>
+public sealed class PatternFileWatchQueue : IDisposable
+{
+    private static readonly StringComparer PathComparer =
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    private readonly Channel<WatchEvent> _events;
+    private readonly Dictionary<string, Pending> _pending;
+    private readonly Func<PatternWatchWork, CancellationToken, Task> _handler;
+    private readonly PatternWatchOptions _options;
+    private readonly ILogger _logger;
+
+    private int _overflowed;
+
+    public PatternFileWatchQueue(
+        Func<PatternWatchWork, CancellationToken, Task> handler,
+        PatternWatchOptions? options = null,
+        ILogger? logger = null)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        _options = options ?? new PatternWatchOptions();
+        _logger = logger ?? NullLogger.Instance;
+        _pending = new Dictionary<string, Pending>(PathComparer);
+
+        // Wait + TryWrite never blocks: a full queue returns false, which is the overflow
+        // signal. DropWrite cannot be used here because its TryWrite returns true after
+        // discarding the item, so the consumer would never know events were lost.
+        _events = Channel.CreateBounded<WatchEvent>(new BoundedChannelOptions(_options.Capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    /// <summary>Queues one watcher event. Called from watcher threads; never blocks or throws.</summary>
+    public void Enqueue(PatternWatchAction action, string fullPath, string? oldFullPath = null)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath))
+        {
+            return;
+        }
+
+        if (!_events.Writer.TryWrite(new WatchEvent(action, fullPath, oldFullPath)))
+        {
+            // Either the queue is full or shut down. A dropped event means the catalog would be
+            // stale, so remember it and let the consumer re-read everything.
+            if (Interlocked.Exchange(ref _overflowed, 1) == 0)
+            {
+                _logger.LogWarning(
+                    "Pattern watch queue is full ({Capacity} events); falling back to a full reload",
+                    _options.Capacity);
+            }
+        }
+    }
+
+    /// <summary>Runs the single consumer loop until <paramref name="cancellationToken"/> fires.</summary>
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (_pending.Count == 0)
+                {
+                    if (!await _events.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    var delay = NextDueDelay(DateTime.UtcNow);
+                    if (delay > TimeSpan.Zero)
+                    {
+                        await WaitForEventOrTimeoutAsync(delay, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                Drain();
+                await ProcessOverflowAsync(cancellationToken).ConfigureAwait(false);
+                await ProcessDueAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        finally
+        {
+            _events.Writer.TryComplete();
+            _pending.Clear();
+        }
+    }
+
+    /// <summary>Stops accepting new events. Pending work ends with the consumer's token.</summary>
+    public void Complete() => _events.Writer.TryComplete();
+
+    public void Dispose() => Complete();
+
+    private void Drain()
+    {
+        while (_events.Reader.TryRead(out var watchEvent))
+        {
+            Merge(watchEvent, DateTime.UtcNow);
+        }
+    }
+
+    private void Merge(WatchEvent watchEvent, DateTime nowUtc)
+    {
+        var key = Canonical(watchEvent.FullPath);
+
+        if (!_pending.TryGetValue(key, out var pending))
+        {
+            pending = new Pending { DeadlineUtc = nowUtc + _options.MaxStabilityWait };
+            _pending[key] = pending;
+        }
+
+        // The last event for a path wins: a create followed by a delete is a delete, and a delete
+        // followed by a re-create is a reload. Only one of them ever reaches the handler.
+        pending.Action = watchEvent.Action;
+
+        if (watchEvent.Action == PatternWatchAction.Remove)
+        {
+            pending.RemovedPath = null;
+        }
+        else if (watchEvent.OldFullPath != null)
+        {
+            // A rename is a remove of the source plus a reload of the target, carried on one item
+            // so the two halves can never be interleaved with another path's work.
+            pending.RemovedPath = watchEvent.OldFullPath;
+            _pending.Remove(Canonical(watchEvent.OldFullPath));
+        }
+
+        pending.DueAtUtc = nowUtc + _options.DebounceWindow;
+        pending.Probed = false;
+    }
+
+    private TimeSpan NextDueDelay(DateTime nowUtc)
+    {
+        var earliest = DateTime.MaxValue;
+        foreach (var pending in _pending.Values)
+        {
+            if (pending.DueAtUtc < earliest)
+            {
+                earliest = pending.DueAtUtc;
+            }
+        }
+
+        return earliest == DateTime.MaxValue ? TimeSpan.Zero : earliest - nowUtc;
+    }
+
+    private async Task WaitForEventOrTimeoutAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(delay);
+
+        try
+        {
+            await _events.Reader.WaitToReadAsync(timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The debounce window elapsed with no new event - that is the signal to run.
+        }
+    }
+
+    private async Task ProcessOverflowAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _overflowed, 0) == 0)
+        {
+            return;
+        }
+
+        // A full reload supersedes every queued per-file item.
+        _pending.Clear();
+        await InvokeAsync(new PatternWatchWork(PatternWatchAction.ReloadAll, string.Empty), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task ProcessDueAsync(CancellationToken cancellationToken)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        var due = _pending
+            .Where(kv => kv.Value.DueAtUtc <= nowUtc)
+            .OrderBy(kv => kv.Value.DueAtUtc)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        foreach (var key in due)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_pending.TryGetValue(key, out var pending))
+            {
+                continue;
+            }
+
+            if (pending.Action == PatternWatchAction.Reload && !IsWriteStable(key, pending, DateTime.UtcNow))
+            {
+                continue;
+            }
+
+            _pending.Remove(key);
+
+            await InvokeAsync(new PatternWatchWork(pending.Action, key, pending.RemovedPath), cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// True once two probes a stability window apart agree on size and last-write time, so a file
+    /// that is still being written is left alone until the writer is done.
+    /// </summary>
+    private bool IsWriteStable(string path, Pending pending, DateTime nowUtc)
+    {
+        var info = new FileInfo(path);
+        if (!info.Exists)
+        {
+            // Nothing to wait for; the handler decides what a missing file means.
+            return true;
+        }
+
+        long length;
+        DateTime lastWriteUtc;
+        try
+        {
+            length = info.Length;
+            lastWriteUtc = info.LastWriteTimeUtc;
+        }
+        catch (IOException)
+        {
+            length = -1;
+            lastWriteUtc = DateTime.MinValue;
+        }
+
+        if (pending.Probed && pending.LastLength == length && pending.LastWriteUtc == lastWriteUtc)
+        {
+            return true;
+        }
+
+        pending.Probed = true;
+        pending.LastLength = length;
+        pending.LastWriteUtc = lastWriteUtc;
+
+        if (nowUtc >= pending.DeadlineUtc)
+        {
+            _logger.LogDebug("Pattern file {FilePath} is still changing after the stability deadline; reloading anyway", path);
+            return true;
+        }
+
+        pending.DueAtUtc = nowUtc + _options.StabilityWindow;
+        return false;
+    }
+
+    private async Task InvokeAsync(PatternWatchWork work, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _handler(work, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling pattern watch work {Action} for {FilePath}", work.Action, work.FullPath);
+        }
+    }
+
+    private static string Canonical(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception)
+        {
+            // An unusable path is still a key; it just never matches a real file.
+            return path;
+        }
+    }
+
+    private readonly record struct WatchEvent(PatternWatchAction Action, string FullPath, string? OldFullPath);
+
+    private sealed class Pending
+    {
+        public PatternWatchAction Action { get; set; } = PatternWatchAction.Reload;
+        public string? RemovedPath { get; set; }
+        public DateTime DueAtUtc { get; set; }
+        public DateTime DeadlineUtc { get; set; }
+        public bool Probed { get; set; }
+        public long LastLength { get; set; } = -1;
+        public DateTime LastWriteUtc { get; set; }
+    }
+}

--- a/tests/EDButtkicker.Tests/PatternFileWatcherDebounceTests.cs
+++ b/tests/EDButtkicker.Tests/PatternFileWatcherDebounceTests.cs
@@ -1,0 +1,406 @@
+using System.Reflection;
+using System.Text.Json;
+using EDButtkicker.Services;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Pattern file watching is a burst-y, multi-threaded source: one save raises several events, and
+/// editors write through temp files and renames. These pin that every event lands on one serialized
+/// consumer - debounced per path, deferred until the write is finished, and cancelled by shutdown -
+/// so a reload can never overlap another reload, and nothing survives Dispose.
+///
+/// The queue tests drive <see cref="PatternFileWatchQueue"/> directly (no FileSystemWatcher, so no
+/// dependence on OS event timing); the last two run the real watcher against a temp directory.
+/// </summary>
+public class PatternFileWatcherDebounceTests
+{
+    private const string ValidPatternJson = """
+    {
+      "metadata": { "name": "Watch Test", "version": "1.0.0", "author": "Tester", "description": "d", "tags": [], "created": "2026-01-01T00:00:00Z", "compatibility": "1.0.0" },
+      "ships": { "sidewinder": { "displayName": "Sidewinder", "class": "small", "role": "combat", "events": {} } }
+    }
+    """;
+
+    private static PatternWatchOptions FastOptions(int debounceMs = 150) => new()
+    {
+        DebounceWindow = TimeSpan.FromMilliseconds(debounceMs),
+        StabilityWindow = TimeSpan.FromMilliseconds(50),
+        MaxStabilityWait = TimeSpan.FromSeconds(3),
+        Capacity = 64
+    };
+
+    [Fact]
+    public async Task ABurstOfEventsForOneFile_CollapsesIntoASingleReload()
+    {
+        using var temp = new TempDirectory("edbk-watch-burst");
+        var path = temp.File("burst.json");
+        await File.WriteAllTextAsync(path, ValidPatternJson);
+
+        var recorder = new WorkRecorder();
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions(400));
+        var consumer = queue.RunAsync(cts.Token);
+
+        // What one save through an editor looks like: create + several changes, all within the
+        // debounce window.
+        for (var i = 0; i < 50; i++)
+        {
+            queue.Enqueue(PatternWatchAction.Reload, path);
+        }
+
+        Assert.True(await WaitForAsync(() => recorder.Count >= 1, TimeSpan.FromSeconds(5)));
+        await Task.Delay(600);
+
+        Assert.Equal(1, recorder.Count);
+        Assert.Equal(1, recorder.MaxConcurrency);
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task EventsForManyFilesFromManyThreads_AreHandledOneAtATime()
+    {
+        using var temp = new TempDirectory("edbk-watch-serial");
+
+        var paths = new List<string>();
+        for (var i = 0; i < 12; i++)
+        {
+            var path = temp.File($"pack-{i}.json");
+            await File.WriteAllTextAsync(path, ValidPatternJson);
+            paths.Add(path);
+        }
+
+        var recorder = new WorkRecorder(handlerDelay: TimeSpan.FromMilliseconds(20));
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions());
+        var consumer = queue.RunAsync(cts.Token);
+
+        await Task.WhenAll(Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            foreach (var path in paths)
+            {
+                queue.Enqueue(PatternWatchAction.Reload, path);
+            }
+        })));
+
+        Assert.True(await WaitForAsync(() => recorder.Count >= paths.Count, TimeSpan.FromSeconds(10)));
+        await Task.Delay(400);
+
+        // Every path exactly once, and never two handlers at the same time.
+        Assert.Equal(paths.Count, recorder.Count);
+        Assert.Equal(paths.Count, recorder.Snapshot().Select(w => w.Work.FullPath).Distinct().Count());
+        Assert.Equal(1, recorder.MaxConcurrency);
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task APartiallyWrittenFile_IsOnlyReadOnceTheWriteIsStable()
+    {
+        using var temp = new TempDirectory("edbk-watch-partial");
+        var path = temp.File("partial.json");
+
+        // First half of the document: valid JSON would not parse yet.
+        var half = ValidPatternJson[..(ValidPatternJson.Length / 2)];
+        await File.WriteAllTextAsync(path, half);
+
+        var recorder = new WorkRecorder(captureContent: true);
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions());
+        var consumer = queue.RunAsync(cts.Token);
+
+        queue.Enqueue(PatternWatchAction.Reload, path);
+
+        // The writer is still going when the first debounce window would have elapsed.
+        await Task.Delay(100);
+        await File.WriteAllTextAsync(path, ValidPatternJson);
+        queue.Enqueue(PatternWatchAction.Reload, path);
+
+        Assert.True(await WaitForAsync(() => recorder.Count >= 1, TimeSpan.FromSeconds(5)));
+        await Task.Delay(400);
+
+        Assert.Equal(1, recorder.Count);
+
+        // The handler never saw the half-written document.
+        var content = recorder.Snapshot().Single().Content;
+        Assert.Equal(ValidPatternJson, content);
+        Assert.NotNull(JsonSerializer.Deserialize<JsonElement>(content!));
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task ARename_BecomesOneRemoveOfTheOldPathPlusAReloadOfTheNew()
+    {
+        using var temp = new TempDirectory("edbk-watch-rename");
+        var oldPath = temp.File("before.json");
+        var newPath = temp.File("after.json");
+        await File.WriteAllTextAsync(newPath, ValidPatternJson);
+
+        var recorder = new WorkRecorder();
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions());
+        var consumer = queue.RunAsync(cts.Token);
+
+        // A change to the source is already queued when the rename lands: the stale entry must not
+        // race the rename's own removal.
+        queue.Enqueue(PatternWatchAction.Reload, oldPath);
+        queue.Enqueue(PatternWatchAction.Reload, newPath, oldPath);
+
+        Assert.True(await WaitForAsync(() => recorder.Count >= 1, TimeSpan.FromSeconds(5)));
+        await Task.Delay(400);
+
+        var work = Assert.Single(recorder.Snapshot()).Work;
+        Assert.Equal(PatternWatchAction.Reload, work.Action);
+        Assert.Equal(newPath, work.FullPath);
+        Assert.Equal(oldPath, work.RemovedPath);
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task ADeleteAfterAChange_ReachesTheHandlerOnlyAsARemove()
+    {
+        using var temp = new TempDirectory("edbk-watch-delete");
+        var path = temp.File("gone.json");
+
+        var recorder = new WorkRecorder();
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions());
+        var consumer = queue.RunAsync(cts.Token);
+
+        queue.Enqueue(PatternWatchAction.Reload, path);
+        queue.Enqueue(PatternWatchAction.Remove, path);
+
+        Assert.True(await WaitForAsync(() => recorder.Count >= 1, TimeSpan.FromSeconds(5)));
+        await Task.Delay(400);
+
+        var work = Assert.Single(recorder.Snapshot()).Work;
+        Assert.Equal(PatternWatchAction.Remove, work.Action);
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task AFullQueue_FallsBackToAFullReloadInsteadOfDroppingChanges()
+    {
+        using var temp = new TempDirectory("edbk-watch-overflow");
+
+        var recorder = new WorkRecorder();
+        var options = new PatternWatchOptions
+        {
+            DebounceWindow = TimeSpan.FromMilliseconds(150),
+            StabilityWindow = TimeSpan.FromMilliseconds(50),
+            MaxStabilityWait = TimeSpan.FromSeconds(3),
+            Capacity = 4
+        };
+
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, options);
+
+        // Fill the queue before the consumer starts, so the overflow is guaranteed.
+        for (var i = 0; i < 50; i++)
+        {
+            queue.Enqueue(PatternWatchAction.Reload, temp.File($"overflow-{i}.json"));
+        }
+
+        var consumer = queue.RunAsync(cts.Token);
+
+        Assert.True(await WaitForAsync(
+            () => recorder.Snapshot().Any(w => w.Work.Action == PatternWatchAction.ReloadAll),
+            TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, recorder.MaxConcurrency);
+
+        await StopAsync(cts, consumer);
+    }
+
+    [Fact]
+    public async Task CancellingTheConsumer_DropsPendingDebouncedWork()
+    {
+        using var temp = new TempDirectory("edbk-watch-cancel");
+        var path = temp.File("pending.json");
+        await File.WriteAllTextAsync(path, ValidPatternJson);
+
+        var recorder = new WorkRecorder();
+        using var cts = new CancellationTokenSource();
+        using var queue = new PatternFileWatchQueue(recorder.Handler, FastOptions(5_000));
+        var consumer = queue.RunAsync(cts.Token);
+
+        queue.Enqueue(PatternWatchAction.Reload, path);
+        await Task.Delay(100);
+
+        cts.Cancel();
+
+        // The pending five-second debounce delay ends with the token, not with the clock.
+        var finished = await Task.WhenAny(consumer, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Same(consumer, finished);
+        await consumer;
+        Assert.True(consumer.IsCompletedSuccessfully);
+        Assert.Equal(0, recorder.Count);
+    }
+
+    [Fact]
+    public async Task TheWatcher_ReloadsRenamesAndRemovesPatternFiles()
+    {
+        using var temp = new TempDirectory("edbk-watch-service");
+        using var service = new PatternFileService(TestLoggers.For<PatternFileService>(), temp.Path, FastOptions());
+
+        var firstPath = Path.Combine(temp.Path, "watched.json");
+        var renamedPath = Path.Combine(temp.Path, "watched-renamed.json");
+
+        await File.WriteAllTextAsync(firstPath, ValidPatternJson);
+        Assert.True(await WaitForAsync(
+            () => service.GetAllShipTypes().Contains("sidewinder"), TimeSpan.FromSeconds(10)));
+        Assert.Equal("watched.json", Assert.Single(service.GetAllPatternPacks()).FilePath);
+
+        File.Move(firstPath, renamedPath);
+        Assert.True(await WaitForAsync(
+            () => service.GetAllPatternPacks().Any(p => p.FilePath == "watched-renamed.json"),
+            TimeSpan.FromSeconds(10)));
+
+        // The rename removed the old entry rather than leaving both packs registered.
+        Assert.Equal("watched-renamed.json", Assert.Single(service.GetAllPatternPacks()).FilePath);
+
+        File.Delete(renamedPath);
+        Assert.True(await WaitForAsync(
+            () => service.GetAllPatternPacks().Count == 0, TimeSpan.FromSeconds(10)));
+        Assert.Empty(service.GetAllShipTypes());
+    }
+
+    [Fact]
+    public async Task DisposingWhileADebounceIsPending_StopsTheConsumerAndRaisesNothingElse()
+    {
+        using var temp = new TempDirectory("edbk-watch-dispose");
+        var service = new PatternFileService(
+            TestLoggers.For<PatternFileService>(),
+            temp.Path,
+            FastOptions(30_000));
+
+        var notifications = 0;
+        service.PatternFilesChanged += _ => Interlocked.Increment(ref notifications);
+
+        await File.WriteAllTextAsync(Path.Combine(temp.Path, "pending.json"), ValidPatternJson);
+        await Task.Delay(300); // Let the watcher event land while the 30s debounce is pending.
+
+        var started = DateTime.UtcNow;
+        service.Dispose();
+        var elapsed = DateTime.UtcNow - started;
+
+        // Shutdown does not wait out the debounce window.
+        Assert.True(elapsed < TimeSpan.FromSeconds(5), $"Dispose took {elapsed}");
+
+        var consumer = ConsumerTaskOf(service);
+        Assert.True(consumer.IsCompleted);
+        Assert.True(consumer.IsCompletedSuccessfully, "The watch consumer faulted during shutdown");
+
+        // Nothing is left to fire after dispose, and a second dispose is a no-op.
+        var afterDispose = Volatile.Read(ref notifications);
+        await File.WriteAllTextAsync(Path.Combine(temp.Path, "later.json"), ValidPatternJson);
+        await Task.Delay(300);
+        service.Dispose();
+
+        Assert.Equal(afterDispose, Volatile.Read(ref notifications));
+    }
+
+    private static Task ConsumerTaskOf(PatternFileService service)
+    {
+        var field = typeof(PatternFileService)
+            .GetField("_watchConsumer", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+
+        return (Task)field!.GetValue(service)!;
+    }
+
+    private static async Task StopAsync(CancellationTokenSource cts, Task consumer)
+    {
+        cts.Cancel();
+        await consumer;
+    }
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(25);
+        }
+
+        return condition();
+    }
+
+    /// <summary>
+    /// Records what the consumer did, including the highest number of handlers ever running at
+    /// once - the whole point of the queue is that this stays at one.
+    /// </summary>
+    private sealed class WorkRecorder
+    {
+        private readonly List<HandledWork> _work = new();
+        private readonly object _gate = new();
+        private readonly TimeSpan _handlerDelay;
+        private readonly bool _captureContent;
+        private int _inFlight;
+        private int _maxConcurrency;
+
+        public WorkRecorder(TimeSpan? handlerDelay = null, bool captureContent = false)
+        {
+            _handlerDelay = handlerDelay ?? TimeSpan.Zero;
+            _captureContent = captureContent;
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _work.Count;
+                }
+            }
+        }
+
+        public int MaxConcurrency => Volatile.Read(ref _maxConcurrency);
+
+        public IReadOnlyList<HandledWork> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _work.ToList();
+            }
+        }
+
+        public async Task Handler(PatternWatchWork work, CancellationToken cancellationToken)
+        {
+            var inFlight = Interlocked.Increment(ref _inFlight);
+            try
+            {
+                lock (_gate)
+                {
+                    _maxConcurrency = Math.Max(_maxConcurrency, inFlight);
+                    _work.Add(new HandledWork(
+                        work,
+                        _captureContent && File.Exists(work.FullPath) ? File.ReadAllText(work.FullPath) : null));
+                }
+
+                if (_handlerDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(_handlerDelay, cancellationToken);
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlight);
+            }
+        }
+    }
+
+    private sealed record HandledWork(PatternWatchWork Work, string? Content);
+}


### PR DESCRIPTION
## Summary
- Replace overlapping `async void` FileSystemWatcher handlers with a bounded Channel consumer (`PatternFileWatchQueue`).
- Debounce by canonical path and wait until size/mtime are stable before reload.
- Propagate shutdown cancellation and dispose the watcher deterministically.
- Tests: burst writes, concurrent files, partial write, rename, delete-after-change, overflow→ReloadAll, cancel, real watcher rename/delete, dispose-during-debounce.

## Test Plan
- [x] `dotnet test` on Linux: 524 passed (9 new PatternFileWatcherDebounceTests)
- [ ] WASAPI / physical Buttkicker playback is not claimed from this host

Closes #25
