### PR TITLE
fix(ui): add screen-reader semantics for tabs, dialogs, and toasts

### DIFF
--- a/src/EDButtkicker/wwwroot/css/styles.css
+++ b/src/EDButtkicker/wwwroot/css/styles.css
@@ -148,6 +148,22 @@ body {
     animation: fadeIn 0.3s ease;
 }
 
+/* Unselected panels and closed dialogs carry the hidden attribute; it has to win over the
+   layout rules above, so that what is hidden from a screen reader is hidden on screen too. */
+[hidden] {
+    display: none !important;
+}
+
+/* Keyboard focus has to be visible - tabs, dialog controls and panels are all reached by key. */
+.nav-tab:focus-visible,
+.tab-panel:focus-visible,
+.modal-close:focus-visible,
+.btn-close:focus-visible,
+.btn:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
 .tab-panel.active {
     display: block;
 }

--- a/src/EDButtkicker/wwwroot/index.html
+++ b/src/EDButtkicker/wwwroot/index.html
@@ -16,37 +16,45 @@
                     <h1>Elite Dangerous Buttkicker</h1>
                 </div>
                 <div class="header-status">
-                    <div class="status-indicator" id="systemStatus">
-                        <i class="fas fa-circle status-icon"></i>
+                    <!-- The connection state is announced, and always spelled out in words: the
+                         coloured dot is decorative, the .status-text is the real label. -->
+                    <div class="status-indicator" id="systemStatus" role="status" aria-live="polite" aria-atomic="true">
+                        <i class="fas fa-circle status-icon" aria-hidden="true"></i>
                         <span class="status-text">Initializing...</span>
                     </div>
                 </div>
             </div>
-            <nav class="main-nav">
-                <button class="nav-tab active" data-tab="dashboard">
-                    <i class="fas fa-tachometer-alt"></i> Dashboard
+            <nav class="main-nav" role="tablist" aria-label="Main sections">
+                <button class="nav-tab active" id="tab-dashboard" role="tab" data-tab="dashboard"
+                        aria-controls="dashboard" aria-selected="true" tabindex="0">
+                    <i class="fas fa-tachometer-alt" aria-hidden="true"></i> Dashboard
                 </button>
-                <button class="nav-tab" data-tab="patterns">
-                    <i class="fas fa-wave-square"></i> Patterns
+                <button class="nav-tab" id="tab-patterns" role="tab" data-tab="patterns"
+                        aria-controls="patterns" aria-selected="false" tabindex="-1">
+                    <i class="fas fa-wave-square" aria-hidden="true"></i> Patterns
                 </button>
-                <button class="nav-tab" data-tab="audio">
-                    <i class="fas fa-volume-up"></i> Audio
+                <button class="nav-tab" id="tab-audio" role="tab" data-tab="audio"
+                        aria-controls="audio" aria-selected="false" tabindex="-1">
+                    <i class="fas fa-volume-up" aria-hidden="true"></i> Audio
                 </button>
-                <button class="nav-tab" data-tab="journal">
-                    <i class="fas fa-file-alt"></i> Journal
+                <button class="nav-tab" id="tab-journal" role="tab" data-tab="journal"
+                        aria-controls="journal" aria-selected="false" tabindex="-1">
+                    <i class="fas fa-file-alt" aria-hidden="true"></i> Journal
                 </button>
-                <button class="nav-tab" data-tab="context">
-                    <i class="fas fa-brain"></i> Intelligence
+                <button class="nav-tab" id="tab-context" role="tab" data-tab="context"
+                        aria-controls="context" aria-selected="false" tabindex="-1">
+                    <i class="fas fa-brain" aria-hidden="true"></i> Intelligence
                 </button>
-                <button class="nav-tab" data-tab="settings">
-                    <i class="fas fa-cog"></i> Settings
+                <button class="nav-tab" id="tab-settings" role="tab" data-tab="settings"
+                        aria-controls="settings" aria-selected="false" tabindex="-1">
+                    <i class="fas fa-cog" aria-hidden="true"></i> Settings
                 </button>
             </nav>
         </header>
 
         <main class="main-content">
             <!-- Dashboard Tab -->
-            <div class="tab-panel active" id="dashboard">
+            <div class="tab-panel active" id="dashboard" role="tabpanel" tabindex="0" aria-labelledby="tab-dashboard">
                 <div class="panel-header">
                     <h2><i class="fas fa-tachometer-alt"></i> System Dashboard</h2>
                     <div class="header-actions">
