### PR TITLE
fix(journal): cancel replay off the request thread and honor timestamps

### DIFF
--- a/src/EDButtkicker/Controllers/JournalApiController.cs
+++ b/src/EDButtkicker/Controllers/JournalApiController.cs
@@ -16,29 +16,24 @@ public class JournalApiController
     private readonly ILogger<JournalApiController> _logger;
     private readonly AppSettings _settings;
     private readonly IJournalEventStore _eventStore;
-    private readonly IJournalEventPipeline _pipeline;
     private readonly JournalMonitorStatus _monitorStatus;
     private readonly SettingsPersistenceService _settingsPersistence;
-
-    // Replay functionality
-    private CancellationTokenSource? _replayTokenSource;
-    private Task? _replayTask;
-    private readonly object ReplayLock = new object();
+    private readonly JournalReplayService _replay;
 
     public JournalApiController(
         ILogger<JournalApiController> logger,
         AppSettings settings,
         IJournalEventStore eventStore,
-        IJournalEventPipeline pipeline,
         JournalMonitorStatus monitorStatus,
-        SettingsPersistenceService settingsPersistence)
+        SettingsPersistenceService settingsPersistence,
+        JournalReplayService replay)
     {
         _logger = logger;
         _settings = settings;
         _eventStore = eventStore;
-        _pipeline = pipeline;
         _monitorStatus = monitorStatus;
         _settingsPersistence = settingsPersistence;
+        _replay = replay;
     }
 
     public async Task GetJournalStatus(HttpContext context)
@@ -283,6 +278,7 @@ public class JournalApiController
             }
 
             string? selectedJournalFile = null;
+            var speed = JournalReplayService.DefaultSpeed;
             if (json.Length > 0)
             {
                 if (!BoundedRequestReader.TryDeserialize<Dictionary<string, object>>(json, out var requestData))
@@ -296,6 +292,15 @@ public class JournalApiController
                 if (requestData != null && requestData.ContainsKey("journalFile"))
                 {
                     selectedJournalFile = requestData["journalFile"].ToString();
+                }
+
+                // Optional accelerator. Out-of-range values are clamped by the replay service
+                // rather than refused: the request is still a valid "replay this file".
+                if (requestData != null &&
+                    requestData.TryGetValue("speed", out var requestedSpeed) &&
+                    double.TryParse(requestedSpeed.ToString(), out var parsedSpeed))
+                {
+                    speed = parsedSpeed;
                 }
             }
 
@@ -339,29 +344,7 @@ public class JournalApiController
                 eventsToReplay = _eventStore.GetSince(cutoffTime).ToList();
             }
             
-            // Now handle replay start/stop in lock
-            lock (ReplayLock)
-            {
-                // Stop any existing replay
-                if (_replayTokenSource != null && !_replayTokenSource.Token.IsCancellationRequested)
-                {
-                    _replayTokenSource.Cancel();
-                    _replayTask?.Wait(TimeSpan.FromSeconds(2));
-                }
-
-                if (eventsToReplay.Any())
-                {
-                    // Start new replay
-                    _replayTokenSource = new CancellationTokenSource();
-                    _replayTask = Task.Run(async () => await ReplayEventsAsync(eventsToReplay, _replayTokenSource.Token));
-
-                    _logger.LogInformation("Started journal replay with {Count} events from {Source}",
-                        eventsToReplay.Count,
-                        sourceFile ?? "recent events");
-                }
-            }
-            
-            if (!eventsToReplay.Any())
+            if (eventsToReplay.Count == 0)
             {
                 context.Response.StatusCode = 404;
                 var errorMessage = sourceFile != null
@@ -371,13 +354,18 @@ public class JournalApiController
                 return;
             }
 
+            // Cancelling and draining any previous replay happens inside the service, on awaits:
+            // the request thread hands the run over and returns rather than waiting on it.
+            await _replay.StartAsync(eventsToReplay, speed, sourceFile, context.RequestAborted);
+
             context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new