@@ -63,7 +71,7 @@
                     <div class="stats-card">
                         <div class="card-header">
                             <h3><i class="fas fa-heartbeat"></i> System Health</h3>
-                            <button class="btn btn-sm" data-bind="refreshHealth">
+                            <button class="btn btn-sm" data-bind="refreshHealth" aria-label="Refresh system health">
                                 <i class="fas fa-sync-alt"></i>
                             </button>
                         </div>
@@ -99,7 +107,7 @@
                     <div class="stats-card full-width">
                         <div class="card-header">
                             <h3><i class="fas fa-history"></i> Recent Events</h3>
-                            <button class="btn btn-sm" data-bind="loadRecentEvents">
+                            <button class="btn btn-sm" data-bind="loadRecentEvents" aria-label="Refresh recent events">
                                 <i class="fas fa-refresh"></i>
                             </button>
                         </div>
@@ -113,7 +121,7 @@
             </div>
 
             <!-- Patterns Tab -->
-            <div class="tab-panel" id="patterns">
+            <div class="tab-panel" id="patterns" role="tabpanel" tabindex="0" aria-labelledby="tab-patterns" hidden>
                 <div class="panel-header">
                     <h2><i class="fas fa-wave-square"></i> Haptic Patterns</h2>
                     <div class="header-actions">
@@ -141,7 +149,7 @@
                     <div class="pattern-tester" id="patternTester" style="display: none;">
                         <div class="tester-header">
                             <h3><i class="fas fa-vial"></i> Pattern Tester</h3>
-                            <button class="btn-close" data-bind="hidePatternTester">&times;</button>
+                            <button class="btn-close" data-bind="hidePatternTester" aria-label="Close pattern tester"><span aria-hidden="true">&times;</span></button>
                         </div>
                         
                         <div class="tester-content">
@@ -245,7 +253,7 @@
             </div>
 
             <!-- Audio Tab -->
-            <div class="tab-panel" id="audio">
+            <div class="tab-panel" id="audio" role="tabpanel" tabindex="0" aria-labelledby="tab-audio" hidden>
                 <div class="panel-header">
                     <h2><i class="fas fa-volume-up"></i> Audio Configuration</h2>
                     <button class="btn btn-primary" data-bind="testAudio">
@@ -283,7 +291,7 @@
             </div>
 
             <!-- Journal Tab -->
-            <div class="tab-panel" id="journal">
+            <div class="tab-panel" id="journal" role="tabpanel" tabindex="0" aria-labelledby="tab-journal" hidden>
                 <div class="panel-header">
                     <h2><i class="fas fa-file-alt"></i> Journal Monitoring</h2>
                     <button class="btn btn-primary" data-bind="refreshJournalStatus">
@@ -324,7 +332,7 @@
                                         <select id="journalFileSelect" class="journal-select">
                                             <option value="">Loading journal files...</option>
                                         </select>
-                                        <button class="btn btn-sm btn-secondary" data-bind="refreshJournalFiles">
+                                        <button class="btn btn-sm btn-secondary" data-bind="refreshJournalFiles" aria-label="Refresh journal file list">
                                             <i class="fas fa-sync-alt"></i>
                                         </button>
                                     </div>
@@ -361,7 +369,7 @@
             </div>
 
             <!-- Contextual Intelligence Tab -->
-            <div class="tab-panel" id="context">
+            <div class="tab-panel" id="context" role="tabpanel" tabindex="0" aria-labelledby="tab-context" hidden>
                 <div class="panel-header">
                     <h2><i class="fas fa-brain"></i> Contextual Intelligence</h2>
                     <div class="header-actions">
@@ -449,7 +457,7 @@
             </div>
 
             <!-- Settings Tab -->
-            <div class="tab-panel" id="settings">
+            <div class="tab-panel" id="settings" role="tabpanel" tabindex="0" aria-labelledby="tab-settings" hidden>
                 <div class="panel-header">
                     <h2><i class="fas fa-cog"></i> Configuration Settings</h2>
                     <div class="header-actions">
@@ -517,11 +525,13 @@
 
     <!-- First-Run Setup Wizard: opens by itself until setup has been completed once, and can be
          reopened from the dashboard at any time. -->