+            {
                 success = true,
                 message = $"Journal replay started from {sourceFile ?? "recent events"}",
                 events_count = eventsToReplay.Count,
-                source = sourceFile ?? "recent_events"
+                source = sourceFile ?? "recent_events",
+                speed = _replay.GetStatus().Speed
             }));
         }
         catch (Exception ex)
@@ -391,14 +379,7 @@ public class JournalApiController
     {
         try
         {
-            lock (ReplayLock)
-            {
-                if (_replayTokenSource != null && !_replayTokenSource.Token.IsCancellationRequested)
-                {
-                    _replayTokenSource.Cancel();
-                    _logger.LogInformation("Stopped journal replay");
-                }
-            }
+            await _replay.StopAsync(context.RequestAborted);
 
             context.Response.ContentType = "application/json";
             await context.Response.WriteAsync(JsonSerializer.Serialize(new 
@@ -418,63 +399,24 @@ public class JournalApiController
     {
         try
         {
-            bool isReplaying = false;
-            int eventsCount = 0;
-
-            lock (ReplayLock)
-            {
-                isReplaying = _replayTokenSource != null && 
-                             !_replayTokenSource.Token.IsCancellationRequested &&
-                             _replayTask != null && 
-                             !_replayTask.IsCompleted;
-                eventsCount = GetEventsToReplayCount();
-            }
+            var replay = _replay.GetStatus();
 
             context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new 
-            { 
-                is_replaying = isReplaying,
-                events_available = eventsCount,
-                last_5_minutes_events = GetEventsInLast5Minutes()
+            await context.Response.WriteAsync(JsonSerializer.Serialize(new
+            {
+                is_replaying = replay.IsReplaying,
+                events_available = GetEventsToReplayCount(),
+                last_5_minutes_events = GetEventsInLast5Minutes(),
+                replay_source = replay.Source ?? "recent_events",
+                replay_events_total = replay.TotalEvents,
+                replay_events_replayed = replay.EventsReplayed,
+                replay_speed = replay.Speed
             }));
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting replay status");
             await ApiError.WriteAsync(context, 500, "Failed to read the replay status");
-        }
-    }
-
-    private async Task ReplayEventsAsync(List<JournalEvent> events, CancellationToken cancellationToken)
-    {
-        try
-        {
-            _logger.LogInformation("Starting replay of {Count} journal events", events.Count);
-            
-            foreach (var journalEvent in events)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                    break;
-
-                // Same ordered pipeline as live monitoring, minus the history write - these
-                // events are historical and (for the in-memory source) already in the store.
-                await _pipeline.ProcessAsync(journalEvent, skipHistory: true);
-                
-                _logger.LogDebug("Replayed event: {EventType} at {Timestamp}", journalEvent.Event, journalEvent.Timestamp);
-
-                // Add a small delay between events to make it more realistic
-                await Task.Delay(500, cancellationToken);
-            }
-            
-            _logger.LogInformation("Journal replay completed");
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogInformation("Journal replay was cancelled");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error during journal replay");
         }
     }
 

--- a/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
+++ b/src/EDButtkicker/Hosting/ServiceCollectionExtensions.cs
@@ -60,6 +60,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPatternCatalog>(sp => sp.GetRequiredService<PatternFileService>());
         services.AddSingleton<PatternSourceCatalogReconciler>();
         services.AddSingleton<IJournalEventPipeline, JournalEventPipeline>();
+
+        // Replay outlives the request that starts it, so its cancellation source, task and status
+        // live in one singleton the container disposes on shutdown - not in the controller.
+        services.AddSingleton<JournalReplayService>();
         // IntensityCurveProcessor is a static class, no need to register
         // AdvancedWaveformGenerator and MultiLayerPatternGenerator are created as needed
 

--- a/src/EDButtkicker/Services/JournalReplayService.cs
+++ b/src/EDButtkicker/Services/JournalReplayService.cs
@@ -1,0 +1,274 @@
+using EDButtkicker.Models;
+using Microsoft.Extensions.Logging;
+
+namespace EDButtkicker.Services;
+
+/// <summary>What the replay API reports about the run this process owns right now.</summary>
+public sealed record JournalReplayStatus(
+    bool IsReplaying,
+    int TotalEvents,
+    int EventsReplayed,
+    string? Source,
+    double Speed);
+
+/// <summary>
+/// Owns the lifetime of a journal replay: the cancellation source, the running task and the status
+/// the API reports. It lives here rather than in the controller because a replay outlives the
+/// request that started it - the request thread must be able to hand it over and return, and the
+/// next request must be able to cancel it without ever blocking on it.
+/// </summary>
+public sealed class JournalReplayService : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// The longest wait between two replayed events. Journals contain hours-long holes (the pilot
+    /// walked away); replaying those verbatim would look like a hung replay, so the gap is capped.
+    /// </summary>
+    public static readonly TimeSpan MaxGap = TimeSpan.FromSeconds(2);
+
+    /// <summary>Playback speed bounds: slower than a quarter or faster than 16x is not a replay.</summary>
+    public const double MinSpeed = 0.25;
+    public const double MaxSpeed = 16.0;
+    public const double DefaultSpeed = 1.0;
+
+    private readonly ILogger<JournalReplayService> _logger;
+    private readonly IJournalEventPipeline _pipeline;
+
+    /// <summary>
+    /// Serializes start/stop. It is an async gate, not a monitor, so the awaits inside - cancelling
+    /// and draining the previous run - never hold a thread, and a request can be aborted while it
+    /// waits its turn.
+    /// </summary>
+    private readonly SemaphoreSlim _lifecycle = new(1, 1);
+
+    /// <summary>Guards the fields below for the readers (status) that never take <see cref="_lifecycle"/>.</summary>
+    private readonly object _state = new();
+
+    private CancellationTokenSource? _cancellation;
+    private Task? _task;
+    private int _totalEvents;
+    private int _eventsReplayed;
+    private string? _source;
+    private double _speed = DefaultSpeed;
+    private volatile bool _disposed;
+
+    public JournalReplayService(ILogger<JournalReplayService> logger, IJournalEventPipeline pipeline)
+    {
+        _logger = logger;
+        _pipeline = pipeline;
+    }
+
+    /// <summary>
+    /// Cancels whatever is replaying, waits for it to unwind, and starts <paramref name="events"/>.
+    /// The previous run is fully drained before the new one is created, so no event from the old
+    /// run can reach the pipeline after this returns. Returns false when nothing was started.
+    /// </summary>
+    /// <param name="requestAborted">
+    /// The caller's cancellation - only aborts the wait for the gate, never the replay itself.
+    /// </param>
+    public async Task<bool> StartAsync(
+        IReadOnlyList<JournalEvent> events,
+        double speed = DefaultSpeed,
+        string? source = null,
+        CancellationToken requestAborted = default)
+    {
+        if (events.Count == 0)
+        {
+            return false;
+        }
+
+        speed = Math.Clamp(speed, MinSpeed, MaxSpeed);
+
+        await _lifecycle.WaitAsync(requestAborted).ConfigureAwait(false);
+        try
+        {
+            await CancelCurrentAsync().ConfigureAwait(false);
+
+            if (_disposed)
+            {
+                _logger.LogWarning("Journal replay was requested after shutdown had begun; not starting");
+                return false;
+            }
+
+            // Copy the caller's list: the replay outlives this call and must not see it mutate.
+            var snapshot = events.ToArray();
+            var cancellation = new CancellationTokenSource();
+            var token = cancellation.Token;
+
+            lock (_state)
+            {
+                _cancellation = cancellation;
+                _totalEvents = snapshot.Length;
+                _eventsReplayed = 0;
+                _source = source;
+                _speed = speed;
+                _task = Task.Run(() => RunAsync(snapshot, speed, token), CancellationToken.None);
+            }
+
+            _logger.LogInformation(
+                "Started journal replay of {Count} events from {Source} at {Speed}x",
+                snapshot.Length, source ?? "recent events", speed);
+
+            return true;
+        }
+        finally
+        {
+            _lifecycle.Release();
+        }
+    }
+
+    /// <summary>
+    /// Cancels the running replay and waits for it to finish. Safe to call when nothing is running,
+    /// and safe to call from a request thread: every wait here is an await.
+    /// </summary>
+    public async Task StopAsync(CancellationToken requestAborted = default)
+    {
+        await _lifecycle.WaitAsync(requestAborted).ConfigureAwait(false);
+        try
+        {
+            await CancelCurrentAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _lifecycle.Release();
+        }
+    }
+
+    public JournalReplayStatus GetStatus()
+    {
+        lock (_state)
+        {
+            var replaying = _task is { IsCompleted: false } && _cancellation is { IsCancellationRequested: false };
+
+            return new JournalReplayStatus(replaying, _totalEvents, Volatile.Read(ref _eventsReplayed), _source, _speed);
+        }
+    }
+
+    /// <summary>
+    /// The wait between two events: the source's own spacing, capped so one hole in the journal
+    /// cannot stall the replay, and divided by the playback speed.
+    /// </summary>
+    public static TimeSpan DelayBetween(DateTime current, DateTime next, double speed = DefaultSpeed)
+    {
+        var gap = next - current;
+
+        // Journals are written in order, but a clock change can still produce a backwards step.
+        if (gap <= TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        if (gap > MaxGap)
+        {
+            gap = MaxGap;
+        }
+
+        return gap / Math.Clamp(speed, MinSpeed, MaxSpeed);
+    }
+
+    /// <summary>
+    /// Takes the running replay out of the fields under a short lock, then cancels and awaits it
+    /// with no lock held - a replay that needs to touch this service while unwinding cannot deadlock
+    /// against its own canceller. Callers must hold <see cref="_lifecycle"/>.
+    /// </summary>
+    private async Task CancelCurrentAsync()
+    {
+        CancellationTokenSource? cancellation;
+        Task? task;
+
+        lock (_state)
+        {
+            cancellation = _cancellation;
+            task = _task;
+            _cancellation = null;
+            _task = null;
+        }
+
+        if (cancellation == null)
+        {
+            return;
+        }
+
+        cancellation.Cancel();
+
+        if (task != null)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: the run was cancelled between events or inside its delay.
+            }
+        }
+
+        cancellation.Dispose();
+
+        _logger.LogInformation("Journal replay stopped");
+    }
+
+    private async Task RunAsync(IReadOnlyList<JournalEvent> events, double speed, CancellationToken cancellationToken)
+    {
+        try
+        {
+            for (var i = 0; i < events.Count; i++)
+            {
+                // Checked before every event as well as inside the delay, so a cancel lands even
+                // when consecutive events carry the same timestamp and the delay is zero.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Same ordered pipeline as live monitoring, minus the history write - these
+                // events are historical and (for the in-memory source) already in the store.
+                await _pipeline.ProcessAsync(events[i], skipHistory: true).ConfigureAwait(false);
+                Interlocked.Increment(ref _eventsReplayed);
+
+                _logger.LogDebug("Replayed event: {EventType} at {Timestamp}", events[i].Event, events[i].Timestamp);
+
+                if (i + 1 < events.Count)
+                {
+                    var delay = DelayBetween(events[i].Timestamp, events[i + 1].Timestamp, speed);
+                    if (delay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            _logger.LogInformation("Journal replay completed after {Count} events", events.Count);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Journal replay was cancelled after {Count} events", Volatile.Read(ref _eventsReplayed));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during journal replay");
+        }
+    }
+
+    /// <summary>
+    /// Synchronous disposal only asks the replay to stop - it never blocks on it, because the
+    /// callers of this path (a service provider being torn down, a test fixture) may be on a thread
+    /// the replay itself needs.
+    /// </summary>
+    public void Dispose()
+    {
+        _disposed = true;
+
+        lock (_state)
+        {
+            _cancellation?.Cancel();
+        }
+    }
+
+    /// <summary>The shutdown path the host uses: cancel, then wait for the replay to unwind.</summary>
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+
+        await StopAsync().ConfigureAwait(false);
+
+        // The gate is deliberately not disposed: a start racing this shutdown would then fail with
+        // ObjectDisposedException instead of simply finding the service closed.
+    }
+}

--- a/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
+++ b/tests/EDButtkicker.Tests/JournalReplayPathTraversalTests.cs
@@ -32,7 +32,7 @@ public class JournalReplayPathTraversalTests
     [InlineData("Journal.2026-09-09T000000.01.log")]
     public async Task StartJournalReplay_WithAFileOutsideTheEnumeration_Returns400AndReplaysNothing(string journalFile)
     {
-        using var fixture = new ReplayFixture();
+        await using var fixture = new ReplayFixture();
 
         var response = await fixture.PostReplayStart(journalFile);
 
@@ -44,7 +44,7 @@ public class JournalReplayPathTraversalTests
     [Fact]
     public async Task StartJournalReplay_WithARootedPathToTheSecret_Returns400AndReplaysNothing()
     {
-        using var fixture = new ReplayFixture();
+        await using var fixture = new ReplayFixture();
 
         var response = await fixture.PostReplayStart(fixture.SecretPath);
 
@@ -55,7 +55,7 @@ public class JournalReplayPathTraversalTests
     [Fact]
     public async Task StartJournalReplay_WithAnEnumeratedJournalFile_IsAccepted()
     {
-        using var fixture = new ReplayFixture();
+        await using var fixture = new ReplayFixture();
 
         var response = await fixture.PostReplayStart(LegitJournalName);
 
@@ -72,7 +72,7 @@ public class JournalReplayPathTraversalTests
     [Fact]
     public async Task StartJournalReplay_WithoutAJournalFile_StillFallsBackToRecentEvents()
     {
-        using var fixture = new ReplayFixture();
+        await using var fixture = new ReplayFixture();
         fixture.EventStore.Add(new JournalEvent
         {
             Timestamp = DateTime.UtcNow,
@@ -90,13 +90,36 @@ public class JournalReplayPathTraversalTests
         await fixture.StopReplay();
     }
 
+    /// <summary>
+    /// The restart path over the controller. Starting again used to block the request thread on the
+    /// previous replay task while holding that replay's lock, so this asserts on the clock: both
+    /// requests, and the stop, return well inside the old two second wait.
+    /// </summary>
+    [Fact]
+    public async Task StartJournalReplay_WhileAReplayIsRunning_RestartsWithoutBlockingTheRequest()
+    {
+        await using var fixture = new ReplayFixture();
+
+        var first = await fixture.PostReplayStart(LegitJournalName).WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(200, first.StatusCode);
+
+        // The journal's two events are 30 seconds apart, so the first replay is still sitting in
+        // its capped gap when the second request arrives.
+        var second = await fixture.PostReplayStart(LegitJournalName).WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(200, second.StatusCode);
+
+        await fixture.StopReplay().WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.False(fixture.Replay.GetStatus().IsReplaying);
+    }
+
     private sealed record ReplayResponse(int StatusCode, string Body);
 
     /// <summary>
     /// A temp journal folder holding one legitimate journal file, and a secret file in the parent
     /// folder that no request may reach. The controller is the real one, wired to fakes.
     /// </summary>
-    private sealed class ReplayFixture : IDisposable
+    private sealed class ReplayFixture : IAsyncDisposable
     {
         private readonly TempDirectory _root = new("edbk-journal-replay");
 
@@ -130,13 +153,15 @@ public class JournalReplayPathTraversalTests
                 new AudioEngineService(NullLogger<AudioEngineService>.Instance, Settings),
                 new JournalMonitorStatus(TimeProvider.System));
 
+            Replay = new JournalReplayService(NullLogger<JournalReplayService>.Instance, Pipeline);
+
             Controller = new JournalApiController(
                 NullLogger<JournalApiController>.Instance,
                 Settings,
                 EventStore,
-                Pipeline,
                 new JournalMonitorStatus(TimeProvider.System),
-                persistence);
+                persistence,
+                Replay);
         }
 
         public string JournalDirectory { get; }
@@ -148,6 +173,8 @@ public class JournalReplayPathTraversalTests
         public JournalEventStore EventStore { get; } = new();
 
         public RecordingJournalPipeline Pipeline { get; } = new();
+
+        public JournalReplayService Replay { get; }
 
         public JournalApiController Controller { get; }
 
@@ -192,7 +219,15 @@ public class JournalReplayPathTraversalTests
             Assert.Empty(Pipeline.Processed);
         }
 
-        public void Dispose() => _root.Dispose();
+        /// <summary>
+        /// Teardown drains the replay instead of only cancelling it, so no run is still handing
+        /// events to the pipeline while the next test's temp folder is being built.
+        /// </summary>
+        public async ValueTask DisposeAsync()
+        {
+            await Replay.DisposeAsync();
+            _root.Dispose();
+        }
 
         private static string JournalLine(DateTime timestamp, string eventName, string starSystem) =>
             JsonSerializer.Serialize(new Dictionary<string, object>

--- a/tests/EDButtkicker.Tests/JournalReplayServiceTests.cs
+++ b/tests/EDButtkicker.Tests/JournalReplayServiceTests.cs
@@ -1,0 +1,178 @@
+using EDButtkicker.Models;
+using EDButtkicker.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Replay used to be cancelled by blocking on the replay task while holding the lock the replay
+/// itself needed, and it handed every event over on a fixed 500 ms tick. These pin the two things
+/// that had to change: cancel/restart/shutdown never wait on a thread, and the spacing between
+/// events comes from the journal's own timestamps - capped, so one hole cannot stall a replay.
+/// </summary>
+public class JournalReplayServiceTests
+{
+    /// <summary>Every wait here is a race guard, not a sleep: a hang fails the test instead of it.</summary>
+    private static readonly TimeSpan NoHang = TimeSpan.FromSeconds(2);
+
+    [Fact]
+    public async Task StopAsync_DuringAReplay_StopsFeedingThePipeline()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        Assert.True(await service.StartAsync(Events("A", 6, TimeSpan.FromSeconds(2))));
+        await SetupTestExtensions.WaitForAsync(() => pipeline.Processed.Count > 0, "the replay to start");
+
+        await service.StopAsync().WaitAsync(NoHang);
+
+        var processedAtStop = pipeline.Processed.Count;
+        Assert.InRange(processedAtStop, 1, 5);
+        Assert.False(service.GetStatus().IsReplaying);
+
+        // Well past the capped gap the cancelled run was sitting in.
+        await Task.Delay(200);
+
+        Assert.Equal(processedAtStop, pipeline.Processed.Count);
+    }
+
+    [Fact]
+    public async Task StopAsync_WithNothingReplaying_Returns()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        await service.StopAsync().WaitAsync(NoHang);
+
+        Assert.False(service.GetStatus().IsReplaying);
+        Assert.Empty(pipeline.Processed);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhileAReplayIsRunning_CancelsTheOldRunBeforeTheNewOneBegins()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        await service.StartAsync(Events("Old", 10, TimeSpan.FromSeconds(2)));
+        await SetupTestExtensions.WaitForAsync(
+            () => pipeline.Processed.Count > 0, "the first replay to start");
+
+        // The restart drains the previous run rather than blocking on it: a hang here is the
+        // deadlock this service exists to rule out.
+        await service.StartAsync(Events("New", 3, TimeSpan.Zero), source: "new.log").WaitAsync(NoHang);
+
+        await SetupTestExtensions.WaitForAsync(
+            () => pipeline.Processed.Count(e => e.Event.StartsWith("New")) == 3, "the second replay to finish");
+
+        var processed = pipeline.Processed.ToList();
+        var firstNew = processed.FindIndex(e => e.Event.StartsWith("New"));
+
+        Assert.Contains(processed, e => e.Event.StartsWith("Old"));
+        // Nothing from the cancelled run reached the pipeline once the new run had started.
+        Assert.All(processed.Skip(firstNew), e => Assert.StartsWith("New", e.Event));
+        Assert.Equal("new.log", service.GetStatus().Source);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WhileAReplayIsInFlight_Completes()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        var service = NewService(pipeline);
+
+        await service.StartAsync(Events("A", 10, TimeSpan.FromSeconds(2)));
+        await SetupTestExtensions.WaitForAsync(() => pipeline.Processed.Count > 0, "the replay to start");
+
+        await service.DisposeAsync().AsTask().WaitAsync(NoHang);
+
+        Assert.False(service.GetStatus().IsReplaying);
+    }
+
+    [Fact]
+    public async Task StartAsync_AfterDisposal_DoesNotReplay()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        var service = NewService(pipeline);
+
+        await service.DisposeAsync();
+
+        Assert.False(await service.StartAsync(Events("A", 3, TimeSpan.Zero)).WaitAsync(NoHang));
+        Assert.Empty(pipeline.Processed);
+    }
+
+    [Fact]
+    public async Task StartAsync_SpacesEventsByTheirOwnTimestamps()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        await service.StartAsync(Events("A", 3, TimeSpan.FromSeconds(1)));
+        await SetupTestExtensions.WaitForAsync(() => pipeline.Processed.Count > 0, "the replay to start");
+
+        // A second apart in the journal is a second apart in the replay, not the old fixed tick.
+        await Task.Delay(200);
+
+        Assert.Single(pipeline.Processed);
+
+        await service.StopAsync().WaitAsync(NoHang);
+    }
+
+    [Fact]
+    public async Task StartAsync_DoesNotStallOnAnHourLongHoleInTheJournal()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        await service.StartAsync(Events("A", 2, TimeSpan.FromHours(1)));
+
+        // Only the cap makes this finish: replayed verbatim it would be an hour.
+        await SetupTestExtensions.WaitForAsync(
+            () => pipeline.Processed.Count == 2, "the capped gap to elapse", timeoutMs: 5000);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithNoEvents_ReportsNothingStarted()
+    {
+        var pipeline = new RecordingJournalPipeline();
+        using var service = NewService(pipeline);
+
+        Assert.False(await service.StartAsync(Array.Empty<JournalEvent>()));
+        Assert.False(service.GetStatus().IsReplaying);
+    }
+
+    [Theory]
+    [InlineData(0, 500, 1.0, 500)]      // the source's own spacing
+    [InlineData(0, 3_600_000, 1.0, 2000)] // an hours-long hole, capped
+    [InlineData(500, 0, 1.0, 0)]        // a backwards clock step never waits
+    [InlineData(0, 2000, 4.0, 500)]     // accelerated
+    [InlineData(0, 2000, 1000.0, 125)]  // speed is clamped, so it stays a replay
+    public void DelayBetween_IsTheCappedGapDividedBySpeed(
+        int currentMs, int nextMs, double speed, int expectedMs)
+    {
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var delay = JournalReplayService.DelayBetween(
+            origin.AddMilliseconds(currentMs), origin.AddMilliseconds(nextMs), speed);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(expectedMs), delay);
+    }
+
+    private static JournalReplayService NewService(RecordingJournalPipeline pipeline) =>
+        new(NullLogger<JournalReplayService>.Instance, pipeline);
+
+    /// <summary>Events named so a replayed event can be traced back to the run that queued it.</summary>
+    private static List<JournalEvent> Events(string prefix, int count, TimeSpan spacing)
+    {
+        var origin = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        return Enumerable.Range(0, count)
+            .Select(i => new JournalEvent
+            {
+                Timestamp = origin + spacing * i,
+                Event = $"{prefix}{i}",
+                StarSystem = "Shinrarta Dezhra"
+            })
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary
- Extract journal replay into `JournalReplayService` so start/stop cancel and await the prior run outside any lock (no more `_replayTask.Wait` while holding `ReplayLock`).
- Space replayed events from journal timestamps, capped at 2s so an hours-long hole cannot stall a replay. Optional `speed` (0.25x–16x) accelerates.
- Drain on `DisposeAsync` so process shutdown does not hang a request thread.

## Test Plan
- [x] `dotnet test` on Linux: 538 passed, 0 failed (this worktree)
- [x] New cancel/restart/shutdown tests plus existing path-traversal replay tests
- [ ] WASAPI / physical Buttkicker playback (not verifiable on this Linux host)

Closes #26