-    <div class="modal" id="setupWizard">
+    <div class="modal" id="setupWizard" role="dialog" aria-modal="true" aria-labelledby="setupWizardTitle" hidden>
         <div class="modal-content">
             <div class="modal-header">
-                <h3><i class="fas fa-magic"></i> First-Run Setup</h3>
-                <button class="modal-close" data-bind="closeSetupWizard">&times;</button>
+                <h3 id="setupWizardTitle"><i class="fas fa-magic" aria-hidden="true"></i> First-Run Setup</h3>
+                <button class="modal-close" data-bind="closeSetupWizard" aria-label="Close setup wizard">
+                    <span aria-hidden="true">&times;</span>
+                </button>
             </div>
             <div class="modal-body">
                 <ol class="setup-steps" id="setupSteps"></ol>
@@ -537,11 +547,13 @@
     </div>
 
     <!-- Pattern Editor Modal -->
-    <div class="modal" id="patternModal">
+    <div class="modal" id="patternModal" role="dialog" aria-modal="true" aria-labelledby="patternModalTitle" hidden>
         <div class="modal-content">
             <div class="modal-header">
                 <h3 id="patternModalTitle">Edit Pattern</h3>
-                <button class="modal-close" data-bind="closePatternModal">&times;</button>
+                <button class="modal-close" data-bind="closePatternModal" aria-label="Close pattern editor">
+                    <span aria-hidden="true">&times;</span>
+                </button>
             </div>
             <div class="modal-body">
                 <div class="pattern-editor" id="patternEditor">
@@ -557,7 +569,7 @@
     </div>
 
     <!-- Toast Notifications -->
-    <div class="toast-container" id="toastContainer"></div>
+    <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="false"></div>
 
     <script src="js/dom.js"></script>
     <script src="js/csrf.js"></script>

--- a/src/EDButtkicker/wwwroot/js/app.js
+++ b/src/EDButtkicker/wwwroot/js/app.js
@@ -8,9 +8,12 @@ class ButtkickerApp {
     }
 
     init() {
-        // Tab switching
-        document.querySelectorAll('.nav-tab').forEach(tab => {
+        // Tab switching. The nav is a tablist: clicking a tab still selects it, and so do the
+        // arrow keys, Home and End, with only the selected tab in the tab order.
+        const tabs = Array.from(document.querySelectorAll('.nav-tab'));
+        tabs.forEach(tab => {
             tab.addEventListener('click', () => this.switchTab(tab.dataset.tab));
+            tab.addEventListener('keydown', event => this.onTabKeydown(event, tabs));
         });
 
         // Range input updates
@@ -28,15 +31,41 @@ class ButtkickerApp {
         setInterval(() => this.updateSystemStatus(), 10000); // Every 10 seconds
     }
 
+    // Enter and Space are the button's own activation and already reach the click handler, so only
+    // the roving-focus keys are handled here.
+    onTabKeydown(event, tabs) {
+        const current = tabs.indexOf(event.currentTarget);
+        if (current < 0) return;
+
+        let next;
+        switch (event.key) {
+            case 'ArrowRight': next = (current + 1) % tabs.length; break;
+            case 'ArrowLeft': next = (current - 1 + tabs.length) % tabs.length; break;
+            case 'Home': next = 0; break;
+            case 'End': next = tabs.length - 1; break;
+            default: return;
+        }
+
+        event.preventDefault();
+        this.switchTab(tabs[next].dataset.tab);
+        tabs[next].focus();
+    }
+
     switchTab(tabName) {
         // Update nav tabs
         document.querySelectorAll('.nav-tab').forEach(tab => {
-            tab.classList.toggle('active', tab.dataset.tab === tabName);
+            const selected = tab.dataset.tab === tabName;
+            tab.classList.toggle('active', selected);
+            tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+            tab.tabIndex = selected ? 0 : -1;
         });
 
-        // Update tab panels
+        // Update tab panels. The unselected ones are hidden outright, so nothing in them is
+        // reachable by a screen reader or by Tab.
         document.querySelectorAll('.tab-panel').forEach(panel => {
-            panel.classList.toggle('active', panel.id === tabName);
+            const selected = panel.id === tabName;
+            panel.classList.toggle('active', selected);
+            panel.hidden = !selected;
         });
 
         // Load tab content
@@ -188,13 +217,13 @@ class ButtkickerApp {
         if (!modal) return;
 
         this.activeStep = stepId || (this.setup ? this.setup.current_step : 'journal');
-        modal.classList.add('active');
+        // Render first so the step's own controls are what focus lands on.
         this.renderSetup();
+        openDialog('setupWizard');
     }
 
     closeSetupWizard() {
-        const modal = document.getElementById('setupWizard');
-        if (modal) modal.classList.remove('active');
+        closeDialog('setupWizard');
     }
 
     renderSetup() {
@@ -906,8 +935,15 @@ class ButtkickerApp {
 
     showToast(message, type = 'success') {
         const toastContainer = document.getElementById('toastContainer');
-        const toast = document.createElement('div');
-        toast.className = `toast ${type}`;
+        // A toast is the only report some actions give, so it is a live region: errors interrupt
+        // (alert), everything else waits for a pause (status).
+        const toast = dom.el('div', {
+            className: `toast ${type}`,
+            attrs: {
+                role: type === 'error' ? 'alert' : 'status',
+                'aria-atomic': 'true'
+            }
+        });
         // Toast text is frequently an error string straight off the API - shown, never parsed.
         dom.append(toast, dom.el('div', {
             style: { display: 'flex', alignItems: 'center', gap: '0.5rem' }
@@ -928,6 +964,103 @@ class ButtkickerApp {
         }, 4000);
     }
 }
+
+// ----- Modal dialogs -----
+//
+// Both modals are role="dialog" aria-modal="true". While one is open, Tab stays inside it, Escape
+// closes it, and whatever was focused before it opened gets the focus back - otherwise a screen
+// reader or keyboard user is left behind the dialog with no way back.
+const DIALOG_FOCUSABLE = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+].join(', ');
+
+let activeDialog = null;
+let dialogReturnFocus = null;
+
+function dialogFocusables(dialog) {
+    return Array.from(dialog.querySelectorAll(DIALOG_FOCUSABLE)).filter(node => !node.closest('[hidden]'));
+}
+
+function focusIntoDialog(dialog) {
+    const focusables = dialogFocusables(dialog);
+    // With nothing focusable inside - a dialog still loading its body - the heading takes focus so
+    // the reader at least starts where the dialog does.
+    const target = focusables[0] || dialog.querySelector('.modal-header h3') || dialog;
+    if (focusables.length === 0) target.setAttribute('tabindex', '-1');
+    target.focus();
+}
+
+function openDialog(id) {
+    const dialog = document.getElementById(id);
+    if (!dialog) return null;
+
+    // Reopening the wizard on a later step must not steal the caller's place in the dialog, nor
+    // forget where focus came from originally.
+    const alreadyOpen = dialog === activeDialog;
+    if (!alreadyOpen) {
+        dialogReturnFocus = document.activeElement;
+        activeDialog = dialog;
+    }
+
+    dialog.hidden = false;
+    dialog.classList.add('active');
+
+    if (!alreadyOpen) focusIntoDialog(dialog);
+    return dialog;
+}
+
+function closeDialog(id) {
+    const dialog = document.getElementById(id);
+    if (!dialog) return;
+
+    dialog.classList.remove('active');
+    dialog.hidden = true;
+
+    if (dialog !== activeDialog) return;
+    activeDialog = null;
+
+    const restore = dialogReturnFocus;
+    dialogReturnFocus = null;
+    if (restore && typeof restore.focus === 'function' && document.contains(restore)) {
+        restore.focus();
+    }
+}
+
+document.addEventListener('keydown', (event) => {
+    const dialog = activeDialog;
+    if (!dialog) return;
+
+    if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDialog(dialog.id);
+        return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusables = dialogFocusables(dialog);
+    if (focusables.length === 0) {
+        event.preventDefault();
+        return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && (active === first || !dialog.contains(active))) {
+        event.preventDefault();
+        last.focus();
+    } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+        event.preventDefault();
+        first.focus();
+    }
+});
 
 // Global functions for inline event handlers
 window.refreshDashboard = () => app.loadDashboard();
@@ -1142,9 +1275,9 @@ window.importConfiguration = () => {
 };
 
 // Pattern editor modal functions
-window.closePatternModal = () => {
-    document.getElementById('patternModal').classList.remove('active');
-};
+window.openPatternModal = () => openDialog('patternModal');
+
+window.closePatternModal = () => closeDialog('patternModal');
 
 window.savePattern = () => {
     app.showToast('Pattern saved - Coming soon!', 'warning');

--- a/tests/EDButtkicker.Tests/AccessibilitySemanticsTests.cs
+++ b/tests/EDButtkicker.Tests/AccessibilitySemanticsTests.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Xunit;
+
+namespace EDButtkicker.Tests;
+
+/// <summary>
+/// Keyboard and screen-reader semantics live in wwwroot markup and js/app.js. This runs
+/// js/a11y_test.js under node (jsdom) and fails with its output. It cannot substitute for NVDA.
+/// </summary>
+public class AccessibilitySemanticsTests
+{
+    private const string ScriptName = "a11y_test.js";
+
+    [Fact]
+    public void TabsDialogsAndToasts_ExposeAccessibleSemantics()
+    {
+        var scriptDirectory = LocateScriptDirectory();
+        EnsureDependenciesInstalled(scriptDirectory);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "node",
+            WorkingDirectory = scriptDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add(ScriptName);
+
+        using var process = Start(startInfo);
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, $"{ScriptName} failed:\n{output}\n{error}");
+    }
+
+    private static void EnsureDependenciesInstalled(string scriptDirectory)
+    {
+        if (Directory.Exists(Path.Combine(scriptDirectory, "node_modules", "jsdom")))
+        {
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "npm",
+            WorkingDirectory = scriptDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("install");
+
+        using var install = Start(startInfo, "npm");
+
+        var output = install.StandardOutput.ReadToEnd();
+        var error = install.StandardError.ReadToEnd();
+        install.WaitForExit();
+
+        Assert.True(install.ExitCode == 0, $"npm install in {scriptDirectory} failed:\n{output}\n{error}");
+    }
+
+    private static Process Start(ProcessStartInfo startInfo, string executable = "node")
+    {
+        try
+        {
+            return Process.Start(startInfo)!;
+        }
+        catch (Win32Exception)
+        {
+            Assert.Fail($"{executable} is required to run the accessibility tests but was not found on PATH.");
+            throw;
+        }
+    }
+
+    private static string LocateScriptDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "js");
+            if (File.Exists(Path.Combine(candidate, ScriptName)))
+            {
+                return candidate;
+            }
+        }
+
+        Assert.Fail($"Could not find js/{ScriptName} above {AppContext.BaseDirectory}");
+        throw new InvalidOperationException();
+    }
+}

--- a/tests/EDButtkicker.Tests/js/a11y_test.js
+++ b/tests/EDButtkicker.Tests/js/a11y_test.js
@@ -1,0 +1,212 @@
+// The configuration UI is driven as much by keyboard and screen reader as by mouse, and none of
+// that is visible in a screenshot: the tabs have to be a tablist, the modals have to be dialogs
+// that trap and restore focus, and status and toasts have to be announced.
+//
+// This loads the real index.html plus the real js/dom.js and js/app.js into a DOM and checks those
+// semantics the way an assistive technology would read them - roles, names, states - and drives
+// the keyboard interactions. It cannot substitute for a run with a real screen reader (no NVDA
+// here); it pins the markup and behaviour that a screen reader depends on.
+const { JSDOM, VirtualConsole } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+const wwwroot = path.resolve(__dirname, '../../../src/EDButtkicker/wwwroot');
+
+let failures = 0;
+
+function check(condition, description) {
+    if (!condition) {
+        console.error('FAIL:', description);
+        failures++;
+    }
+}
+
+function equal(actual, expected, description) {
+    check(actual === expected, `${description} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`);
+}
+
+// A script that throws while loading would leave every later assertion meaningless, so surface it.
+const virtualConsole = new VirtualConsole();
+virtualConsole.on('jsdomError', (error) => {
+    console.error('script error while loading the page:', error.message);
+    failures++;
+});
+
+const html = fs.readFileSync(path.join(wwwroot, 'index.html'), 'utf8');
+const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost:8080/', virtualConsole });
+const { window } = dom;
+const { document } = window;
+
+// There is no local service behind this DOM. Every call answers "unavailable" so the page takes its
+// error paths instead of hanging, and no rejection escapes.
+window.fetch = () => Promise.resolve({
+    ok: false,
+    status: 503,
+    json: async () => ({}),
+    text: async () => ''
+});
+
+for (const file of ['js/dom.js', 'js/app.js']) {
+    const script = document.createElement('script');
+    script.textContent = fs.readFileSync(path.join(wwwroot, file), 'utf8');
+    document.head.appendChild(script);
+}
+
+// index.html is fully parsed by the time the scripts above are injected, so the page's own
+// DOMContentLoaded wiring has to be kicked off by hand.
+document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+const key = (target, name, init = {}) => target.dispatchEvent(
+    new window.KeyboardEvent('keydown', Object.assign({ key: name, bubbles: true, cancelable: true }, init)));
+
+// ----- Tabs -----
+
+const nav = document.querySelector('.main-nav');
+equal(nav.getAttribute('role'), 'tablist', 'main nav is a tablist');
+check(!!nav.getAttribute('aria-label'), 'tablist has an accessible name');
+
+const tabs = Array.from(document.querySelectorAll('.nav-tab'));
+check(tabs.length === 6, 'all six tabs are present');
+
+for (const tab of tabs) {
+    equal(tab.getAttribute('role'), 'tab', `${tab.dataset.tab} tab has role=tab`);
+
+    const panel = document.getElementById(tab.getAttribute('aria-controls'));
+    check(!!panel, `${tab.dataset.tab} tab controls an existing panel`);
+    equal(panel.getAttribute('role'), 'tabpanel', `${panel.id} panel has role=tabpanel`);
+    equal(panel.getAttribute('aria-labelledby'), tab.id, `${panel.id} panel is labelled by its tab`);
+    check(tab.textContent.trim().length > 0, `${tab.dataset.tab} tab has a visible name`);
+}
+
+function assertSelection(expectedTab, description) {
+    for (const tab of tabs) {
+        const selected = tab.dataset.tab === expectedTab;
+        equal(tab.getAttribute('aria-selected'), String(selected), `${description}: ${tab.dataset.tab} aria-selected`);
+        equal(tab.tabIndex, selected ? 0 : -1, `${description}: ${tab.dataset.tab} roving tabindex`);
+        equal(document.getElementById(tab.dataset.tab).hidden, !selected, `${description}: ${tab.dataset.tab} panel hidden`);
+    }
+}
+
+assertSelection('dashboard', 'initial markup');
+
+// Right arrow moves to the next tab and takes focus with it.
+tabs[0].focus();
+key(tabs[0], 'ArrowRight');
+assertSelection('patterns', 'after ArrowRight');
+equal(document.activeElement, tabs[1], 'ArrowRight moves focus to the newly selected tab');
+
+key(tabs[1], 'ArrowLeft');
+assertSelection('dashboard', 'after ArrowLeft');
+
+key(tabs[0], 'End');
+assertSelection('settings', 'after End');
+equal(document.activeElement, tabs[tabs.length - 1], 'End focuses the last tab');
+
+key(tabs[tabs.length - 1], 'Home');
+assertSelection('dashboard', 'after Home');
+
+// Clicking still works, and leaves the same state the keyboard does.
+tabs[3].dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+assertSelection('journal', 'after click');
+tabs[0].dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+assertSelection('dashboard', 'back on the dashboard');
+
+// ----- Icon-only controls -----
+
+const named = {
+    refreshHealth: 'Refresh system health',
+    loadRecentEvents: 'Refresh recent events'
+};
+
+for (const [binding, label] of Object.entries(named)) {
+    const button = document.querySelector(`[data-bind="${binding}"]`);
+    equal(button.getAttribute('aria-label'), label, `${binding} button is named`);
+}
+
+for (const binding of ['hidePatternTester', 'closeSetupWizard', 'closePatternModal', 'refreshJournalFiles']) {
+    const button = document.querySelector(`button[data-bind="${binding}"]`);
+    const name = button.getAttribute('aria-label') || button.textContent.trim();
+    check(name.length > 0 && name !== '×', `${binding} button has an accessible name, not just a glyph`);
+}
+
+// ----- Dialogs -----
+
+for (const id of ['setupWizard', 'patternModal']) {
+    const modal = document.getElementById(id);
+    equal(modal.getAttribute('role'), 'dialog', `${id} has role=dialog`);
+    equal(modal.getAttribute('aria-modal'), 'true', `${id} is modal`);
+
+    const heading = document.getElementById(modal.getAttribute('aria-labelledby'));
+    check(!!heading && heading.textContent.trim().length > 0, `${id} is labelled by a heading with text`);
+    check(modal.contains(heading), `${id} label lives inside the dialog`);
+
+    const close = modal.querySelector('.modal-close');
+    check((close.getAttribute('aria-label') || '').length > 0, `${id} close button has an accessible name`);
+
+    check(modal.hidden, `${id} starts hidden`);
+}
+
+const trigger = document.querySelector('[data-bind="openSetupWizard"]');
+trigger.focus();
+window.openDialog('setupWizard');
+
+const wizard = document.getElementById('setupWizard');
+check(!wizard.hidden && wizard.classList.contains('active'), 'the wizard opens');
+check(wizard.contains(document.activeElement), 'focus moves into the wizard');
+
+// Tab from the last control inside the dialog wraps back to the first instead of escaping it.
+const focusables = Array.from(wizard.querySelectorAll('button:not([disabled]), a[href], input:not([disabled])'));
+focusables[focusables.length - 1].focus();
+key(document.activeElement, 'Tab');
+equal(document.activeElement, focusables[0], 'Tab wraps to the first control in the dialog');
+
+focusables[0].focus();
+key(document.activeElement, 'Tab', { shiftKey: true });
+equal(document.activeElement, focusables[focusables.length - 1], 'Shift+Tab wraps to the last control');
+
+// Escape closes it and hands focus back to whatever opened it.
+key(document.activeElement, 'Escape');
+check(wizard.hidden && !wizard.classList.contains('active'), 'Escape closes the wizard');
+equal(document.activeElement, trigger, 'closing restores focus to the opener');
+
+// The close button does the same as Escape.
+trigger.focus();
+window.openDialog('setupWizard');
+wizard.querySelector('.modal-close').dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+check(wizard.hidden, 'the close button closes the wizard');
+equal(document.activeElement, trigger, 'the close button restores focus too');
+
+const patternModal = document.getElementById('patternModal');
+window.openDialog('patternModal');
+check(!patternModal.hidden, 'the pattern dialog opens');
+key(document.activeElement, 'Escape');
+check(patternModal.hidden, 'Escape closes the pattern dialog');
+
+// ----- Status and toasts -----
+
+const status = document.getElementById('systemStatus');
+const statusIsLive = status.getAttribute('role') === 'status' || status.getAttribute('aria-live') === 'polite';
+check(statusIsLive, 'system status is a live region');
+check(status.querySelector('.status-text').textContent.trim().length > 0,
+    'system status says its state in words, not only in colour');
+
+const toastContainer = document.getElementById('toastContainer');
+equal(toastContainer.getAttribute('aria-live'), 'polite', 'the toast container is a polite live region');
+
+window.eval('app.showToast("Saved the thing", "success")');
+window.eval('app.showToast("Could not reach the service", "error")');
+
+const toasts = Array.from(toastContainer.querySelectorAll('.toast'));
+equal(toasts.length, 2, 'both toasts were added');
+equal(toasts[0].getAttribute('role'), 'status', 'a normal toast is a status');
+check(toasts[0].textContent.includes('Saved the thing'), 'the toast shows its message');
+equal(toasts[1].getAttribute('role'), 'alert', 'an error toast is an alert');
+check(toasts[1].textContent.includes('Could not reach the service'), 'the error toast shows its message');
+
+if (failures > 0) {
+    console.error(`${failures} accessibility assertion(s) failed`);
+    process.exit(1);
+}
+
+console.log('ok');
+process.exit(0);


### PR DESCRIPTION
## Summary
Implements GitHub issue #29 (screen-reader semantics on the main configuration UI).

- Main nav is a `tablist` with `tab`/`tabpanel`, `aria-selected`, and roving tabindex. Arrow/Home/End move selection.
- `#setupWizard` and `#patternModal` are `role=dialog` with `aria-modal`, labelled headings, named close buttons, Tab trap, Escape close, and focus restore.
- Icon-only controls get accessible names. `#systemStatus` is a polite live region with persistent text. Toasts use `role=status` / `role=alert` inside an `aria-live` container.
- jsdom test `tests/EDButtkicker.Tests/js/a11y_test.js` (wired through `AccessibilitySemanticsTests`) pins those semantics. Existing XSS test still forbids `innerHTML` in `app.js`.

## Test plan
- [x] `node tests/EDButtkicker.Tests/js/dom_xss_test.js`
- [x] `node tests/EDButtkicker.Tests/js/a11y_test.js`
- [x] `dotnet test` (539 passed on Linux)
- [ ] NVDA on Windows — not run on this Linux host

Related: #29
